### PR TITLE
Fixed pug class tree

### DIFF
--- a/Endless Space Competitive Mod/Simulation/HeroDefinitions.xml
+++ b/Endless Space Competitive Mod/Simulation/HeroDefinitions.xml
@@ -717,4 +717,22 @@
     <SkillTree Name="HeroSkillTreeCorporate"/>
     <LevelUpRuleReference Name="HeroLevelUpRule"/>
   </HeroDefinition>
+	
+	<!-- Pug Hero -->
+	<HeroDefinition Name="HeroPug01">
+		<Skill Name="HeroSkill01Illo01"/>
+		<Skill Name="HeroSkill03BranchMajorHisshos"/>
+
+		<Affinity Name="HeroAffinityPug"/>
+		<Class Name="HeroClassAdmiral"/>
+		<!--Ecologist-->
+		<Politics Name="HeroPolitics04"/>
+
+		<ShipDesign Name="ShipDesignHeroSmall04Defender"/>
+
+		<SkillTree Name="HeroSkillTreeGeneric"/>
+		<SkillTree Name="HeroSkillTreeVenetians"/>
+		<SkillTree Name="HeroSkillTreeAdmiral"/>
+		<LevelUpRuleReference Name="HeroLevelUpRule"/>
+	</HeroDefinition>
 </Datatable>


### PR DESCRIPTION
Had the overseer skill tree, but was labeled as a guardian. Replaced overseer tree with guardian tree.