### PR TITLE
Econ-Rework-Part-I-(Inflation,-Buyouts,-Market)

### DIFF
--- a/Endless Space Competitive Mod/Registry.xml
+++ b/Endless Space Competitive Mod/Registry.xml
@@ -15,13 +15,15 @@
         </DepartmentOfCommerce>
         <DepartmentOfTheInterior>
           <GrowthFormula>(300 + (5 * $(Population))) * Property(Empire, @ClassEmpire, GameSpeedMultiplier) * $(Population)</GrowthFormula>
+          <MothershipGrowthFormula>(1200 + (20 * $(Population))) * Property(Empire, @ClassEmpire, GameSpeedMultiplier) * $(Population)</MothershipGrowthFormula>
+
           <OutpostBuyoutCostFormula>((Ceil(((((Property(Empire, @AffinityGameplayVenetians, OwnedSystems) + Property(Empire, @AffinityGameplayVenetians, OwnedOutposts) - 1)) + 1) * 100) ^ (1 + 1.25 * ((Property(Empire, @AffinityGameplayVenetians, OwnedSystems) + Property(Empire, @AffinityGameplayVenetians, OwnedOutposts) - 1) / Property(Empire, @AffinityGameplayVenetians, NumberOfGalaxyNodes)))) + 100))</OutpostBuyoutCostFormula>
           <OutpostBuyoutRefoundFormula>((Ceil(((((Property(Empire, @AffinityGameplayVenetians, OwnedSystems) + Property(Empire, @AffinityGameplayVenetians, OwnedOutposts) - 2)) + 1) * 100) ^ (1 + 1.25 * ((Property(Empire, @AffinityGameplayVenetians, OwnedSystems) + Property(Empire, @AffinityGameplayVenetians, OwnedOutposts) - 2) / Property(Empire, @AffinityGameplayVenetians, NumberOfGalaxyNodes)))) + 100))</OutpostBuyoutRefoundFormula>
           <InfluenceConversionLifeforceGain>1500</InfluenceConversionLifeforceGain>
         </DepartmentOfTheInterior>
         <DepartmentOfDefense>
-          <RetrofitCostFormula>(30 * Property(Empire, @ClassEmpire, DustInflation) * Property(Empire, @ClassEmpire, GameSpeedMultiplier)) * Property(Empire, @ClassEmpire, RetrofitCost)</RetrofitCostFormula>
-          <RepairCostFormula>((0.25 + 0.25 * Count(Ship, @'ClassShip,ShipRoleSuperColonizer')) * (Property(Ship, @ClassShip, MaximumHealth) - Property(Ship, @ClassShip, Health)) * Property(Empire, @ClassEmpire, GameSpeedMultiplier) * Property(Empire, @ClassEmpire, DustInflation) + 500 * Property(Empire, @ClassEmpire, DustInflation) * Count(Ship, @'ClassShip,ShipStateLockedInGarrisonFromDamage')) * Property(Empire, @ClassEmpire, RepairCost)</RepairCostFormula>
+          <RetrofitCostFormula>(30 * (Property(Empire, @ClassEmpire, DustInflation)^0.33) * Property(Empire, @ClassEmpire, GameSpeedMultiplier)) * Property(Empire, @ClassEmpire, RetrofitCost)</RetrofitCostFormula>
+          <RepairCostFormula>((0.25 + 0.25 * Count(Ship, @'ClassShip,ShipRoleSuperColonizer')) * (Property(Ship, @ClassShip, MaximumHealth) - Property(Ship, @ClassShip, Health)) * Property(Empire, @ClassEmpire, GameSpeedMultiplier) * (Property(Empire, @ClassEmpire, DustInflation)^0.33) + 500 * (Property(Empire, @ClassEmpire, DustInflation)^0.33) * Count(Ship, @'ClassShip,ShipStateLockedInGarrisonFromDamage')) * Property(Empire, @ClassEmpire, RepairCost)</RepairCostFormula>
         </DepartmentOfDefense>
       </Agencies>
     </Empire>

--- a/Endless Space Competitive Mod/Simulation/ResourceConverterDefinitions.xml
+++ b/Endless Space Competitive Mod/Simulation/ResourceConverterDefinitions.xml
@@ -6,16 +6,16 @@
       <InterpreterModifier>$(Input)</InterpreterModifier>
     </ToConverter>
     <ToConverter To="Retrofit">
-      <InterpreterModifier>($(Input)) * Property(StockLocation,@../ClassEmpire, GameSpeedMultiplier) * Property(StockLocation, @../ClassEmpire, DustInflation)</InterpreterModifier>
+      <InterpreterModifier>($(Input)) * Property(StockLocation,@../ClassEmpire, GameSpeedMultiplier) * (Property(StockLocation, @../ClassEmpire, DustInflation)^0.33)</InterpreterModifier>
     </ToConverter>
     <ToConverter To="ScrapShip">
       <!-- ((x -> money) ^ 1.2) * modifier * health ratio -->
       <!--Sale is another formula-->
-      <InterpreterModifier>($(Input)) * 0.15 * Property(StockLocation, @../ClassEmpire, DustInflation)</InterpreterModifier>
+      <InterpreterModifier>($(Input)) * 0.15 * (Property(StockLocation, @../ClassEmpire, DustInflation)^0.33)</InterpreterModifier>
     </ToConverter>
     <ToConverter To="ScrapImprovement">
       <!-- ((x -> money) ^ 1.2) * modifier -->
-      <InterpreterModifier>Property(ScrappedElement, @../ClassEmpire, CanSellImprovements) * (0.20 * $(Input) * Property(ScrappedElement, @../ClassEmpire, GameSpeedMultiplier)) * Property(ScrappedElement, @../ClassEmpire,ImprovementScrapValueModifier) * Property(StockLocation, @../ClassEmpire, DustInflation)</InterpreterModifier>
+      <InterpreterModifier>Property(ScrappedElement, @../ClassEmpire, CanSellImprovements) * (0.20 * $(Input) * Property(ScrappedElement, @../ClassEmpire, GameSpeedMultiplier)) * Property(ScrappedElement, @../ClassEmpire,ImprovementScrapValueModifier) * (Property(StockLocation, @../ClassEmpire, DustInflation)^0.33)</InterpreterModifier>
     </ToConverter>
     <ToConverter To="MoneyGainOnConstructionComplete">
       <InterpreterModifier>$(Input) * Property(StockLocation, @../ClassEmpire, RatioOfProductionSpentGainedAsMoney)</InterpreterModifier>
@@ -31,7 +31,7 @@
   <ResourceConverterDefinition ResourceName="Buyout">
     <ToConverter To="EmpireMoney">
       <InterpreterModifier>
-        (($(Input)) ^ 1.2125 + 50) * Property(StockLocation, @../ClassEmpire,BuyoutActivated) * Property(StockLocation, @../ClassEmpire, DustInflation)
+        (($(Input)) ^ 1.15 + 50) * Property(StockLocation, @../ClassEmpire,BuyoutActivated) * (Property(StockLocation, @../ClassEmpire, DustInflation)^0.33)
       </InterpreterModifier>
     </ToConverter>
     <ToConverter To="EmpireEmpirePoint">

--- a/Endless Space Competitive Mod/Simulation/SimulationDescriptors[Marketplace].xml
+++ b/Endless Space Competitive Mod/Simulation/SimulationDescriptors[Marketplace].xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Datatable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xsi:noNamespaceSchemaLocation="../Schemas/Amplitude.Unity.Simulation.SimulationDescriptor.xsd">
+
+    <SimulationDescriptor Name="ClassMarketplace" Type="ClassMarketplace">
+
+        <!-- Global properties -->
+        <Property Name="Turn"                           IsSealed="true"/>
+        <Property Name="GameSpeedMultiplier"            BaseValue="1"/>
+
+        <Property Name="DustGlobalProduction"           BaseValue="0"           MinValue="Negative"   IsSealed="true"/>
+        <Property Name="DustGlobalProductionLastTurn"   BaseValue="0"           MinValue="Negative"   IsSealed="true"/>
+        
+        <Property Name="DustInflation"                  BaseValue="1"           MinValue="0.25"/>
+		<Property Name="DustInflationLastTurn"			BaseValue="1"			MinValue="0.25"/>
+        <Property Name="DustInflationFactor"            BaseValue="0.000175"   MinValue="0"/>
+        
+        <!-- Tax rate -->
+        <Property Name="OwnerTaxRate"                   BaseValue="0.1"         IsSealed="true"/>
+        <Property Name="MinimumOwnerTaxRate"            BaseValue="0"/>
+        <Property Name="MaximumOwnerTaxRate"            BaseValue="0.25"/>
+        <Property Name="AbstractTaxRate"                BaseValue="0.1"/>
+        <Property Name="TurnsSinceLastTaxRateChange"    BaseValue="0"           IsSealed="true"/>
+        
+        <!-- Number of turns displayed in Tradable history GUI -->
+        <Property Name="TradableHistorySpanTurnCount"   BaseValue="20"          MinValue="Negative"/>
+
+        <!-- Events -->
+        <Property Name="BaseEventCooldown"              BaseValue="6"/> <!--5--> <!--3--> <!--6-->
+        <Property Name="EventCooldown"                  BaseValue="0"          IsSealed="true"/>
+        <Property Name="NetEventCooldown"               BaseValue="-1"          MinValue="Negative"/>
+
+		<!-- PERCENT -->
+        <Property Name="MarketplaceEventPass0Chance"    BaseValue="95"/> <!--90--> <!--90--> <!--90--> <!--95-->
+        <Property Name="MarketplaceEventPass1Chance"    BaseValue="30"/> <!--65--> <!--30--> <!--15--> <!--30-->
+        <Property Name="MarketplaceEventPass2Chance"    BaseValue="15"/> <!--40--> <!--15--> <!--7--> <!--15-->
+        <Property Name="MarketplaceEventPass3Chance"    BaseValue="5"/> <!--15--> <!--5--> <!--2--> <!--5-->
+        
+        <!-- Refill -->
+        <Property Name="HeroSpawnCooldown"                           BaseValue="15"          IsSealed="true"/>
+        <Property Name="NetHeroSpawnCooldown"                        BaseValue="-1"          MinValue="-7"/>
+        <Property Name="NetHeroSpawnCooldownPerPlayerCount"          BaseValue="1"/>
+        <Property Name="BaseHeroSpawnCooldown"                       BaseValue="15"/>
+        <Property Name="HeroMaximumLevelDifference"                  BaseValue="3"/>
+
+        <Property Name="ShipSpawnCooldown"              BaseValue="5"           IsSealed="true"/>
+        <Property Name="NetShipSpawnCooldown"           BaseValue="-1"          MinValue="Negative"/>
+        <Property Name="BaseShipSpawnCooldown"          BaseValue="5"/>
+        <Property Name="ShipSpawnMinimumCount"          BaseValue="1"/>
+        <Property Name="ShipSpawnMaximumCount"          BaseValue="5"/>
+
+        <Property Name="MajorEmpiresCount"              BaseValue="0"           IsSealed="true"/>
+        
+        <Property Name="ColdWarCount"                   BaseValue="0"           IsSealed="true"/>
+        <Property Name="ColdWarCountLastTurn"           BaseValue="0"           IsSealed="true"/>
+        <Property Name="WarCount"                       BaseValue="0"           IsSealed="true"/>
+        <Property Name="WarCountLastTurn"               BaseValue="0"           IsSealed="true"/>
+        <Property Name="PeaceCount"                     BaseValue="0"           IsSealed="true"/>
+        <Property Name="PeaceCountLastTurn"             BaseValue="0"           IsSealed="true"/>
+        <Property Name="AllianceCount"                  BaseValue="0"           IsSealed="true"/>
+        <Property Name="AllianceCountLastTurn"          BaseValue="0"           IsSealed="true"/>
+		<Property Name="TensionScore"					BaseValue="0"			MinValue="Negative"/>
+		<Property Name="TensionScoreLastTurn"			BaseValue="0"			MinValue="Negative"/>
+
+        <Property Name="MarketplaceSiegeTime"           BaseValue="0"           IsSealed="true"/>
+        <Property Name="MarketplaceBlockadeTime"        BaseValue="0"           IsSealed="true"/>
+		<Property Name="MarketplaceRiskedTime"			BaseValue="0"/>
+        
+        <!-- Modifiers -->
+		<!--MarketplaceRiskedTime-->
+		<BinaryModifier TargetProperty="MarketplaceRiskedTime" Operation="Addition" Left="$(MarketplaceSiegeTime)" BinaryOperation="Addition" Right="$(MarketplaceBlockadeTime)" Priority="-15"/>
+		
+		<!--Tension Score-->
+		<Modifier		TargetProperty="TensionScore" Operation="Addition"		Value="$(ColdWarCount)" Priority="-15"/>
+		<BinaryModifier TargetProperty="TensionScore" Operation="Addition"		Left="2" BinaryOperation="Multiplication" Right="$(WarCount)" Priority="-15"/>
+		<Modifier		TargetProperty="TensionScore" Operation="Subtraction"	Value="$(PeaceCount)" Priority="-15"/>
+		<BinaryModifier TargetProperty="TensionScore" Operation="Addition"		Left="2" BinaryOperation="Multiplication" Right="$(AllianceCount)" Priority="-15"/>
+		<!--Tension Score Last Turn-->
+		<Modifier		TargetProperty="TensionScoreLastTurn" Operation="Addition"		Value="$(ColdWarCountLastTurn)" Priority="-15"/>
+		<BinaryModifier TargetProperty="TensionScoreLastTurn" Operation="Addition"		Left="2" BinaryOperation="Multiplication" Right="$(WarCountLastTurn)" Priority="-15"/>
+		<Modifier		TargetProperty="TensionScoreLastTurn" Operation="Subtraction"	Value="$(PeaceCountLastTurn)" Priority="-15"/>
+		<BinaryModifier TargetProperty="TensionScoreLastTurn" Operation="Addition"		Left="2" BinaryOperation="Multiplication" Right="$(AllianceCountLastTurn)" Priority="-15"/>
+		
+		<!--GameSpeeds-->
+		<Modifier TargetProperty="BaseEventCooldown" Operation="Multiplication" Value="$(GameSpeedMultiplier)" Priority="-10"/>
+		<Modifier TargetProperty="TradableHistorySpanTurnCount" Operation="Multiplication" Value="$(GameSpeedMultiplier)" Priority="-10"/>
+		<Modifier TargetProperty="GameSpeedMultiplier"	Operation="Force" Value="$(GameSpeedMultiplier)" Path="ClassMarketplace/ClassTradableCategory/ClassTradableSubCategory/ClassTradable" Priority="-10"/>
+
+		<!--Dust Inflation-->
+		<BinaryModifier TargetProperty="DustInflation"  Operation="Addition"    Left="$(DustGlobalProduction)"   BinaryOperation="Multiplication"    Right="$(DustInflationFactor)" Priority="-10"/>
+		<Modifier TargetProperty="Inflation" Operation="Force" Value="$(DustInflation)" Path="ClassMarketplace/ClassTradableCategory/ClassTradableSubCategory/ClassTradable" Priority="-10"/>
+		
+		<BinaryModifier TargetProperty="DustInflationLastTurn"  Operation="Addition"    Left="$(DustGlobalProductionLastTurn)"   BinaryOperation="Multiplication"    Right="$(DustInflationFactor)" Priority="-10"/>
+		<Modifier TargetProperty="InflationLastTurn" Operation="Force" Value="$(DustInflationLastTurn)" Path="ClassMarketplace/ClassTradableCategory/ClassTradableSubCategory/ClassTradable" Priority="-10"/>
+
+        <!--Hero Cooldown and Gamespeed-->
+        <Modifier		TargetProperty="NetHeroSpawnCooldownPerPlayerCount" Operation="Multiplication"		Value="$(MajorEmpiresCount)"  Priority="-15"/>
+        <Modifier		TargetProperty="NetHeroSpawnCooldownPerPlayerCount" Operation="Division"		Value="2"  Priority="-15"/>
+        
+        <BinaryModifier TargetProperty="NetHeroSpawnCooldown"  Operation="Multiplication"    Left="$(NetHeroSpawnCooldownPerPlayerCount)"   BinaryOperation="Division"    Right="$(GameSpeedMultiplier)" Priority="-20"/>
+      
+    </SimulationDescriptor>
+</Datatable>

--- a/Endless Space Competitive Mod/Simulation/SimulationDescriptors[StarSystem].xml
+++ b/Endless Space Competitive Mod/Simulation/SimulationDescriptors[StarSystem].xml
@@ -1,0 +1,419 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Datatable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xsi:noNamespaceSchemaLocation="../Schemas/Amplitude.Unity.Simulation.SimulationDescriptor.xsd">
+
+    <SimulationDescriptor Name="ClassStarSystem" Type="Class">
+
+        <!-- ########################################################## -->
+        <!-- ######################## PROPERTY ######################## -->
+        <!-- ########################################################## -->
+
+        <Property Name="VisionRange"    BaseValue="1"/>
+        
+        <Property Name="Population" BaseValue="0" Composition="Sum"/>
+        <Property Name="PopulationWithGrowth" BaseValue="0"/>
+        <Property Name="PopulationGrowthUpkeep" />
+        <Property Name="PopulationGrowthUpkeepFromGeneHunter" />
+        <Property Name="HasAffinityGeneHunter" />
+        <Property Name="MaximumPopulation" BaseValue="0" />
+        <Property Name="SystemTerritoryInfluence"        BaseValue="0"/>
+
+        <Property Name="AnomalyCount" BaseValue="0" Composition="Sum"/>
+        <Property Name="WreckedMothershipCount" BaseValue="0" IsSealed="true"/>
+
+        <Property Name="SystemLevel" BaseValue="1" MaxValue="4"  IsSealed="true"/>
+        <Property Name="NbConstructedRecipes" BaseValue="0" MaxValue="5" Composition="Sum"/>
+
+        <!-- Used to compute the star system XP value for governors passive gain -->
+        <Property Name="PassiveStarSystemExperienceRewardForGovernors" BaseValue="0" />
+
+        <Property Name="PlanetDepletionPoints" Composition="Sum"/>
+
+        <!-- Planet's refined resources  -->
+        <Property Name="PlanetFoodReceiver"      MinValue="Negative" />
+        <Property Name="PlanetIndustryReceiver"  MinValue="Negative" />
+        <Property Name="PlanetDustReceiver"      MinValue="Negative" />
+        <Property Name="PlanetScienceReceiver"   MinValue="Negative" />
+        <Property Name="PlanetPrestigeReceiver"  MinValue="Negative" />
+
+        <Property Name="PlanetFoodConverted"      MinValue="Negative" />
+        <Property Name="PlanetIndustryConverted"  MinValue="Negative" />
+        <Property Name="PlanetDustConverted"      MinValue="Negative" />
+        <Property Name="PlanetScienceConverted"   MinValue="Negative" />
+        <Property Name="PlanetPrestigeConverted"  MinValue="Negative" />
+
+        <!-- System's refined resources -->
+        <Property Name="SystemFIDSIPercent"                               MinValue="Negative"/>
+        <Property Name="SystemHeroFIDSIPercent"                           MinValue="Negative"/>
+        <Property Name="SystemFIDSIFlat"                                  MinValue="Negative"/>
+        <Property Name="SystemFIDSIPercentFromTimeBubble"                 MinValue="Negative"/>
+        <Property Name="SystemFIDSIPercentFromImprovementUniqueTemplars"  MinValue="Negative"/>
+        
+        <Property Name="SystemFIDSPercent"                 MinValue="Negative"/>
+        <Property Name="SystemFIDSFlat"                    MinValue="Negative"/>
+        
+        <Property Name="SystemGrowth" MinValue="Negative"/>
+        <Property Name="SystemProduction"/>
+        <Property Name="SystemProductionHissho" BaseValue="1"/>
+        <Property Name="SystemMoney"/>
+        <Property Name="SystemResearch"/>
+        <Property Name="SystemEmpirePoint"/>
+        <Property Name="SystemEmpirePointFromHappiness" MinValue="Negative"/>
+        <Property Name="SystemEmpirePointFromHisshoBonus" MinValue="Negative"/>
+        <Property Name="HasObedience" BaseValue="0" MinValue="0" MaxValue="1"/>
+
+        <Property Name="SystemOutpostSupply"/>
+
+        <!-- System's upkeep resources -->
+        <Property Name="SystemGrowthUpkeep"/>
+        <Property Name="SystemProductionUpkeep"/>
+        <Property Name="SystemMoneyUpkeep"   Composition="Sum"/>
+        <Property Name="SystemResearchUpkeep"/>
+        <Property Name="SystemEmpirePointUpkeep"/>
+
+        <!-- System's net resources -->
+        <Property Name="NetSystemGrowth"        MinValue="Negative"/>
+        <Property Name="NetSystemProduction" MinValue="Negative"/>
+        <Property Name="NetSystemMoney" MinValue="Negative"/>
+        <Property Name="NetSystemResearch" MinValue="Negative"/>
+        <Property Name="NetSystemEmpirePoint" MinValue="Negative"/>
+        <Property Name="NetSystemTurnBased" BaseValue="1"/>
+
+        <!-- Necessary for displaying resource deposit stuff -->
+        <Property Name="FakeResourceStock"     IsSealed="true"/>
+        <Property Name="MinimumLuxuryStock"    BaseValue="0"/>
+        <Property Name="MaximumLuxuryStock"    BaseValue="0"/>
+        <Property Name="MinimumStrategicStock" BaseValue="0"/>
+        <Property Name="MaximumStrategicStock" BaseValue="0"/>
+
+        <Property Name="Strategic1" MinValue="Negative"  Composition="Sum"/>
+        <Property Name="Strategic2" MinValue="Negative"  Composition="Sum"/>
+        <Property Name="Strategic3" MinValue="Negative"  Composition="Sum"/>
+        <Property Name="Strategic4" MinValue="Negative"  Composition="Sum"/>
+        <Property Name="Strategic5" MinValue="Negative"  Composition="Sum"/>
+        <Property Name="Strategic6" MinValue="Negative"  Composition="Sum"/>
+
+        <Property Name="Luxury1"    MinValue="Negative"  Composition="Sum"/>
+        <Property Name="Luxury2"    MinValue="Negative"  Composition="Sum"/>
+        <Property Name="Luxury3"    MinValue="Negative"  Composition="Sum"/>
+        <Property Name="Luxury4"    MinValue="Negative"  Composition="Sum"/>
+        <Property Name="Luxury5"    MinValue="Negative"  Composition="Sum"/>
+        <Property Name="Luxury6"    MinValue="Negative"  Composition="Sum"/>
+        <Property Name="Luxury7"    MinValue="Negative"  Composition="Sum"/>
+        <Property Name="Luxury8"    MinValue="Negative"  Composition="Sum"/>
+        <Property Name="Luxury9"    MinValue="Negative"  Composition="Sum"/>
+        <Property Name="Luxury10"   MinValue="Negative"  Composition="Sum"/>
+        <Property Name="Luxury11"   MinValue="Negative"  Composition="Sum"/>
+        <Property Name="Luxury12"   MinValue="Negative"  Composition="Sum"/>
+        <Property Name="Luxury13"   MinValue="Negative"  Composition="Sum"/>
+        <Property Name="Luxury14"   MinValue="Negative"  Composition="Sum"/>
+        <Property Name="Luxury15"   MinValue="Negative"  Composition="Sum"/>
+        <Property Name="Luxury16"   MinValue="Negative"  Composition="Sum"/>
+        <Property Name="Luxury17"   MinValue="Negative"  Composition="Sum"/>
+        <Property Name="Luxury18"   MinValue="Negative"  Composition="Sum"/>
+        <Property Name="Luxury19"   MinValue="Negative"  Composition="Sum"/>
+        <Property Name="Luxury20"   MinValue="Negative"  Composition="Sum"/>
+        <Property Name="Luxury21"   MinValue="Negative"  Composition="Sum"/>
+        <Property Name="Luxury22"   MinValue="Negative"  Composition="Sum"/>
+        <Property Name="Luxury23"   MinValue="Negative"  Composition="Sum"/>
+        <Property Name="Luxury24"   MinValue="Negative"  Composition="Sum"/>
+
+        <Property Name="NetStrategic1" MinValue="Negative"/>
+        <Property Name="NetStrategic2" MinValue="Negative"/>
+        <Property Name="NetStrategic3" MinValue="Negative"/>
+        <Property Name="NetStrategic4" MinValue="Negative"/>
+        <Property Name="NetStrategic5" MinValue="Negative"/>
+        <Property Name="NetStrategic6" MinValue="Negative"/>
+
+        <Property Name="NetLuxury1"    MinValue="Negative"/>
+        <Property Name="NetLuxury2"    MinValue="Negative"/>
+        <Property Name="NetLuxury3"    MinValue="Negative"/>
+        <Property Name="NetLuxury4"    MinValue="Negative"/>
+        <Property Name="NetLuxury5"    MinValue="Negative"/>
+        <Property Name="NetLuxury6"    MinValue="Negative"/>
+        <Property Name="NetLuxury7"    MinValue="Negative"/>
+        <Property Name="NetLuxury8"    MinValue="Negative"/>
+        <Property Name="NetLuxury9"    MinValue="Negative"/>
+        <Property Name="NetLuxury10"   MinValue="Negative"/>
+        <Property Name="NetLuxury11"   MinValue="Negative"/>
+        <Property Name="NetLuxury12"   MinValue="Negative"/>
+        <Property Name="NetLuxury13"   MinValue="Negative"/>
+        <Property Name="NetLuxury14"   MinValue="Negative"/>
+        <Property Name="NetLuxury15"   MinValue="Negative"/>
+        <Property Name="NetLuxury16"   MinValue="Negative"/>
+        <Property Name="NetLuxury17"   MinValue="Negative"/>
+        <Property Name="NetLuxury18"   MinValue="Negative"/>
+        <Property Name="NetLuxury19"   MinValue="Negative"/>
+        <Property Name="NetLuxury20"   MinValue="Negative"/>
+        <Property Name="NetLuxury21"   MinValue="Negative"/>
+        <Property Name="NetLuxury22"   MinValue="Negative"/>
+        <Property Name="NetLuxury23"   MinValue="Negative"/>
+        <Property Name="NetLuxury24"   MinValue="Negative"/>
+
+        <Property Name="TotalNetLuxury"  MinValue="Negative"  BaseValue="0"/>
+
+        <Property Name="LuxuryDepositQuantity"/>
+
+        <Property Name="PlanetIndustryToSystemIndustryGrowthConversionFactor" BaseValue="0"/>
+        <Property Name="PlanetIndustryToSystemFoodGrowthConversionFactor"     BaseValue="0"/>
+
+        <Property Name="PlanetDustToSystemDustGrowthConversionFactor"         BaseValue="0"/>
+        <Property Name="PlanetDustToSystemFoodGrowthConversionFactor"         BaseValue="0"/>
+        <Property Name="PlanetDustToSystemResearchConversionFactor"           BaseValue="0"/>
+        <Property Name="PlanetDustToSystemPrestigeConversionFactor"           BaseValue="0"/>
+
+        <Property Name="PlanetScienceToSystemScienceGrowthConversionFactor"   BaseValue="0"/>
+        <Property Name="PlanetScienceToSystemProductionConversionFactor"      BaseValue="0"/>
+        <Property Name="PlanetScienceToSystemEmpirePointConversionFactor"     BaseValue="0"/>
+
+        <Property Name="PlanetPrestigeToSystemPrestigeGrowthConversionFactor" BaseValue="0"/>
+
+        <Property Name="PopulationTypeBasedOnSystemFoodGrowthCount"       BaseValue="0"/>
+        <Property Name="PopulationTypeBasedOnSystemIndustryGrowthCount"   BaseValue="0"/>
+        <Property Name="PopulationTypeBasedOnSystemDustGrowthCount"       BaseValue="0"/>
+        <Property Name="PopulationTypeBasedOnSystemScienceGrowthCount"    BaseValue="0"/>
+        <Property Name="PopulationTypeBasedOnSystemPrestigeGrowthCount"   BaseValue="0"/>
+
+        <Property Name="PopulationBasedOnSystemFoodGrowthCount"       BaseValue="0"/>
+        <Property Name="PopulationBasedOnSystemIndustryGrowthCount"   BaseValue="0"/>
+        <Property Name="PopulationBasedOnSystemDustGrowthCount"       BaseValue="0"/>
+        <Property Name="PopulationBasedOnSystemScienceGrowthCount"    BaseValue="0"/>
+        <Property Name="PopulationBasedOnSystemPrestigeGrowthCount"   BaseValue="0"/>
+
+        <Property Name="RequiredHackingProgress" BaseValue="120"/>
+        
+        <!-- Production cost bonus -->
+        <Property Name="WonderProductionCostReduction"/>
+        <Property Name="BuildingProductionCostReduction"/>
+        <Property Name="ShipProductionCostReduction" MinValue="Negative"/>
+        <Property Name="ColonyShipProductionCostReduction"/>
+        <Property Name="MilitaryShipProductionCostReduction" MinValue="Negative"/>
+        <Property Name="ProbesProductionCostReduction"/>
+        <Property Name="MothershipProductionCostReduction" BaseValue="1"/>
+        <Property Name="JuggernautShipProductionCostReduction" MinValue="Negative"/>
+
+        <!-- Buyout bonus -->
+        <Property Name="WonderBuyoutReduction"      MaxValue="0.75"/>
+        <Property Name="BuildingBuyoutReduction"    MaxValue="0.75"/>
+        <Property Name="ShipBuyoutReduction"        MaxValue="0.75"/>
+        <Property Name="ColonyShipBuyoutReduction"  MaxValue="0.75"/>
+
+        <!-- Game speed -->
+        <Property Name="GameSpeedProductionCostReduction" MinValue="Negative"/>
+
+        <!-- Spaceport -->
+        <Property Name="SpaceportCapacity" />
+		<Property Name="SpaceportMaximumCapacity" BaseValue="5"/>
+
+        <!-- Wonder -->
+        <Property Name="WonderAmount" BaseValue="0"/>
+        <Property Name="HasVictoryWonder" BaseValue="0"/>
+
+        <Property Name="RawRelics" BaseValue="0" MinValue="0"/>
+      
+        <!-- ########################################################## -->
+        <!-- ######################## MODIFIER ######################## -->
+        <!-- ########################################################## -->
+
+        <Modifier TargetProperty="ColonyShipProductionCostReduction" Operation="Addition" Value="$(ShipProductionCostReduction)" />
+        
+        <!-- Resources  Conversion -->
+
+        <BinaryModifier TargetProperty="PlanetFoodConverted"                Operation="Addition"        Left="$(PlanetIndustryToSystemFoodGrowthConversionFactor)"  BinaryOperation="Multiplication"  Right="$(PlanetIndustryReceiver)"          Priority="-1"  Path="ClassStarSystem"/>
+        <BinaryModifier TargetProperty="PlanetFoodConverted"                Operation="Addition"        Left="$(PlanetDustToSystemFoodGrowthConversionFactor)"      BinaryOperation="Multiplication"  Right="$(PlanetDustReceiver)"              Priority="-1"  Path="ClassStarSystem"/>
+
+
+        <BinaryModifier TargetProperty="PlanetIndustryConverted"            Operation="Subtraction"     Left="$(PlanetIndustryToSystemFoodGrowthConversionFactor)"  BinaryOperation="Multiplication"  Right="$(PlanetIndustryReceiver)"      Priority="-1"  Path="ClassStarSystem"/>
+        <BinaryModifier TargetProperty="PlanetIndustryConverted"            Operation="Addition"        Left="$(PlanetScienceToSystemProductionConversionFactor)"   BinaryOperation="Multiplication"  Right="$(PlanetScienceReceiver)"       Priority="-1"  Path="ClassStarSystem"/>
+
+
+        <BinaryModifier TargetProperty="PlanetDustConverted"                Operation="Subtraction"     Left="$(PlanetDustToSystemResearchConversionFactor)"      BinaryOperation="Multiplication"  Right="$(PlanetDustReceiver)"                       Priority="-1"  Path="ClassStarSystem"/>
+        <BinaryModifier TargetProperty="PlanetDustConverted"                Operation="Subtraction"     Left="$(PlanetDustToSystemFoodGrowthConversionFactor)"    BinaryOperation="Multiplication"  Right="$(PlanetDustReceiver)"                       Priority="-1"  Path="ClassStarSystem"/>
+        <BinaryModifier TargetProperty="PlanetDustConverted"                Operation="Subtraction"     Left="$(PlanetDustToSystemPrestigeConversionFactor)"      BinaryOperation="Multiplication"  Right="$(PlanetDustReceiver)"                       Priority="-1"  Path="ClassStarSystem"/>
+
+
+        <BinaryModifier TargetProperty="PlanetScienceConverted"             Operation="Subtraction"     Left="$(PlanetScienceToSystemProductionConversionFactor)"    BinaryOperation="Multiplication"  Right="$(PlanetScienceReceiver)"       Priority="-1"  Path="ClassStarSystem"/>
+        <BinaryModifier TargetProperty="PlanetScienceConverted"             Operation="Subtraction"     Left="$(PlanetScienceToSystemEmpirePointConversionFactor)"   BinaryOperation="Multiplication"  Right="$(PlanetScienceReceiver)"       Priority="-1"  Path="ClassStarSystem"/>
+        <BinaryModifier TargetProperty="PlanetScienceConverted"             Operation="Addition"        Left="$(PlanetDustToSystemResearchConversionFactor)"         BinaryOperation="Multiplication"  Right="$(PlanetDustReceiver)"       Priority="-1"  Path="ClassStarSystem"/>
+
+
+        <BinaryModifier TargetProperty="PlanetPrestigeConverted"            Operation="Addition"     Left="$(PlanetScienceToSystemEmpirePointConversionFactor)"       BinaryOperation="Multiplication"  Right="$(PlanetScienceReceiver)"       Priority="-1"  Path="ClassStarSystem"/>
+        <BinaryModifier TargetProperty="PlanetPrestigeConverted"            Operation="Addition"     Left="$(PlanetDustToSystemPrestigeConversionFactor)"             BinaryOperation="Multiplication"  Right="$(PlanetDustReceiver)"       Priority="-1"  Path="ClassStarSystem"/>
+
+        <!-- Planet refined to system refined -->
+        <Modifier       TargetProperty="SystemGrowth"       Operation="Addition"        Value="$(SystemFIDSIFlat)"                      Path="ClassStarSystem"/>
+        <Modifier       TargetProperty="SystemGrowth"       Operation="Addition"        Value="$(SystemFIDSFlat)"                       Path="ClassStarSystem"/>
+        <Modifier       TargetProperty="SystemGrowth"       Operation="Addition"        Value="$(PlanetFoodReceiver)"                   Path="ClassStarSystem"/>
+        <Modifier       TargetProperty="SystemGrowth"       Operation="Addition"        Value="$(PlanetFoodConverted)"                  Path="ClassStarSystem"/>
+        <Modifier       TargetProperty="SystemGrowth"       Operation="Percent"         Value="$(SystemFIDSIPercent)"                   Path="ClassStarSystem"/>
+        <Modifier       TargetProperty="SystemGrowth"       Operation="Percent"         Value="$(SystemHeroFIDSIPercent)"               Path="ClassStarSystem"/>
+        <Modifier       TargetProperty="SystemGrowth"       Operation="Percent"         Value="$(SystemFIDSPercent)"                    Path="ClassStarSystem"/>
+		    <Modifier       TargetProperty="SystemGrowth"       Operation="Percent"         Value="$(SystemFIDSIPercentFromTimeBubble)"     Path="ClassStarSystem"/>
+        <Modifier       TargetProperty="SystemGrowth"       Operation="Percent"         Value="$(SystemFIDSIPercentFromImprovementUniqueTemplars)"     Path="ClassStarSystem"/>
+
+
+        <Modifier       TargetProperty="SystemProduction"       Operation="Addition"            Value="$(SystemFIDSIFlat)"                          Path="ClassStarSystem"/>
+        <Modifier       TargetProperty="SystemProduction"       Operation="Addition"            Value="$(SystemFIDSFlat)"                           Path="ClassStarSystem"/>
+        <Modifier       TargetProperty="SystemProduction"       Operation="Addition"            Value="$(PlanetIndustryReceiver)"				    Path="ClassStarSystem"/>
+        <Modifier       TargetProperty="SystemProduction"       Operation="Addition"            Value="$(PlanetIndustryConverted)"				    Path="ClassStarSystem"/>
+        <Modifier       TargetProperty="SystemProduction"       Operation="Multiplication"      Value="$(SystemProductionHissho)"	                Path="ClassStarSystem,HasObedience"/>
+        <Modifier       TargetProperty="SystemProduction"       Operation="Percent"             Value="$(SystemFIDSIPercent)"					    Path="ClassStarSystem"/>
+        <Modifier       TargetProperty="SystemProduction"       Operation="Percent"             Value="$(SystemHeroFIDSIPercent)"					Path="ClassStarSystem"/>
+        <Modifier       TargetProperty="SystemProduction"       Operation="Percent"             Value="$(SystemFIDSPercent)"					    Path="ClassStarSystem"/>
+		    <Modifier       TargetProperty="SystemProduction"       Operation="Percent"             Value="$(SystemFIDSIPercentFromTimeBubble)"         Path="ClassStarSystem"/>
+        <Modifier       TargetProperty="SystemProduction"       Operation="Percent"             Value="$(SystemFIDSIPercentFromImprovementUniqueTemplars)"     Path="ClassStarSystem"/>
+
+        <Modifier       TargetProperty="SystemMoney"            Operation="Addition"            Value="$(SystemFIDSIFlat)"                          Path="ClassStarSystem"/>
+        <Modifier       TargetProperty="SystemMoney"            Operation="Addition"            Value="$(SystemFIDSFlat)"                           Path="ClassStarSystem"/>
+        <Modifier       TargetProperty="SystemMoney"            Operation="Addition"            Value="$(PlanetDustReceiver)"						Path="ClassStarSystem"/>
+        <Modifier       TargetProperty="SystemMoney"            Operation="Addition"            Value="$(PlanetDustConverted)"						Path="ClassStarSystem"/>
+        <Modifier       TargetProperty="SystemMoney"            Operation="Percent"             Value="$(SystemFIDSIPercent)"						Path="ClassStarSystem"/>
+        <Modifier       TargetProperty="SystemMoney"            Operation="Percent"             Value="$(SystemHeroFIDSIPercent)"					Path="ClassStarSystem"/>
+        <Modifier       TargetProperty="SystemMoney"            Operation="Percent"             Value="$(SystemFIDSPercent)"						Path="ClassStarSystem"/>
+		    <Modifier       TargetProperty="SystemMoney"            Operation="Percent"             Value="$(SystemFIDSIPercentFromTimeBubble)"         Path="ClassStarSystem"/>
+        <Modifier       TargetProperty="SystemMoney"            Operation="Percent"             Value="$(SystemFIDSIPercentFromImprovementUniqueTemplars)"     Path="ClassStarSystem"/>
+
+
+        <Modifier       TargetProperty="SystemResearch"         Operation="Addition"            Value="$(SystemFIDSIFlat)"              Priority="-1"   Path="ClassStarSystem"/>
+        <Modifier       TargetProperty="SystemResearch"         Operation="Addition"            Value="$(SystemFIDSFlat)"               Priority="-1"   Path="ClassStarSystem"/>
+        <Modifier       TargetProperty="SystemResearch"         Operation="Addition"            Value="$(PlanetScienceReceiver)"        Priority="-1"   Path="ClassStarSystem"/>
+        <Modifier       TargetProperty="SystemResearch"         Operation="Addition"            Value="$(PlanetScienceConverted)"       Priority="-1"   Path="ClassStarSystem"/>
+        <Modifier       TargetProperty="SystemResearch"         Operation="Percent"             Value="$(SystemFIDSIPercent)"							Path="ClassStarSystem"/>
+        <Modifier       TargetProperty="SystemResearch"         Operation="Percent"             Value="$(SystemHeroFIDSIPercent)"						Path="ClassStarSystem"/>
+        <Modifier       TargetProperty="SystemResearch"         Operation="Percent"             Value="$(SystemFIDSPercent)"							Path="ClassStarSystem"/>
+		    <Modifier       TargetProperty="SystemResearch"         Operation="Percent"             Value="$(SystemFIDSIPercentFromTimeBubble)"				Path="ClassStarSystem"/>
+        <Modifier       TargetProperty="SystemResearch"         Operation="Percent"             Value="$(SystemFIDSIPercentFromImprovementUniqueTemplars)"     Path="ClassStarSystem"/>
+
+
+        <Modifier       TargetProperty="SystemEmpirePoint"      Operation="Addition"            Value="$(SystemFIDSIFlat)"                   Priority="-1"   Path="ClassStarSystem"/>
+        <Modifier       TargetProperty="SystemEmpirePoint"      Operation="Addition"            Value="$(PlanetPrestigeReceiver)"            Priority="-1"   Path="ClassStarSystem"/>
+        <Modifier       TargetProperty="SystemEmpirePoint"      Operation="Addition"            Value="$(PlanetPrestigeConverted)"           Priority="-1"   Path="ClassStarSystem"/>
+        <Modifier       TargetProperty="SystemEmpirePoint"      Operation="Addition"            Value="$(SystemEmpirePointFromHisshoBonus)"  Priority="-1"   Path="ClassStarSystem,HasObedience" TooltipHidden="true" />
+        <Modifier       TargetProperty="SystemEmpirePoint"      Operation="Percent"             Value="$(SystemFIDSIPercent)"							Path="ClassStarSystem"/>
+        <Modifier       TargetProperty="SystemEmpirePoint"      Operation="Percent"             Value="$(SystemHeroFIDSIPercent)"						Path="ClassStarSystem"/>
+		    <Modifier       TargetProperty="SystemEmpirePoint"      Operation="Percent"             Value="$(SystemFIDSIPercentFromTimeBubble)"				Path="ClassStarSystem"/>
+        <Modifier       TargetProperty="SystemEmpirePoint"      Operation="Percent"             Value="$(SystemFIDSIPercentFromImprovementUniqueTemplars)"     Path="ClassStarSystem"/>
+
+
+        <!-- Planet refines + system upkeep = system net -->
+        <BinaryModifier TargetProperty="NetSystemGrowth"        Operation="Addition"    Left="$(SystemGrowth)"        BinaryOperation="Subtraction"    Right="$(SystemGrowthUpkeep)" TooltipHidden="true"  />
+
+        <BinaryModifier TargetProperty="NetSystemProduction"        Operation="Addition"    Left="$(SystemProduction)"        BinaryOperation="Subtraction"    Right="$(SystemProductionUpkeep)"    TooltipHidden="true"    />
+        <BinaryModifier TargetProperty="NetSystemMoney"             Operation="Addition"    Left="$(SystemMoney)"             BinaryOperation="Subtraction"    Right="$(SystemMoneyUpkeep)"         TooltipHidden="true"    />
+        <BinaryModifier TargetProperty="NetSystemResearch"          Operation="Addition"    Left="$(SystemResearch)"          BinaryOperation="Subtraction"    Right="$(SystemResearchUpkeep)"      TooltipHidden="true"    />
+        <BinaryModifier TargetProperty="NetSystemEmpirePoint"       Operation="Addition"    Left="$(SystemEmpirePoint)"       BinaryOperation="Subtraction"    Right="$(SystemEmpirePointUpkeep)"   TooltipHidden="true"    />
+
+        <!-- [FS] 2017.01.06: Moved to ClassColonizedStarSystem. -->
+        <!--<Modifier TargetProperty="MaximumSystemProductionStock" Operation="Multiplication"  Value="$(NetSystemProduction)"/>-->
+
+        <Modifier TargetProperty="NetStrategic1" Operation="Addition" Value="$(Strategic1)"/>
+        <Modifier TargetProperty="NetStrategic2" Operation="Addition" Value="$(Strategic2)"/>
+        <Modifier TargetProperty="NetStrategic3" Operation="Addition" Value="$(Strategic3)"/>
+        <Modifier TargetProperty="NetStrategic4" Operation="Addition" Value="$(Strategic4)"/>
+        <Modifier TargetProperty="NetStrategic5" Operation="Addition" Value="$(Strategic5)"/>
+        <Modifier TargetProperty="NetStrategic6" Operation="Addition" Value="$(Strategic6)"/>
+        
+        <Modifier TargetProperty="NetLuxury1" Operation="Addition" Value="$(Luxury1)"/>
+        <Modifier TargetProperty="NetLuxury2" Operation="Addition" Value="$(Luxury2)"/>
+        <Modifier TargetProperty="NetLuxury3" Operation="Addition" Value="$(Luxury3)"/>
+        <Modifier TargetProperty="NetLuxury4" Operation="Addition" Value="$(Luxury4)"/>
+        <Modifier TargetProperty="NetLuxury5" Operation="Addition" Value="$(Luxury5)"/>
+        <Modifier TargetProperty="NetLuxury6" Operation="Addition" Value="$(Luxury6)"/>
+        <Modifier TargetProperty="NetLuxury7" Operation="Addition" Value="$(Luxury7)"/>
+        <Modifier TargetProperty="NetLuxury8" Operation="Addition" Value="$(Luxury8)"/>
+        <Modifier TargetProperty="NetLuxury9" Operation="Addition" Value="$(Luxury9)"/>
+        <Modifier TargetProperty="NetLuxury10" Operation="Addition" Value="$(Luxury10)"/>
+        <Modifier TargetProperty="NetLuxury11" Operation="Addition" Value="$(Luxury11)"/>
+        <Modifier TargetProperty="NetLuxury12" Operation="Addition" Value="$(Luxury12)"/>
+        <Modifier TargetProperty="NetLuxury13" Operation="Addition" Value="$(Luxury13)"/>
+        <Modifier TargetProperty="NetLuxury14" Operation="Addition" Value="$(Luxury14)"/>
+        <Modifier TargetProperty="NetLuxury15" Operation="Addition" Value="$(Luxury15)"/>
+        <Modifier TargetProperty="NetLuxury16" Operation="Addition" Value="$(Luxury16)"/>
+        <Modifier TargetProperty="NetLuxury17" Operation="Addition" Value="$(Luxury17)"/>
+        <Modifier TargetProperty="NetLuxury18" Operation="Addition" Value="$(Luxury18)"/>
+        <Modifier TargetProperty="NetLuxury19" Operation="Addition" Value="$(Luxury19)"/>
+        <Modifier TargetProperty="NetLuxury20" Operation="Addition" Value="$(Luxury20)"/>
+        <Modifier TargetProperty="NetLuxury21" Operation="Addition" Value="$(Luxury21)"/>
+        <Modifier TargetProperty="NetLuxury22" Operation="Addition" Value="$(Luxury22)"/>
+        <Modifier TargetProperty="NetLuxury23" Operation="Addition" Value="$(Luxury23)"/>
+        <Modifier TargetProperty="NetLuxury24" Operation="Addition" Value="$(Luxury24)"/>
+        
+        <Modifier TargetProperty="TotalNetLuxury" Operation="Addition" Value="$(NetLuxury1)"/>
+        <Modifier TargetProperty="TotalNetLuxury" Operation="Addition" Value="$(NetLuxury2)"/>
+        <Modifier TargetProperty="TotalNetLuxury" Operation="Addition" Value="$(NetLuxury3)"/>
+        <Modifier TargetProperty="TotalNetLuxury" Operation="Addition" Value="$(NetLuxury4)"/>
+        <Modifier TargetProperty="TotalNetLuxury" Operation="Addition" Value="$(NetLuxury5)"/>
+        <Modifier TargetProperty="TotalNetLuxury" Operation="Addition" Value="$(NetLuxury6)"/>
+        <Modifier TargetProperty="TotalNetLuxury" Operation="Addition" Value="$(NetLuxury7)"/>
+        <Modifier TargetProperty="TotalNetLuxury" Operation="Addition" Value="$(NetLuxury8)"/>
+        <Modifier TargetProperty="TotalNetLuxury" Operation="Addition" Value="$(NetLuxury9)"/>
+        <Modifier TargetProperty="TotalNetLuxury" Operation="Addition" Value="$(NetLuxury10)"/>
+        <Modifier TargetProperty="TotalNetLuxury" Operation="Addition" Value="$(NetLuxury11)"/>
+        <Modifier TargetProperty="TotalNetLuxury" Operation="Addition" Value="$(NetLuxury12)"/>
+        <Modifier TargetProperty="TotalNetLuxury" Operation="Addition" Value="$(NetLuxury13)"/>
+        <Modifier TargetProperty="TotalNetLuxury" Operation="Addition" Value="$(NetLuxury14)"/>
+        <Modifier TargetProperty="TotalNetLuxury" Operation="Addition" Value="$(NetLuxury15)"/>
+        <Modifier TargetProperty="TotalNetLuxury" Operation="Addition" Value="$(NetLuxury16)"/>
+        <Modifier TargetProperty="TotalNetLuxury" Operation="Addition" Value="$(NetLuxury17)"/>
+        <Modifier TargetProperty="TotalNetLuxury" Operation="Addition" Value="$(NetLuxury18)"/>
+        <Modifier TargetProperty="TotalNetLuxury" Operation="Addition" Value="$(NetLuxury19)"/>
+        <Modifier TargetProperty="TotalNetLuxury" Operation="Addition" Value="$(NetLuxury20)"/>
+        <Modifier TargetProperty="TotalNetLuxury" Operation="Addition" Value="$(NetLuxury21)"/>
+        <Modifier TargetProperty="TotalNetLuxury" Operation="Addition" Value="$(NetLuxury22)"/>
+        <Modifier TargetProperty="TotalNetLuxury" Operation="Addition" Value="$(NetLuxury23)"/>
+        <Modifier TargetProperty="TotalNetLuxury" Operation="Addition" Value="$(NetLuxury24)"/>
+
+        <Modifier TargetProperty="PopulationWithGrowth" Operation="Addition" Value="$(Population)"/>
+
+      <Modifier       TargetProperty="PassiveStarSystemExperienceRewardForGovernors"  Operation="Addition"  Value="1.15" Path="ClassStarSystem" Priority="6"/>
+      <BinaryModifier TargetProperty="PassiveStarSystemExperienceRewardForGovernors"  Operation="Power" Left="$(SystemLevel)" BinaryOperation="Subtraction" Right="1" Path="ClassStarSystem" Priority="7"/>
+      <BinaryModifier TargetProperty="PassiveStarSystemExperienceRewardForGovernors"  Operation="Multiplication"  Left="$(Population)" BinaryOperation="Division" Right="2" Path="ClassStarSystem" Priority="8"/>
+      <Modifier       TargetProperty="ExperiencePerTurn"                              Operation="Addition"        Value="$(PassiveStarSystemExperienceRewardForGovernors)" Path="ClassStarSystem/ClassHero"/>
+
+        <Modifier TargetProperty="NetSystemLifeforce"       Operation="Addition" Value="$(NetSystemLifeforce)"      Path="!ColonizedStarSystemStateGhost/../ClassEmpire"/>
+        <Modifier TargetProperty="NetSystemGrowth"          Operation="Addition" Value="$(NetSystemGrowth)"         Path="!ColonizedStarSystemStateGhost/../ClassEmpire"/>
+        <Modifier TargetProperty="NetSystemProduction"      Operation="Addition" Value="$(NetSystemProduction)"     Path="!ColonizedStarSystemStateGhost/../ClassEmpire"/>
+        <Modifier TargetProperty="NetSystemMoney"           Operation="Addition" Value="$(NetSystemMoney)"          Path="!ColonizedStarSystemStateGhost/../ClassEmpire"/>
+        <Modifier TargetProperty="NetSystemResearch"        Operation="Addition" Value="$(NetSystemResearch)"       Path="!ColonizedStarSystemStateGhost/../ClassEmpire"/>
+        <Modifier TargetProperty="NetSystemEmpirePoint"     Operation="Addition" Value="$(NetSystemEmpirePoint)"    Path="!ColonizedStarSystemStateGhost/../ClassEmpire"/>
+
+        <!-- Gui Empire Happiness-->
+        <Modifier TargetProperty="GUIStarSystemsPopulationSum" Operation="Addition" Value="$(Population)" Path="../EmpireTypeMajor"/>
+    </SimulationDescriptor>
+
+    <SimulationDescriptor Name="WorldAcademy" Type="WorldAcademy">
+        <Modifier TargetProperty="EmpireGlobalScore" Operation="Addition" Value="16" Path="../ClassEmpire" TooltipHidden="true"/>
+
+        <Modifier TargetProperty="HeroUnlockThresholdModifier" Operation="Subtraction" Value="0.2" Path="../ClassEmpire" TooltipHidden="true"/>
+    </SimulationDescriptor>
+    
+    <SimulationDescriptor Name="NodeTypeSpecialNode" Type="NodeTypeSpecialNode"/>
+    <SimulationDescriptor Name="UniqueStarSystemAcademy" Type="UniqueStarSystem">
+        <Modifier TargetProperty="ExperiencePerTurn" Operation="Addition" Value="5" Path="ClassColonizedStarSystem/ClassHero"/>
+    </SimulationDescriptor>
+
+    <SimulationDescriptor Name="ConnectedNode" Type="ConnectedNode"/>
+    <SimulationDescriptor Name="IsolatedNode" Type="IsolatedNode"/>
+
+    <SimulationDescriptor Name="GuardedGameNode" Type="GuardedGameNode"/>
+
+    <SimulationDescriptor Name="QuestNode" Type="QuestNode"/>
+
+    <!-- Metaplot -->
+    <SimulationDescriptor Name="MetaplotStateRestored" Type="MetaplotState"/>
+    <SimulationDescriptor Name="MetaplotStateDestroyed" Type="MetaplotState"/>
+    
+    <SimulationDescriptor Name="CannotBeColonized" Type="CannotBeColonized"/>
+
+    <SimulationDescriptor Name="StarSystemStateExploited" Type="StarSystemState" IsSerializable="false"/>
+    <SimulationDescriptor Name="TabernacleSystem" Type="TabernacleSystem"/>
+    
+    <SimulationDescriptor Name="QuestCraversSystem" Type="QuestCraversSystem">
+        <Modifier   TargetProperty="MaximumSystemManpower"              Operation="Addition"        Value="1000"    Path="ClassStarSystem,ClassColonizedStarSystem"/>
+        <Modifier   TargetProperty="GroundBattleDefenderManpowerLimit"  Operation="Addition"        Value="100"     Path="./ClassColonizedStarSystem"/>
+    </SimulationDescriptor>
+
+    <SimulationDescriptor Name="CannotBeConverted" Type="CannotBeConverted"/>
+    <SimulationDescriptor Name="SystemCannotBeDestroyed" Type="SystemCannotBeDestroyed"/>
+
+    <SimulationDescriptor Name="AllPlanetDestroyed" Type="AllPlanetDestroyed" />
+</Datatable>

--- a/Endless Space Competitive Mod/Simulation/SimulationDescriptors[TradableCategories].xml
+++ b/Endless Space Competitive Mod/Simulation/SimulationDescriptors[TradableCategories].xml
@@ -1,0 +1,287 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Datatable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xsi:noNamespaceSchemaLocation="../Schemas/Amplitude.Unity.Simulation.SimulationDescriptor.xsd">
+
+    
+    <!-- CATEGORIES -->
+    <SimulationDescriptor Name="ClassTradableCategory" Type="ClassTradableCategory">
+        
+        <Property Name="Quantity"                   Composition="Sum"/>
+        <Property Name="MaximumCount"               BaseValue="10000"/>
+        
+        <Property Name="QuantityBoughtThisTurn"     Composition="Sum"/>
+        <Property Name="QuantitySoldThisTurn"       Composition="Sum"/>
+        
+        <Property Name="QuantityBoughtLastTurn"     Composition="Sum"/>
+        <Property Name="QuantitySoldLastTurn"       Composition="Sum"/>
+
+        <Property Name="TurnsSinceLastTimeBought"   Composition="Minimum"/>
+        <Property Name="TurnsSinceLastTimeSold"     Composition="Minimum"/>
+        
+        <Property Name="Demand"                     BaseValue="0" MinValue="Negative"/>
+        <Property Name="DemandLastTurn"             IsSealed="true" BaseValue="0" MinValue="Negative"/>
+
+    </SimulationDescriptor>
+
+    <SimulationDescriptor Name="TradableCategoryResource" Type="TradableCategoryResource"/>
+    
+    <SimulationDescriptor Name="TradableCategoryShip" Type="TradableCategoryShip">
+        
+        <Modifier TargetProperty="MaximumCount" Operation="Force" Value="20"/>
+    </SimulationDescriptor>
+
+    <SimulationDescriptor Name="TradableCategoryHero" Type="TradableCategoryHero"/>
+
+    
+    <!-- SUBCATEGORIES -->
+    <SimulationDescriptor Name="ClassTradableSubCategory" Type="ClassTradableSubCategory">
+		
+        <Property Name="Quantity"                   Composition="Sum"/>
+        <Property Name="MaximumCount"               BaseValue="10000"/>
+
+        <Property Name="QuantityBoughtThisTurn"     IsSealed="true"/>
+        <Property Name="QuantitySoldThisTurn"       IsSealed="true"/>
+
+        <Property Name="QuantityBoughtLastTurn"     IsSealed="true"/>
+        <Property Name="QuantitySoldLastTurn"       IsSealed="true"/>
+
+        <Property Name="TurnsSinceLastTimeBought"   IsSealed="true"/>
+        <Property Name="TurnsSinceLastTimeSold"     IsSealed="true"/>
+
+        <Property Name="Demand"                     BaseValue="0" MinValue="Negative"/>
+        <Property Name="DemandLastTurn"             IsSealed="true" BaseValue="0" MinValue="Negative"/>    
+		
+    </SimulationDescriptor>
+
+    <SimulationDescriptor Name="TradableSubCategoryResource" Type="TradableSubCategoryResource">
+        <Property Name="StockIncreasePerTurn"   BaseValue="0"/>
+    </SimulationDescriptor>
+
+    <SimulationDescriptor Name="TradableSubCategoryResourceLuxury" Type="TradableSubCategoryResourceLuxury"/>
+    <SimulationDescriptor Name="TradableSubCategoryResourceStrategic" Type="TradableSubCategoryResourceStrategic"/>
+
+	<SimulationDescriptor Name="TradableSubCategoryShip" Type="TradableSubCategoryShip">
+		<!-- SIM PROPERTIES -->
+		<!-- Stock values -->
+		<Property Name="StockLastTurn"				BaseValue="0"			MinValue="Negative"/>
+		<Property Name="StockDifference"			BaseValue="0"			MinValue="Negative"/>
+		<Property Name="StockSum"					BaseValue="0"			MinValue="Negative"/>
+
+		<!--QUANTITIES & SEALED VALUES-->
+		<!-- Note: Bought = bought by empires (quantity in marketplace reduced). Sold = sold by empires (quantity increased) -->
+		<Property Name="QuantityBoughtThisTurn"     IsSealed="true"/>
+		<Property Name="QuantitySoldThisTurn"       IsSealed="true"/>
+
+		<!-- Sum of the transactions of this turn -->
+		<Property Name="QuantitySum"                MinValue="0.001"/>
+
+		<!-- Difference between buyouts and sellouts -->
+		<Property Name="QuantityDifference"         MinValue="Negative"/>
+
+		<!-- Log(QuantitySum / 2 + 1) -->
+		<Property Name="QuantityDifferenceLogarithm"   MinValue="Negative"/>
+
+		<Property Name="QuantityBoughtLastTurn"     IsSealed="true"/>
+		<Property Name="QuantitySoldLastTurn"       IsSealed="true"/>
+
+		<Property Name="TurnsSinceLastTimeBought"   IsSealed="true"/>
+		<Property Name="TurnsSinceLastTimeSold"     IsSealed="true"/>
+
+		<!--VALUE CHECK AND ADD-->
+		<!--Set Value of Increments-->
+		<BinaryModifier TargetProperty="DemandPriceChangeFactor"	Operation="Addition"	Left="10"	BinaryOperation="Multiplication"	Right="$(DemandValueIncrementShip)"	Priority="-10"	Path="TradableSubCategoryShip/ClassTradable" SearchValueFromPath="true"/>
+		<BinaryModifier TargetProperty="DemandMinPriceChangeFactor"	Operation="Addition"	Left="3"	BinaryOperation="Multiplication"	Right="$(ValueIncrementShip)"	Priority="-10"	Path="TradableSubCategoryShip/ClassTradable" SearchValueFromPath="true"/>
+		<BinaryModifier TargetProperty="PriceChangeFactor"			Operation="Addition"	Left="1"	BinaryOperation="Multiplication"	Right="$(ValueIncrementShip)"	Priority="-10"  Path="TradableSubCategoryShip/ClassTradable" SearchValueFromPath="true"/>
+
+		
+		<Modifier TargetProperty="MaximumQuantity"                          Operation="Addition"        Value="4999" Priority="-1"/>
+
+		<!-- Quantity bought & sold -->
+		<Modifier TargetProperty="QuantitySum"                              Operation="Addition"        Value="$(QuantityBoughtThisTurn)" Priority="-1"/>
+		<Modifier TargetProperty="QuantitySum"                              Operation="Addition"        Value="$(QuantitySoldThisTurn)" Priority="-1"/>
+
+		<Modifier TargetProperty="QuantityDifference"                       Operation="Addition"        Value="$(QuantityBoughtThisTurn)" Priority="-1"/>
+		<Modifier TargetProperty="QuantityDifference"                       Operation="Subtraction"     Value="$(QuantitySoldThisTurn)" Priority="-1"/>
+
+		<!-- PRICE COMPUTATIONS -->
+		<!-- Last Turn Stock -->
+		<Modifier TargetProperty="StockLastTurn" Operation="Addition" Value="$(Quantity)" Priority="-1"/>
+		<Modifier TargetProperty="StockLastTurn" Operation="Addition" Value="$(QuantityBoughtThisTurn)" Priority="-1"/>
+		<Modifier TargetProperty="StockLastTurn" Operation="Subtraction" Value="$(QuantitySoldThisTurn)" Priority="-1"/>
+
+		<!-- StockSum -->
+		<Modifier		TargetProperty="StockSum"			Operation="Addition"	Value="$(StockLastTurn)" Priority="-1"/>
+		<Modifier		TargetProperty="StockSum"			Operation="Addition"	Value="$(Quantity)" Priority="-1"/>
+		<Modifier		TargetProperty="StockSum"			Operation="Addition"	Value="1" Priority="-1"/>
+
+		<!-- StockDifference -->
+		<Modifier TargetProperty="StockDifference" Operation="Addition" Value="$(StockLastTurn)" Priority="-1"/>
+		<Modifier TargetProperty="StockDifference" Operation="Subtraction" Value="$(Quantity)" Priority="-1"/>
+		<Modifier TargetProperty="StockDifference" Operation="Addition"	Value="$(StockDifference)" Priority="-1" Path="TradableSubCategoryShip/ClassTradable"/>
+
+		<!-- MinPriceChange-->
+		<BinaryModifier TargetProperty="MinPriceChange"			Operation="Addition"	Left="$(BaseValue)"	BinaryOperation="Multiplication"	Right="$(PriceChangeFactor)" Priority="-1" Path="TradableSubCategoryShip/ClassTradable" SearchValueFromPath="true"/>
+		<BinaryModifier TargetProperty="MinDemandPriceChange"	Operation="Addition"	Left="$(BaseValue)"	BinaryOperation="Multiplication"	Right="$(DemandMinPriceChangeFactor)" Priority="-1"  Path="TradableSubCategoryShip/ClassTradable" SearchValueFromPath="true"/>
+		<!-- PriceChange-->
+		<BinaryModifier		TargetProperty="PriceChange"		Operation="Addition"	Left="$(MinPriceChange)"	BinaryOperation="Multiplication"	Right="$(StockDifference)" Priority="-1" Path="TradableSubCategoryShip/ClassTradable" SearchValueFromPath="true"/>
+		<!--Demandvalues-->
+		<BinaryModifier TargetProperty="DemandPriceChange"		Operation="Addition"	Left="$(BaseValue)"	BinaryOperation="Multiplication"	Right="$(DemandPriceChangeFactor)" Priority="-1" Path="TradableSubCategoryShip/ClassTradable" SearchValueFromPath="true"/>
+		<Modifier TargetProperty="PassedDemand"			Operation="Addition" Value="$(Demand)"			Priority="-1" Path="TradableSubCategoryShip/ClassTradable"/>
+		<Modifier TargetProperty="PassedDemandLastTurn"	Operation="Addition" Value="$(DemandLastTurn)"	Priority="-1" Path="TradableSubCategoryShip/ClassTradable"/>
+		
+		<!-- MinValue -->
+		<BinaryModifier TargetProperty="MinValue"		Operation="Addition" Left="0.4" BinaryOperation="Multiplication" Right="$(BaseValue)" Path="TradableSubCategoryShip/ClassTradable" SearchValueFromPath="true"/>
+		<BinaryModifier	TargetProperty="MinValue"		Operation="Addition"     Left="$(DemandPriceChange)" BinaryOperation="Multiplication" Right="$(PassedDemand)" Path="TradableSubCategoryShip/ClassTradable"  SearchValueFromPath="true"/>
+		
+		<BinaryModifier TargetProperty="FakeMinValue"	Operation="Addition" Left="0.4" BinaryOperation="Multiplication" Right="$(BaseValue)" Path="TradableSubCategoryShip/ClassTradable" SearchValueFromPath="true"/>
+		<BinaryModifier	TargetProperty="FakeMinValue"	Operation="Addition"     Left="$(DemandPriceChange)" BinaryOperation="Multiplication" Right="$(PassedDemand)" Path="TradableSubCategoryShip/ClassTradable" SearchValueFromPath="true"/>
+
+		<!-- Value -->
+		<!-- Just standard price variations for buy / sell transactions -->
+		<Modifier			TargetProperty="Value"					Operation="Addition"        Value="$(ValueLastTurn)"  Path="TradableSubCategoryShip/ClassTradable" SearchValueFromPath="true"/>
+		<Modifier			TargetProperty="Value"					Operation="Division"		Value="$(InflationLastTurn)" Path="TradableSubCategoryShip/ClassTradable" SearchValueFromPath="true"/>
+		<Modifier			TargetProperty="Value"					Operation="Addition"        Value="$(PriceChange)" Path="TradableSubCategoryShip/ClassTradable"  SearchValueFromPath="true"/>
+		<BinaryModifier		TargetProperty="Value"					Operation="Addition"		Left="$(PassedDemand)" BinaryOperation="Multiplication" Right="$(MinDemandPriceChange)" Path="TradableSubCategoryShip/ClassTradable" SearchValueFromPath="true"/>
+
+		<Modifier			TargetProperty="FakeValue"				Operation="Addition"        Value="$(ValueLastTurn)" Path="TradableSubCategoryShip/ClassTradable" SearchValueFromPath="true"/>
+		<Modifier			TargetProperty="FakeValue"				Operation="Division"		Value="$(InflationLastTurn)" Path="TradableSubCategoryShip/ClassTradable" SearchValueFromPath="true"/>
+		<Modifier			TargetProperty="FakeValue"				Operation="Addition"        Value="$(PriceChange)" Path="TradableSubCategoryShip/ClassTradable"  SearchValueFromPath="true"/>
+		<BinaryModifier		TargetProperty="FakeValue"				Operation="Addition"		Left="$(PassedDemand)" BinaryOperation="Multiplication" Right="$(MinDemandPriceChange)" Path="TradableSubCategoryShip/ClassTradable" SearchValueFromPath="true"/>
+
+		<Modifier			TargetProperty="FakeValueForCorrect"	Operation="Addition"        Value="$(ValueLastTurn)" Path="TradableSubCategoryShip/ClassTradable" SearchValueFromPath="true"/>
+		<Modifier			TargetProperty="FakeValueForCorrect"	Operation="Division"		Value="$(InflationLastTurn)" Path="TradableSubCategoryShip/ClassTradable" SearchValueFromPath="true"/>
+		<Modifier			TargetProperty="FakeValueForCorrect"	Operation="Addition"        Value="$(PriceChange)" Path="TradableSubCategoryShip/ClassTradable"  SearchValueFromPath="true"/>
+		<BinaryModifier		TargetProperty="FakeValueForCorrect"	Operation="Addition"		Left="$(PassedDemand)" BinaryOperation="Multiplication" Right="$(MinDemandPriceChange)" Path="TradableSubCategoryShip/ClassTradable" SearchValueFromPath="true"/>
+
+		<Modifier			TargetProperty="FakeValue"				Operation="Addition"		Value="0.001"	Path="TradableSubCategoryShip/ClassTradable" SearchValueFromPath="true"/>
+
+		<!-- Check the booleans for comparison -->
+		<BinaryModifier TargetProperty="ValueLowerThanMinValue"	Operation="Addition" Left="$(FakeMinValue)" BinaryOperation="Subtraction"		Right="$(FakeValue)" Path="TradableSubCategoryShip/ClassTradable" SearchValueFromPath="true"/>
+		<BinaryModifier TargetProperty="MinValueLowerThanValue"	Operation="Addition" Left="$(FakeValue)" BinaryOperation="Subtraction"		Right="$(FakeMinValue)" Path="TradableSubCategoryShip/ClassTradable" SearchValueFromPath="true"/>
+
+		<!-- Add either real value or min value : 	Add real value IF min value < real value  OR	Add min value IF real value < min value -->
+		<Modifier	TargetProperty="Value"	Operation="Force" Value="0" Priority="2" Path="TradableSubCategoryShip/ClassTradable"/>
+		<!-- Force 0 then add correct value -->
+		<BinaryModifier TargetProperty="Value" Operation="Addition" Left="$(MinValue)" BinaryOperation="Multiplication" Right="$(ValueLowerThanMinValue)" Priority="3" Path="TradableSubCategoryShip/ClassTradable" SearchValueFromPath="true"/>
+		<BinaryModifier TargetProperty="Value" Operation="Addition" Left="$(FakeValueForCorrect)" BinaryOperation="Multiplication" Right="$(MinValueLowerThanValue)" Priority="3" Path="TradableSubCategoryShip/ClassTradable" SearchValueFromPath="true"/>
+
+		<!-- Add Inflation -->
+		<Modifier TargetProperty="Value"	Operation="Multiplication" Value="$(Inflation)" Priority="4" Path="TradableSubCategoryShip/ClassTradable" SearchValueFromPath="true"/>
+	</SimulationDescriptor>
+
+	<SimulationDescriptor Name="TradableSubCategoryShipColonizer"	Type="TradableSubCategoryShipColonizer"/>
+	<SimulationDescriptor Name="TradableSubCategoryShipExplorer"	Type="TradableSubCategoryShipExplorer"/>
+	<SimulationDescriptor Name="TradableSubCategoryShipOffense"		Type="TradableSubCategoryShipOffense"/>
+	<SimulationDescriptor Name="TradableSubCategoryShipSupport"		Type="TradableSubCategoryShipSupport"/>
+	<SimulationDescriptor Name="TradableSubCategoryShipCarrier"		Type="TradableSubCategoryShipCarrier"/>
+	<SimulationDescriptor Name="TradableSubCategoryShipLeecher"		Type="TradableSubCategoryShipLeecher"/>
+	<SimulationDescriptor Name="TradableSubCategoryShipRootCreator" Type="TradableSubCategoryShipRootCreator"/>
+
+	<SimulationDescriptor Name="TradableSubCategoryHero" Type="TradableSubCategoryHero">
+		<!-- SIM PROPERTIES -->
+		<!-- Stock values -->
+		<Property Name="StockLastTurn"				BaseValue="0"			MinValue="Negative"/>
+		<Property Name="StockDifference"			BaseValue="0"			MinValue="Negative"/>
+		<Property Name="StockSum"					BaseValue="0"			MinValue="Negative"/>
+
+		<!--QUANTITIES & SEALED VALUES-->
+		<!-- Note: Bought = bought by empires (quantity in marketplace reduced). Sold = sold by empires (quantity increased) -->
+		<Property Name="QuantityBoughtThisTurn"     IsSealed="true"/>
+		<Property Name="QuantitySoldThisTurn"       IsSealed="true"/>
+
+		<!-- Sum of the transactions of this turn -->
+		<Property Name="QuantitySum"                MinValue="0.001"/>
+
+		<!-- Difference between buyouts and sellouts -->
+		<Property Name="QuantityDifference"         MinValue="Negative"/>
+
+		<!-- Log(QuantitySum / 2 + 1) -->
+		<Property Name="QuantityDifferenceLogarithm"   MinValue="Negative"/>
+
+		<Property Name="QuantityBoughtLastTurn"     IsSealed="true"/>
+		<Property Name="QuantitySoldLastTurn"       IsSealed="true"/>
+
+		<Property Name="TurnsSinceLastTimeBought"   IsSealed="true"/>
+		<Property Name="TurnsSinceLastTimeSold"     IsSealed="true"/>
+
+		<!--VALUE CHECK AND ADD-->
+		<!--Set Value of Increments-->
+		<BinaryModifier TargetProperty="DemandPriceChangeFactor"	Operation="Addition"	Left="10"		BinaryOperation="Multiplication"	Right="$(DemandValueIncrementHero)"	Priority="-10"	Path="TradableSubCategoryHero/ClassTradable" SearchValueFromPath="true"/>
+		<BinaryModifier TargetProperty="DemandMinPriceChangeFactor"	Operation="Addition"	Left="3"	BinaryOperation="Multiplication"	Right="$(ValueIncrementHero)"	Priority="-10"	Path="TradableSubCategoryHero/ClassTradable" SearchValueFromPath="true"/>
+		<BinaryModifier TargetProperty="PriceChangeFactor"		Operation="Addition"	Left="1"	BinaryOperation="Multiplication"	Right="$(ValueIncrementHero)"	Priority="-10"  Path="TradableSubCategoryHero/ClassTradable" SearchValueFromPath="true"/>
+		
+		<Modifier TargetProperty="MaximumQuantity"                          Operation="Addition"        Value="4999" Priority="-1"/>
+
+		<!-- Quantity bought & sold -->
+		<Modifier TargetProperty="QuantitySum"                              Operation="Addition"        Value="$(QuantityBoughtThisTurn)" Priority="-1"/>
+		<Modifier TargetProperty="QuantitySum"                              Operation="Addition"        Value="$(QuantitySoldThisTurn)" Priority="-1"/>
+
+		<Modifier TargetProperty="QuantityDifference"                       Operation="Addition"        Value="$(QuantityBoughtThisTurn)" Priority="-1"/>
+		<Modifier TargetProperty="QuantityDifference"                       Operation="Subtraction"     Value="$(QuantitySoldThisTurn)" Priority="-1"/>
+
+		<!-- PRICE COMPUTATIONS -->
+		<!-- Last Turn Stock -->
+		<Modifier TargetProperty="StockLastTurn" Operation="Addition" Value="$(Quantity)" Priority="-1"/>
+		<Modifier TargetProperty="StockLastTurn" Operation="Addition" Value="$(QuantityBoughtThisTurn)" Priority="-1"/>
+		<Modifier TargetProperty="StockLastTurn" Operation="Subtraction" Value="$(QuantitySoldThisTurn)" Priority="-1"/>
+
+		<!-- StockSum -->
+		<Modifier		TargetProperty="StockSum"			Operation="Addition"	Value="$(StockLastTurn)" Priority="-1"/>
+		<Modifier		TargetProperty="StockSum"			Operation="Addition"	Value="$(Quantity)" Priority="-1"/>
+		<Modifier		TargetProperty="StockSum"			Operation="Addition"	Value="1" Priority="-1"/>
+
+		<!-- StockDifference -->
+		<Modifier TargetProperty="StockDifference" Operation="Addition" Value="$(StockLastTurn)" Priority="-1"/>
+		<Modifier TargetProperty="StockDifference" Operation="Subtraction" Value="$(Quantity)" Priority="-1"/>
+		<Modifier TargetProperty="StockDifference" Operation="Addition"	Value="$(StockDifference)" Priority="-1" Path="TradableSubCategoryHero/ClassTradable"/>
+
+		<!-- MinPriceChange-->
+		<BinaryModifier TargetProperty="MinPriceChange"			Operation="Addition"	Left="$(BaseValue)"	BinaryOperation="Multiplication"	Right="$(PriceChangeFactor)" Priority="-1" Path="TradableSubCategoryHero/ClassTradable" SearchValueFromPath="true"/>
+		<BinaryModifier TargetProperty="MinDemandPriceChange"	Operation="Addition"	Left="$(BaseValue)"	BinaryOperation="Multiplication"	Right="$(DemandMinPriceChangeFactor)" Priority="-1"  Path="TradableSubCategoryHero/ClassTradable" SearchValueFromPath="true"/>
+		<!-- PriceChange-->
+		<BinaryModifier		TargetProperty="PriceChange"		Operation="Addition"	Left="$(MinPriceChange)"	BinaryOperation="Multiplication"	Right="$(StockDifference)" Priority="-1" Path="TradableSubCategoryHero/ClassTradable" SearchValueFromPath="true"/>
+		<!--Demandvalues-->
+		<BinaryModifier TargetProperty="DemandPriceChange"		Operation="Addition"	Left="$(BaseValue)"	BinaryOperation="Multiplication"	Right="$(DemandPriceChangeFactor)" Priority="-1" Path="TradableSubCategoryHero/ClassTradable" SearchValueFromPath="true"/>
+		<Modifier TargetProperty="PassedDemand"			Operation="Addition" Value="$(Demand)"			Priority="-1" Path="TradableSubCategoryHero/ClassTradable"/>
+		<Modifier TargetProperty="PassedDemandLastTurn"	Operation="Addition" Value="$(DemandLastTurn)"	Priority="-1" Path="TradableSubCategoryHero/ClassTradable"/>
+
+		<!-- MinValue -->
+		<BinaryModifier TargetProperty="MinValue"		Operation="Addition" Left="0.4" BinaryOperation="Multiplication" Right="$(BaseValue)" Path="TradableSubCategoryHero/ClassTradable" SearchValueFromPath="true"/>
+		<BinaryModifier	TargetProperty="MinValue"		Operation="Addition"     Left="$(DemandPriceChange)" BinaryOperation="Multiplication" Right="$(PassedDemand)" Path="TradableSubCategoryHero/ClassTradable"  SearchValueFromPath="true"/>
+		
+		<BinaryModifier TargetProperty="FakeMinValue"	Operation="Addition" Left="0.4" BinaryOperation="Multiplication" Right="$(BaseValue)" Path="TradableSubCategoryHero/ClassTradable" SearchValueFromPath="true"/>
+		<BinaryModifier	TargetProperty="FakeMinValue"	Operation="Addition"     Left="$(DemandPriceChange)" BinaryOperation="Multiplication" Right="$(PassedDemand)" Path="TradableSubCategoryHero/ClassTradable" SearchValueFromPath="true"/>
+
+		<!-- Value -->
+		<!-- Just standard price variations for buy / sell transactions -->
+		<Modifier			TargetProperty="Value"					Operation="Addition"        Value="$(ValueLastTurn)"  Path="TradableSubCategoryHero/ClassTradable" SearchValueFromPath="true"/>
+		<BinaryModifier		TargetProperty="Value"					Operation="Division"		Left="$(InflationLastTurn)" BinaryOperation="Multiplication" Right="2" Path="TradableSubCategoryHero/ClassTradable" SearchValueFromPath="true"/>
+		<Modifier			TargetProperty="Value"					Operation="Addition"        Value="$(PriceChange)" Path="TradableSubCategoryHero/ClassTradable"  SearchValueFromPath="true"/>
+		<BinaryModifier		TargetProperty="Value"					Operation="Addition"		Left="$(PassedDemand)" BinaryOperation="Multiplication" Right="$(MinDemandPriceChange)" Priority="4" Path="TradableSubCategoryHero/ClassTradable" SearchValueFromPath="true"/>
+
+		<Modifier			TargetProperty="FakeValue"				Operation="Addition"        Value="$(ValueLastTurn)" Path="TradableSubCategoryHero/ClassTradable" SearchValueFromPath="true"/>
+		<BinaryModifier		TargetProperty="FakeValue"				Operation="Division"		Left="$(InflationLastTurn)" BinaryOperation="Multiplication" Right="2" Path="TradableSubCategoryHero/ClassTradable" SearchValueFromPath="true"/>
+		<Modifier			TargetProperty="FakeValue"				Operation="Addition"        Value="$(PriceChange)" Path="TradableSubCategoryHero/ClassTradable"  SearchValueFromPath="true"/>
+		<BinaryModifier		TargetProperty="FakeValue"				Operation="Addition"		Left="$(PassedDemand)" BinaryOperation="Multiplication" Right="$(MinDemandPriceChange)" Priority="4" Path="TradableSubCategoryHero/ClassTradable" SearchValueFromPath="true"/>
+
+		<Modifier			TargetProperty="FakeValueForCorrect"	Operation="Addition"        Value="$(ValueLastTurn)" Path="TradableSubCategoryHero/ClassTradable" SearchValueFromPath="true"/>
+		<BinaryModifier		TargetProperty="FakeValueForCorrect"	Operation="Division"		Left="$(InflationLastTurn)" BinaryOperation="Multiplication" Right="2" Path="TradableSubCategoryHero/ClassTradable" SearchValueFromPath="true"/>
+		<Modifier			TargetProperty="FakeValueForCorrect"	Operation="Addition"        Value="$(PriceChange)" Path="TradableSubCategoryHero/ClassTradable"  SearchValueFromPath="true"/>
+		<BinaryModifier		TargetProperty="FakeValueForCorrect"	Operation="Addition"		Left="$(PassedDemand)" BinaryOperation="Multiplication" Right="$(MinDemandPriceChange)" Priority="4" Path="TradableSubCategoryHero/ClassTradable" SearchValueFromPath="true"/>
+
+		<Modifier			TargetProperty="FakeValue"				Operation="Addition"		Value="0.1"	Path="TradableSubCategoryHero/ClassTradable" SearchValueFromPath="true"/>
+
+		<!-- Check the booleans for comparison -->
+		<BinaryModifier TargetProperty="ValueLowerThanMinValue"	Operation="Addition" Left="$(FakeMinValue)" BinaryOperation="Subtraction"		Right="$(FakeValue)" Path="TradableSubCategoryHero/ClassTradable" SearchValueFromPath="true"/>
+		<BinaryModifier TargetProperty="MinValueLowerThanValue"	Operation="Addition" Left="$(FakeValue)" BinaryOperation="Subtraction"		Right="$(FakeMinValue)" Path="TradableSubCategoryHero/ClassTradable" SearchValueFromPath="true"/>
+
+		<!-- Add either real value or min value : 	Add real value IF min value < real value  OR	Add min value IF real value < min value -->
+		<Modifier	TargetProperty="Value"	Operation="Force" Value="0" Priority="2" Path="TradableSubCategoryHero/ClassTradable"/>
+		<!-- Force 0 then add correct value -->
+		<BinaryModifier TargetProperty="Value" Operation="Addition" Left="$(MinValue)" BinaryOperation="Multiplication" Right="$(ValueLowerThanMinValue)" Priority="3" Path="TradableSubCategoryHero/ClassTradable" SearchValueFromPath="true"/>
+		<BinaryModifier TargetProperty="Value" Operation="Addition" Left="$(FakeValueForCorrect)" BinaryOperation="Multiplication" Right="$(MinValueLowerThanValue)" Priority="3" Path="TradableSubCategoryHero/ClassTradable" SearchValueFromPath="true"/>
+
+		<!-- Add Inflation -->
+		<BinaryModifier TargetProperty="Value"	Operation="Multiplication" Left="$(Inflation)" BinaryOperation="Multiplication" Right="2" Priority="4" Path="TradableSubCategoryHero/ClassTradable" SearchValueFromPath="true"/>
+	</SimulationDescriptor>
+
+</Datatable>

--- a/Endless Space Competitive Mod/Simulation/SimulationDescriptors[Tradables].xml
+++ b/Endless Space Competitive Mod/Simulation/SimulationDescriptors[Tradables].xml
@@ -1,0 +1,427 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Datatable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xsi:noNamespaceSchemaLocation="../Schemas/Amplitude.Unity.Simulation.SimulationDescriptor.xsd">
+    
+    <SimulationDescriptor Name="ClassTradable" Type="ClassTradable">
+		<Property Name="Value"						MinValue="0"/>
+		<Property Name="ValueLastTurn"              IsSealed="true"/>
+		<Property Name="BaseValue"                  IsSealed="true"/>
+		<Property Name="FakeValue"					MinValue="0"/>
+		<Property Name="FakeValueForCorrect"		MinValue="0"/>
+		<Property Name="MinValue"					BaseValue="1" MinValue="1"/>
+		<Property Name="FakeMinValue"				BaseValue="1" MinValue="1"/>
+		<Property Name="ValueLowerThanMinValue"		MinValue="0" MaxValue="1"		RoundingFunction="Ceil"/>
+		<Property Name="MinValueLowerThanValue"		MinValue="0" MaxValue="1"		RoundingFunction="Ceil"/>
+		<Property Name="AddedMinValue"				BaseValue="-1" MinValue="Negative"/>
+		<Property Name="GameSpeedMultiplier"		BaseValue="1"/>
+
+		<Property Name="ValueIncrementResource"     BaseValue="0.025"/>
+		<Property Name="ValueIncrementShip"         BaseValue="0.1"/>
+		<Property Name="ValueIncrementHero"         BaseValue="0.1"/>
+		
+		<Property Name="DemandValueIncrementResource"     BaseValue="0.025"/>
+		<Property Name="DemandValueIncrementShip"         BaseValue="0.025"/>
+		<Property Name="DemandValueIncrementHero"         BaseValue="0.025"/>
+		
+		<Property Name="DemandPriceChange"			BaseValue="0"/>
+
+		<Property Name="Quantity"                   IsSealed="true"/>
+		<Property Name="MaximumQuantity"            BaseValue="1"/>
+
+		<Property Name="Inflation"                  BaseValue="1"/>
+		<Property Name="InflationLastTurn"			BaseValue="1"/>
+
+		<Property Name="Lifetime"                   IsSealed="true"/>
+		<Property Name="MaximumLifetime"/>
+
+        <!-- For MarketplaceEvents testing purposes: Demand increases value by 10% per demand per turn. Off for now -->
+        <!--<BinaryModifier TargetProperty="Value" Operation="Percent" Left="$(Demand)" BinaryOperation="Multiplication" Right="0.1" Priority="4"/>-->
+	</SimulationDescriptor>
+
+	<SimulationDescriptor Name="TradableResource" Type="TradableResource">
+		<Property Name="Value"						MinValue="0"/>
+		<Property Name="FakeValue"					MinValue="0"/>
+		<Property Name="FakeValueForCorrect"		MinValue="0"/>
+		<Property Name="MinValue"					BaseValue="0"/>
+		<Property Name="FakeMinValue"				BaseValue="0"/>
+		<Property Name="ValueLowerThanMinValue"		MinValue="0" MaxValue="1"		RoundingFunction="Ceil"/>
+		<Property Name="MinValueLowerThanValue"		MinValue="0" MaxValue="1"		RoundingFunction="Ceil"/>
+		<Property Name="AddedMinValue"				BaseValue="-1" MinValue="Negative"/>
+
+        <Property Name="Demand"                     BaseValue="0" MinValue="Negative"/>
+        <Property Name="DemandLastTurn"             IsSealed="true" BaseValue="0" MinValue="Negative"/>
+		<Property Name="DemandPriceChange"			BaseValue="0" MinValue="Negative"/>
+		<Property Name="DemandPriceChangeFactor"	BaseValue="0"/>
+
+        <!-- SIM PROPERTIES -->
+        <!-- Stock values -->
+        <Property Name="StockLastTurn"				BaseValue="0"			MinValue="Negative"/>
+        <Property Name="StockDifference"			BaseValue="0"			MinValue="Negative"/>
+        <Property Name="StockSum"					BaseValue="0"			MinValue="Negative"/>
+        <Property Name="StockIncreasePerTurn"		BaseValue="0"			MinValue="Negative"/>
+        <Property Name="StockThresholdForDecay"     BaseValue="50"/>
+        
+		<!-- Price variations according to market state -->
+		<Property Name="PriceChange"				BaseValue="0"			MinValue="Negative"/>
+		<Property Name="MinPriceChange"				BaseValue="0"			MinValue="Negative"/>
+		<Property Name="MinDemandPriceChange"		BaseValue="0"			MinValue="Negative"/>
+		<Property Name="PriceChangeFactor"			BaseValue="0"/>
+		<Property Name="DemandMinPriceChangeFactor"	BaseValue="0"/>
+		<!--1 Price increment-->
+		<!-- Price decay values -->
+		<Property Name="PriceShouldDecay"			BaseValue="0"			MinValue="0" MaxValue="1" RoundingFunction="Ceil"/> <!-- PriceShouldDecay = (PriceDecayTSSCheck * PriceDecayTSBCheck) -->
+		<Property Name="PriceDecayTurnDelay"		BaseValue="0"/> <!--Constant: delay until price starts to decay-->
+		<Property Name="PriceDecayTSSCheck"			BaseValue="0" MinValue="0" MaxValue="1"/> <!--TurnsSinceLastTimeSold - PriceDecayTurnDelay-->
+		<Property Name="PriceDecayTSBCheck"			BaseValue="0" MinValue="0" MaxValue="1"/> <!--TurnsSinceLastTimeBought - PriceDecayTurnDelay-->
+		<Property Name="PriceDecay"					BaseValue="0"			MinValue="Negative"/>
+		<Property Name="PriceDecayValue"			BaseValue="0"			MinValue="Negative"/>
+		<Property Name="PriceDecayFactor"			BaseValue="0"/>
+		<!--2 Price increments-->
+		<!-- Price increase values -->
+		<Property Name="PriceShouldIncrease"		BaseValue="0"			MinValue="0" MaxValue="1"/>
+		<Property Name="PriceIncrease"				BaseValue="0"			MinValue="Negative"/>
+		<Property Name="PriceIncreaseValue"			BaseValue="0"			MinValue="Negative"/>
+		<Property Name="PriceIncreaseFactor"		BaseValue="0"/>
+		<!--3 Price increments-->
+		
+		<!--QUANTITIES & SEALED VALUES-->
+		<!-- Note: Bought = bought by empires (quantity in marketplace reduced). Sold = sold by empires (quantity increased) -->
+		<Property Name="QuantityBoughtThisTurn"     IsSealed="true"/>
+		<Property Name="QuantitySoldThisTurn"       IsSealed="true"/>
+
+		<!-- Sum of the transactions of this turn -->
+		<Property Name="QuantitySum"                MinValue="0.001"/>
+
+		<!-- Difference between buyouts and sellouts -->
+		<Property Name="QuantityDifference"         MinValue="Negative"/>
+
+		<!-- Log(QuantitySum / 2 + 1) -->
+		<Property Name="QuantityDifferenceLogarithm"   MinValue="Negative"/>
+
+		<Property Name="QuantityBoughtLastTurn"     IsSealed="true"/>
+		<Property Name="QuantitySoldLastTurn"       IsSealed="true"/>
+
+		<Property Name="TurnsSinceLastTimeBought"   IsSealed="true"/>
+		<Property Name="TurnsSinceLastTimeSold"     IsSealed="true"/>
+
+		<Property Name="ChancesToRefill"            BaseValue="-15"/>
+
+		<!--VALUE CHECK AND ADD-->
+		<!--Set Value of Increments-->
+		<BinaryModifier TargetProperty="PriceChangeFactor"			Operation="Addition"	Left="1"	BinaryOperation="Multiplication"	Right="$(ValueIncrementResource)"		Priority="-10"/>
+		<BinaryModifier TargetProperty="PriceDecayFactor"			Operation="Addition"	Left="2"	BinaryOperation="Multiplication"	Right="$(ValueIncrementResource)"		Priority="-10"/>
+		<BinaryModifier TargetProperty="PriceIncreaseFactor"		Operation="Addition"	Left="3"	BinaryOperation="Multiplication"	Right="$(ValueIncrementResource)"		Priority="-10"/>
+		<BinaryModifier TargetProperty="DemandMinPriceChangeFactor"	Operation="Addition"	Left="3"	BinaryOperation="Multiplication"	Right="$(ValueIncrementResource)"		Priority="-10"/>
+		<BinaryModifier TargetProperty="DemandPriceChangeFactor"	Operation="Addition"	Left="10"	BinaryOperation="Multiplication"	Right="$(DemandValueIncrementResource)"	Priority="-10"/>
+		<BinaryModifier	TargetProperty="PriceDecayTurnDelay"		Operation="Addition"	Left="5"	BinaryOperation="Multiplication"	Right="$(GameSpeedMultiplier)"			Priority="-10"/>
+
+		<Modifier TargetProperty="MaximumQuantity"                          Operation="Addition"        Value="4999" Priority="-1"/>
+
+		<!-- Quantity bought & sold -->
+		<Modifier TargetProperty="QuantitySum"                              Operation="Addition"        Value="$(QuantityBoughtThisTurn)" Priority="-1"/>
+		<Modifier TargetProperty="QuantitySum"                              Operation="Addition"        Value="$(QuantitySoldThisTurn)" Priority="-1"/>
+
+		<Modifier TargetProperty="QuantityDifference"                       Operation="Addition"        Value="$(QuantityBoughtThisTurn)" Priority="-1"/>
+		<Modifier TargetProperty="QuantityDifference"                       Operation="Subtraction"     Value="$(QuantitySoldThisTurn)" Priority="-1"/>
+
+		<!-- PRICE COMPUTATIONS -->
+		<!-- Last Turn Stock -->
+		<Modifier TargetProperty="StockLastTurn" Operation="Addition" Value="$(Quantity)" Priority="-1"/>
+		<Modifier TargetProperty="StockLastTurn" Operation="Addition" Value="$(QuantityBoughtThisTurn)" Priority="-1"/>
+		<Modifier TargetProperty="StockLastTurn" Operation="Subtraction" Value="$(QuantitySoldThisTurn)" Priority="-1"/>
+
+		<!-- StockSum -->
+		<Modifier		TargetProperty="StockSum"			Operation="Addition"	Value="$(StockLastTurn)" Priority="-1"/>
+		<Modifier		TargetProperty="StockSum"			Operation="Addition"	Value="$(Quantity)" Priority="-1"/>
+		<Modifier		TargetProperty="StockSum"			Operation="Addition"	Value="1" Priority="-1"/>
+
+		<!-- StockDifference -->
+		<Modifier TargetProperty="StockDifference" Operation="Addition" Value="$(StockLastTurn)" Priority="-1"/>
+		<Modifier TargetProperty="StockDifference" Operation="Subtraction" Value="$(Quantity)" Priority="-1"/>
+
+		<!-- MinPriceChange-->
+		<BinaryModifier TargetProperty="MinPriceChange"			Operation="Addition"	Left="$(BaseValue)"	BinaryOperation="Multiplication"	Right="$(PriceChangeFactor)" Priority="-1"/>
+		<BinaryModifier TargetProperty="MinDemandPriceChange"	Operation="Addition"	Left="$(BaseValue)"	BinaryOperation="Multiplication"	Right="$(DemandMinPriceChangeFactor)" Priority="-1"/>
+		<!-- PriceChange-->
+		<BinaryModifier		TargetProperty="PriceChange"		Operation="Addition"	Left="$(MinPriceChange)"	BinaryOperation="Multiplication"	Right="$(StockDifference)" Priority="-1"/>
+		<!--DemandValues-->
+		<BinaryModifier TargetProperty="DemandPriceChange"		Operation="Addition"	Left="$(BaseValue)"	BinaryOperation="Multiplication"	Right="$(DemandPriceChangeFactor)" Priority="-1"/>
+
+		<!-- PRICE DECAY COMPUTATIONS -->
+		<BinaryModifier TargetProperty="PriceDecayValue"		Operation="Subtraction"		Left="$(BaseValue)"					BinaryOperation="Multiplication"	Right="$(PriceDecayFactor)"		Priority="-1"/>
+		<!-- If no activity over PriceDecayTurnDelay turns, PriceShouldDecay will be at 1, otherwise 0-->
+		<BinaryModifier TargetProperty="PriceDecayTSSCheck"		Operation="Addition"		Left="$(TurnsSinceLastTimeSold)"	BinaryOperation="Subtraction"		Right="$(PriceDecayTurnDelay)"	Priority="-1"/>
+		<BinaryModifier TargetProperty="PriceDecayTSBCheck"		Operation="Addition"		Left="$(TurnsSinceLastTimeBought)"	BinaryOperation="Subtraction"		Right="$(PriceDecayTurnDelay)"	Priority="-1"/>
+		<!-- This is more or less a hack: if the stock is not yet at 50, we basically force the PriceDecayTSSCheck at 0 so the price won't decay-->
+        <BinaryModifier TargetProperty="PriceDecayTSSCheck"     Operation="Addition"        Left="$(StockLastTurn)"             BinaryOperation="Subtraction"       Right="$(StockThresholdForDecay)"/>
+        <!-- End hack -->
+        <BinaryModifier TargetProperty="PriceShouldDecay"		Operation="Addition"		Left="$(PriceDecayTSSCheck)"		BinaryOperation="Multiplication"	Right="$(PriceDecayTSBCheck)"	Priority="-1"/>
+		<!-- If should decay, add PriceDecayValue -->
+		<Modifier		TargetProperty="PriceDecay"				Operation="Addition"		Value="0"			Priority="-1"/>
+		<BinaryModifier TargetProperty="PriceDecay"				Operation="Addition"		Left="$(PriceShouldDecay)"			BinaryOperation="Multiplication"	Right="$(PriceDecayValue)"		Priority="-1"/>
+
+		<!--PRICE INCREASE COMPUTATIONS-->
+		<BinaryModifier TargetProperty="PriceIncreaseValue"		Operation="Addition"		Left="$(BaseValue)"					BinaryOperation="Multiplication"	Right="$(PriceIncreaseFactor)"	Priority="-1"/>
+		<!-- If no stock, PriceShouldIncrease will be at 1-->
+		<BinaryModifier TargetProperty="PriceShouldIncrease"	Operation="Addition"		Left="$(StockThresholdForDecay)"	BinaryOperation="Subtraction"		Right="$(StockLastTurn)"		Priority="-1"/>
+		<!-- As PriceIncreaseValue is negative, add it to price Increase-->
+		<BinaryModifier	TargetProperty="PriceIncrease"			Operation="Addition"		Left="$(PriceIncreaseValue)"		BinaryOperation="Multiplication"	Right="$(PriceShouldIncrease)"	Priority="-1"/>
+		<!-- If PriceIncrease should not Increase, we substract the negative PriceIncreaseValue to PriceIncreaseValue, which makes PriceIncrease a null value and will thus not impact price -->
+
+		<!-- MinValue -->
+		<!--<BinaryModifier TargetProperty="MinValue"		Operation="Addition" Left="0.4" BinaryOperation="Multiplication" Right="$(BaseValue)"/>-->
+		<BinaryModifier TargetProperty="MinValue"		Operation="Addition" Left="$(DemandPriceChange)" BinaryOperation="Multiplication" Right="$(Demand)"/>
+		
+		<!--<BinaryModifier TargetProperty="FakeMinValue"	Operation="Addition" Left="0.4" BinaryOperation="Multiplication" Right="$(BaseValue)"/>-->
+		<BinaryModifier TargetProperty="FakeMinValue"	Operation="Addition" Left="$(DemandPriceChange)" BinaryOperation="Multiplication" Right="$(Demand)"/>
+
+		<!-- Value -->
+		<!-- Just standard price variations for buy / sell transactions -->
+		<Modifier			TargetProperty="Value"					Operation="Addition"        Value="$(ValueLastTurn)"/>
+		<BinaryModifier		TargetProperty="Value"					Operation="Division"		Left="$(InflationLastTurn)" BinaryOperation="Power" Right="0.33"/>
+		<Modifier			TargetProperty="Value"					Operation="Addition"        Value="$(PriceChange)"/>
+		<BinaryModifier		TargetProperty="Value"					Operation="Addition"		Left="$(Demand)" BinaryOperation="Multiplication" Right="$(MinDemandPriceChange)"/>
+
+		<Modifier			TargetProperty="FakeValue"				Operation="Addition"        Value="$(ValueLastTurn)"/>
+		<BinaryModifier		TargetProperty="FakeValue"				Operation="Division"		Left="$(InflationLastTurn)" BinaryOperation="Power" Right="0.33"/>
+		<Modifier			TargetProperty="FakeValue"				Operation="Addition"        Value="$(PriceChange)"/>
+		<BinaryModifier		TargetProperty="FakeValue"				Operation="Addition"		Left="$(Demand)" BinaryOperation="Multiplication" Right="$(MinDemandPriceChange)"/>
+
+		<Modifier			TargetProperty="FakeValueForCorrect"	Operation="Addition"        Value="$(ValueLastTurn)"/>
+		<BinaryModifier		TargetProperty="FakeValueForCorrect"	Operation="Division"		Left="$(InflationLastTurn)" BinaryOperation="Power" Right="0.33"/>
+		<Modifier			TargetProperty="FakeValueForCorrect"	Operation="Addition"        Value="$(PriceChange)"/>
+		<BinaryModifier		TargetProperty="FakeValueForCorrect"	Operation="Addition"		Left="$(Demand)" BinaryOperation="Multiplication" Right="$(MinDemandPriceChange)"/>
+		
+		<Modifier			TargetProperty="FakeValue"				Operation="Addition"		Value="0.001"/>
+
+		<!-- Add price decay - will be null if not correct -->
+		<Modifier			TargetProperty="Value"					Operation="Addition"		Value="$(PriceDecay)"/>
+		<Modifier			TargetProperty="FakeValue"				Operation="Addition"		Value="$(PriceDecay)"/>
+		<Modifier			TargetProperty="FakeValueForCorrect"	Operation="Addition"		Value="$(PriceDecay)"/>
+
+		<!-- Add price increase - will be null if not correct -->
+		<Modifier			TargetProperty="Value"					Operation="Addition"		Value="$(PriceIncrease)"/>
+		<Modifier			TargetProperty="FakeValue"				Operation="Addition"		Value="$(PriceIncrease)"/>
+		<Modifier			TargetProperty="FakeValueForCorrect"	Operation="Addition"		Value="$(PriceIncrease)"/>
+
+		<!-- Check the booleans for comparison -->
+		<BinaryModifier TargetProperty="ValueLowerThanMinValue"	Operation="Addition" Left="$(FakeMinValue)" BinaryOperation="Subtraction"		Right="$(FakeValue)"/>
+		<BinaryModifier TargetProperty="MinValueLowerThanValue"	Operation="Addition" Left="$(FakeValue)" BinaryOperation="Subtraction"		Right="$(FakeMinValue)"/>
+
+		<!-- Add either real value or min value : 	Add real value IF min value < real value  OR	Add min value IF real value < min value -->
+		<Modifier	TargetProperty="Value"	Operation="Force" Value="0" Priority="2"/>
+		<!-- Force 0 then add correct value -->
+		<BinaryModifier TargetProperty="Value" Operation="Addition" Left="$(MinValue)" BinaryOperation="Multiplication" Right="$(ValueLowerThanMinValue)" Priority="3"/>
+		<BinaryModifier TargetProperty="Value" Operation="Addition" Left="$(FakeValueForCorrect)" BinaryOperation="Multiplication" Right="$(MinValueLowerThanValue)" Priority="3"/>
+
+		<!-- Add Inflation -->
+		<BinaryModifier TargetProperty="Value"	Operation="Multiplication" Left="$(Inflation)" BinaryOperation="Power" Right="0.33" Priority="4"/>
+	</SimulationDescriptor>
+	
+    <SimulationDescriptor Name="TradableResourceLuxuryCommon"		Type="TradableResourceLuxuryCommon"/>
+    <SimulationDescriptor Name="TradableResourceLuxuryUncommon"		Type="TradableResourceLuxuryUncommon"/>
+    <SimulationDescriptor Name="TradableResourceLuxuryRare"			Type="TradableResourceLuxuryRare"/>
+
+    <SimulationDescriptor Name="TradableResourceLuxuryFood"			Type="TradableResourceLuxuryFood"/>
+    <SimulationDescriptor Name="TradableResourceLuxuryIndustry"		Type="TradableResourceLuxuryIndustry"/>
+    <SimulationDescriptor Name="TradableResourceLuxuryMoney"		Type="TradableResourceLuxuryMoney"/>
+    <SimulationDescriptor Name="TradableResourceLuxuryResearch"		Type="TradableResourceLuxuryResearch"/>
+    <SimulationDescriptor Name="TradableResourceLuxuryInfluence"	Type="TradableResourceLuxuryInfluence"/>
+    <SimulationDescriptor Name="TradableResourceLuxuryHappiness"	Type="TradableResourceLuxuryHappiness"/>
+    <SimulationDescriptor Name="TradableResourceLuxuryDefense"		Type="TradableResourceLuxuryDefense"/>
+    <SimulationDescriptor Name="TradableResourceLuxuryTrading"		Type="TradableResourceLuxuryTrading"/>
+
+    <SimulationDescriptor Name="TradableResourceStrategicCommon"	Type="TradableResourceStrategicCommon"/>
+    <SimulationDescriptor Name="TradableResourceStrategicUncommon"	Type="TradableResourceStrategicUncommon"/>
+    <SimulationDescriptor Name="TradableResourceStrategicRare"		Type="TradableResourceStrategicRare"/>
+	
+	<SimulationDescriptor Name="TradableResourceStrategic1"		Type="TradableResourceStrategic1"/>
+	<SimulationDescriptor Name="TradableResourceStrategic2"		Type="TradableResourceStrategic2"/>
+	<SimulationDescriptor Name="TradableResourceStrategic3"		Type="TradableResourceStrategic3"/>
+	<SimulationDescriptor Name="TradableResourceStrategic4"		Type="TradableResourceStrategic4"/>
+	<SimulationDescriptor Name="TradableResourceStrategic5"		Type="TradableResourceStrategic5"/>
+	<SimulationDescriptor Name="TradableResourceStrategic6"		Type="TradableResourceStrategic6"/>
+	
+	<SimulationDescriptor Name="TradableResourceLuxury1"		Type="TradableResourceLuxury1"/>
+	<SimulationDescriptor Name="TradableResourceLuxury2"		Type="TradableResourceLuxury2"/>
+	<SimulationDescriptor Name="TradableResourceLuxury3"		Type="TradableResourceLuxury3"/>
+	<SimulationDescriptor Name="TradableResourceLuxury4"		Type="TradableResourceLuxury4"/>
+	<SimulationDescriptor Name="TradableResourceLuxury5"		Type="TradableResourceLuxury5"/>
+	<SimulationDescriptor Name="TradableResourceLuxury6"		Type="TradableResourceLuxury6"/>
+	<SimulationDescriptor Name="TradableResourceLuxury7"		Type="TradableResourceLuxury7"/>
+	<SimulationDescriptor Name="TradableResourceLuxury8"		Type="TradableResourceLuxury8"/>
+	<SimulationDescriptor Name="TradableResourceLuxury9"		Type="TradableResourceLuxury9"/>
+	<SimulationDescriptor Name="TradableResourceLuxury10"		Type="TradableResourceLuxury10"/>
+	<SimulationDescriptor Name="TradableResourceLuxury11"		Type="TradableResourceLuxury11"/>
+	<SimulationDescriptor Name="TradableResourceLuxury12"		Type="TradableResourceLuxury12"/>
+	<SimulationDescriptor Name="TradableResourceLuxury13"		Type="TradableResourceLuxury13"/>
+	<SimulationDescriptor Name="TradableResourceLuxury14"		Type="TradableResourceLuxury14"/>
+	<SimulationDescriptor Name="TradableResourceLuxury15"		Type="TradableResourceLuxury15"/>
+	<SimulationDescriptor Name="TradableResourceLuxury16"		Type="TradableResourceLuxury16"/>
+	<SimulationDescriptor Name="TradableResourceLuxury17"		Type="TradableResourceLuxury17"/>
+	<SimulationDescriptor Name="TradableResourceLuxury18"		Type="TradableResourceLuxury18"/>
+	<SimulationDescriptor Name="TradableResourceLuxury19"		Type="TradableResourceLuxury19"/>
+	<SimulationDescriptor Name="TradableResourceLuxury20"		Type="TradableResourceLuxury20"/>
+	<SimulationDescriptor Name="TradableResourceLuxury21"		Type="TradableResourceLuxury21"/>
+	<SimulationDescriptor Name="TradableResourceLuxury22"		Type="TradableResourceLuxury22"/>
+	<SimulationDescriptor Name="TradableResourceLuxury23"		Type="TradableResourceLuxury23"/>
+	<SimulationDescriptor Name="TradableResourceLuxury24"		Type="TradableResourceLuxury24"/>
+
+	<!--SHIPS-->
+	<SimulationDescriptor Name="TradableShipColonizer"				Type="TradableShipColonizer">
+		<!-- Price variations according to market state -->
+		<Property Name="PriceChange"				BaseValue="0"			MinValue="Negative"/>
+		<Property Name="MinPriceChange"				BaseValue="0"			MinValue="Negative"/>
+		<Property Name="MinDemandPriceChange"		BaseValue="0"			MinValue="Negative"/>
+		<Property Name="PriceChangeFactor"			BaseValue="0"/>
+		<Property Name="DemandMinPriceChangeFactor"	BaseValue="0"/>
+		<Property Name="DemandPriceChange"			BaseValue="0"			MinValue="Negative"/>
+		<Property Name="DemandPriceChangeFactor"    BaseValue="0"/>
+		<Property Name="PassedDemand"				BaseValue="0"			MinValue="Negative"/>
+		<Property Name="PassedDemandLastTurn"		BaseValue="0"			MinValue="Negative"/>
+		<!--1 Price increment-->
+		<Property Name="StockDifference"			BaseValue="0"			MinValue="Negative"/>
+	</SimulationDescriptor>
+    <SimulationDescriptor Name="TradableShipRootCreator"				Type="TradableShipRootCreator">
+        <!-- Price variations according to market state -->
+        <Property Name="PriceChange"				BaseValue="0"			MinValue="Negative"/>
+        <Property Name="MinPriceChange"				BaseValue="0"			MinValue="Negative"/>
+        <Property Name="MinDemandPriceChange"		BaseValue="0"			MinValue="Negative"/>
+        <Property Name="PriceChangeFactor"			BaseValue="0"/>
+        <Property Name="DemandMinPriceChangeFactor"	BaseValue="0"/>
+        <Property Name="DemandPriceChange"			BaseValue="0"			MinValue="Negative"/>
+        <Property Name="DemandPriceChangeFactor"    BaseValue="0"/>
+        <Property Name="PassedDemand"				BaseValue="0"			MinValue="Negative"/>
+        <Property Name="PassedDemandLastTurn"		BaseValue="0"			MinValue="Negative"/>
+        <!--1 Price increment-->
+        <Property Name="StockDifference"			BaseValue="0"			MinValue="Negative"/>
+    </SimulationDescriptor>
+	<SimulationDescriptor Name="TradableShipExplorer"				Type="TradableShipExplorer">
+		<!-- Price variations according to market state -->
+		<Property Name="PriceChange"				BaseValue="0"			MinValue="Negative"/>
+		<Property Name="MinPriceChange"				BaseValue="0"			MinValue="Negative"/>
+		<Property Name="MinDemandPriceChange"		BaseValue="0"			MinValue="Negative"/>
+		<Property Name="PriceChangeFactor"			BaseValue="0"/>
+		<Property Name="DemandMinPriceChangeFactor"	BaseValue="0"/>
+		<Property Name="DemandPriceChange"			BaseValue="0"			MinValue="Negative"/>
+		<Property Name="DemandPriceChangeFactor"    BaseValue="0"/>
+		<Property Name="PassedDemand"				BaseValue="0"			MinValue="Negative"/>
+		<Property Name="PassedDemandLastTurn"		BaseValue="0"			MinValue="Negative"/>
+		<!--1 Price increment-->
+		<Property Name="StockDifference"			BaseValue="0"			MinValue="Negative"/>
+	</SimulationDescriptor>
+	<SimulationDescriptor Name="TradableShipOffense"				Type="TradableShipOffense">
+		<!-- Price variations according to market state -->
+		<Property Name="PriceChange"				BaseValue="0"			MinValue="Negative"/>
+		<Property Name="MinPriceChange"				BaseValue="0"			MinValue="Negative"/>
+		<Property Name="MinDemandPriceChange"		BaseValue="0"			MinValue="Negative"/>
+		<Property Name="PriceChangeFactor"			BaseValue="0"/>
+		<Property Name="DemandMinPriceChangeFactor"	BaseValue="0"/>
+		<Property Name="DemandPriceChange"			BaseValue="0"			MinValue="Negative"/>
+		<Property Name="DemandPriceChangeFactor"    BaseValue="0"/>
+		<Property Name="PassedDemand"				BaseValue="0"			MinValue="Negative"/>
+		<Property Name="PassedDemandLastTurn"		BaseValue="0"			MinValue="Negative"/>
+		<!--1 Price increment-->
+		<Property Name="StockDifference"			BaseValue="0"			MinValue="Negative"/>
+	</SimulationDescriptor>
+	<SimulationDescriptor Name="TradableShipSupport"				Type="TradableShipSupport">
+		<!-- Price variations according to market state -->
+		<Property Name="PriceChange"				BaseValue="0"			MinValue="Negative"/>
+		<Property Name="MinPriceChange"				BaseValue="0"			MinValue="Negative"/>
+		<Property Name="MinDemandPriceChange"		BaseValue="0"			MinValue="Negative"/>
+		<Property Name="PriceChangeFactor"			BaseValue="0"/>
+		<Property Name="DemandMinPriceChangeFactor"	BaseValue="0"/>
+		<Property Name="DemandPriceChange"			BaseValue="0"			MinValue="Negative"/>
+		<Property Name="DemandPriceChangeFactor"    BaseValue="0"/>
+		<Property Name="PassedDemand"				BaseValue="0"			MinValue="Negative"/>
+		<Property Name="PassedDemandLastTurn"		BaseValue="0"			MinValue="Negative"/>
+		<!--1 Price increment-->
+		<Property Name="StockDifference"			BaseValue="0"			MinValue="Negative"/>
+	</SimulationDescriptor>
+	<SimulationDescriptor Name="TradableShipCarrier"				Type="TradableShipCarrier">
+		<!-- Price variations according to market state -->
+		<Property Name="PriceChange"				BaseValue="0"			MinValue="Negative"/>
+		<Property Name="MinPriceChange"				BaseValue="0"			MinValue="Negative"/>
+		<Property Name="MinDemandPriceChange"		BaseValue="0"			MinValue="Negative"/>
+		<Property Name="PriceChangeFactor"			BaseValue="0"/>
+		<Property Name="DemandMinPriceChangeFactor"	BaseValue="0"/>
+		<Property Name="DemandPriceChange"			BaseValue="0"			MinValue="Negative"/>
+		<Property Name="DemandPriceChangeFactor"    BaseValue="0"/>
+		<Property Name="PassedDemand"				BaseValue="0"			MinValue="Negative"/>
+		<Property Name="PassedDemandLastTurn"		BaseValue="0"			MinValue="Negative"/>
+		<!--1 Price increment-->
+		<Property Name="StockDifference"			BaseValue="0"			MinValue="Negative"/>
+	</SimulationDescriptor>
+	<SimulationDescriptor Name="TradableShipLeecher"				Type="TradableShipLeecher">
+		<!-- Price variations according to market state -->
+		<Property Name="PriceChange"				BaseValue="0"			MinValue="Negative"/>
+		<Property Name="MinPriceChange"				BaseValue="0"			MinValue="Negative"/>
+		<Property Name="MinDemandPriceChange"		BaseValue="0"			MinValue="Negative"/>
+		<Property Name="PriceChangeFactor"			BaseValue="0"/>
+		<Property Name="DemandMinPriceChangeFactor"	BaseValue="0"/>
+		<Property Name="DemandPriceChange"			BaseValue="0"			MinValue="Negative"/>
+		<Property Name="DemandPriceChangeFactor"    BaseValue="0"/>
+		<Property Name="PassedDemand"				BaseValue="0"			MinValue="Negative"/>
+		<Property Name="PassedDemandLastTurn"		BaseValue="0"			MinValue="Negative"/>
+		<!--1 Price increment-->
+		<Property Name="StockDifference"			BaseValue="0"			MinValue="Negative"/>
+	</SimulationDescriptor>
+	
+	<!--HEROES-->
+	<SimulationDescriptor Name="TradableHeroAdventurer"				Type="TradableHeroAdventurer">
+		<!-- Price variations according to market state -->
+		<Property Name="PriceChange"				BaseValue="0"			MinValue="Negative"/>
+		<Property Name="MinPriceChange"				BaseValue="0"			MinValue="Negative"/>
+		<Property Name="MinDemandPriceChange"		BaseValue="0"			MinValue="Negative"/>
+		<Property Name="PriceChangeFactor"			BaseValue="0"/>
+		<Property Name="DemandMinPriceChangeFactor"	BaseValue="0"/>
+		<Property Name="DemandPriceChange"			BaseValue="0"			MinValue="Negative"/>
+		<Property Name="DemandPriceChangeFactor"    BaseValue="0"/>
+		<Property Name="PassedDemand"				BaseValue="0"			MinValue="Negative"/>
+		<Property Name="PassedDemandLastTurn"		BaseValue="0"			MinValue="Negative"/>
+		<!--1 Price increment-->
+		<Property Name="StockDifference"			BaseValue="0"			MinValue="Negative"/>
+	</SimulationDescriptor>
+	<SimulationDescriptor Name="TradableHeroAdmiral"				Type="TradableHeroAdmiral">
+		<!-- Price variations according to market state -->
+		<Property Name="PriceChange"				BaseValue="0"			MinValue="Negative"/>
+		<Property Name="MinPriceChange"				BaseValue="0"			MinValue="Negative"/>
+		<Property Name="MinDemandPriceChange"		BaseValue="0"			MinValue="Negative"/>
+		<Property Name="PriceChangeFactor"			BaseValue="0"/>
+		<Property Name="DemandMinPriceChangeFactor"	BaseValue="0"/>
+		<Property Name="DemandPriceChange"			BaseValue="0"			MinValue="Negative"/>
+		<Property Name="DemandPriceChangeFactor"    BaseValue="0"/>
+		<Property Name="PassedDemand"				BaseValue="0"			MinValue="Negative"/>
+		<Property Name="PassedDemandLastTurn"		BaseValue="0"			MinValue="Negative"/>
+		<!--1 Price increment-->
+		<Property Name="StockDifference"			BaseValue="0"			MinValue="Negative"/>
+	</SimulationDescriptor>
+	<SimulationDescriptor Name="TradableHeroCorporate"				Type="TradableHeroCorporate">
+		<!-- Price variations according to market state -->
+		<Property Name="PriceChange"				BaseValue="0"			MinValue="Negative"/>
+		<Property Name="MinPriceChange"				BaseValue="0"			MinValue="Negative"/>
+		<Property Name="MinDemandPriceChange"		BaseValue="0"			MinValue="Negative"/>
+		<Property Name="PriceChangeFactor"			BaseValue="0"/>
+		<Property Name="DemandMinPriceChangeFactor"	BaseValue="0"/>
+		<Property Name="DemandPriceChange"			BaseValue="0"			MinValue="Negative"/>
+		<Property Name="DemandPriceChangeFactor"    BaseValue="0"/>
+		<Property Name="PassedDemand"				BaseValue="0"			MinValue="Negative"/>
+		<Property Name="PassedDemandLastTurn"		BaseValue="0"			MinValue="Negative"/>
+		<!--1 Price increment-->
+		<Property Name="StockDifference"			BaseValue="0"			MinValue="Negative"/>
+	</SimulationDescriptor>
+	<SimulationDescriptor Name="TradableHeroAdministrator"			Type="TradableHeroAdministrator">
+		<!-- Price variations according to market state -->
+		<Property Name="PriceChange"				BaseValue="0"			MinValue="Negative"/>
+		<Property Name="MinPriceChange"				BaseValue="0"			MinValue="Negative"/>
+		<Property Name="MinDemandPriceChange"		BaseValue="0"			MinValue="Negative"/>
+		<Property Name="PriceChangeFactor"			BaseValue="0"/>
+		<Property Name="DemandMinPriceChangeFactor"	BaseValue="0"/>
+		<Property Name="DemandPriceChange"			BaseValue="0"			MinValue="Negative"/>
+		<Property Name="DemandPriceChangeFactor"    BaseValue="0"/>
+		<Property Name="PassedDemand"				BaseValue="0"			MinValue="Negative"/>
+		<Property Name="PassedDemandLastTurn"		BaseValue="0"			MinValue="Negative"/>
+		<!--1 Price increment-->
+		<Property Name="StockDifference"			BaseValue="0"			MinValue="Negative"/>
+	</SimulationDescriptor>
+
+</Datatable>


### PR DESCRIPTION
Reduced inflation scaling (similar to Cobbs' prior version, but this seemed not to cause the "pending" bug when implemented this way instead) and very slightly reduced buyout scaling
Capped buyout reduction at 75%
Increased hero market prices and spawn rate
Applied reduced inflation scaling to market prices