### PR TITLE
Replaced Collateral Damage with Team Spirit

### DIFF
--- a/Endless Space Competitive Mod/GUI/GUIElements[PlayDeck].xml
+++ b/Endless Space Competitive Mod/GUI/GUIElements[PlayDeck].xml
@@ -44,7 +44,7 @@
       <Icon Size="Large" Path="Textures\EmpireImprovements\EmpireImprovementPlayDeckLarge.png" />
     </Icons>
     <UnlockedPlay Name ="PlayDefensiveShortAccuracyReduction"/>
-    <UnlockedPlay Name ="PlayOffensiveLongSplashDamage"/>
+    <UnlockedPlay Name ="PlayOffensiveShortMoraleBonusIncrease"/>
     <UnlockedPlay Name ="PlayPostShortMovementGain"/>
   </PlayDeckGuiElement>
 

--- a/Endless Space Competitive Mod/Simulation/Battles/EncounterPlayDefinitions.xml
+++ b/Endless Space Competitive Mod/Simulation/Battles/EncounterPlayDefinitions.xml
@@ -194,46 +194,6 @@
     </ReinforcementSpawnParameters>
   </EncounterPlayDefinition>
 
-  <EncounterPlayDefinition Name="PlayOffensiveLongSplashDamage" FamilyName="FamilyOffensiveLong">
-    <AIBattleSituations Situation="LargeShip" Mode="Use" Value="1"/>
-    <AIBattleSituations Situation="SmallShip" Mode="Against" Value="1"/>
-    <AIBattleSituations Situation="LargeShip" Mode="Against" Value="-1"/>
-    <AIBattleSituations Situation="ShipToProtect" Mode="Against" Value="0.5"/>
-    <TechnologyPrerequisite Flags="Prerequisite,Discard,Technology" UnlockHidden="true">TechnologyPlayDeck4</TechnologyPrerequisite>
-    <CounterRule FamilyName="FamilyShort"/>
-    <StatusModifier StatusTags="Regular Counter Countered">
-      <SimulationDescriptorReference Name="PlayEffectSplashDamage"/>
-    </StatusModifier>
-    <Flotilla Name="Flotilla01" OptimalRangeName="Long" UICommandPointsMinForUnlock="5" UIShipsMinForUnlock="2">
-      <InterpreterPrerequisite Flags="Prerequisite,Discard">$(CommandPoints) ge 5 and $(ShipsCount) ge 2</InterpreterPrerequisite>
-      <ShipSizeQuota ShipSize="ShipSizeJuggernaut" Quota="1"/>
-      <FormationReference Name="Formation03"/>
-    </Flotilla>
-    <Flotilla Name="Flotilla02" OptimalRangeName="Medium" CommandPointMin="1">
-      <ShipSizeQuota ShipSize="ShipSizeJuggernaut" Quota="1"/>
-      <FormationReference Name="Formation03"/>
-    </Flotilla>
-    <Flotilla Name="Flotilla03" OptimalRangeName="Long" UICommandPointsMinForUnlock="10" UIShipsMinForUnlock="3">
-      <InterpreterPrerequisite Flags="Prerequisite,Discard">$(CommandPoints) ge 10 and $(ShipsCount) ge 3</InterpreterPrerequisite>
-      <ShipSizeQuota ShipSize="ShipSizeJuggernaut" Quota="1"/>
-      <FormationReference Name="Formation03"/>
-    </Flotilla>
-    <ReinforcementFlotilla Name="ReinforcementFlotilla01" CommandPointMax="10">
-      <TechnologyPrerequisite Flags="Technology,Discard">TechnologyUnknown</TechnologyPrerequisite>
-      <ShipSizeQuota ShipSize="ShipSizeJuggernaut" Quota="1"/>
-      <FormationReference Name="Formation03"/>
-    </ReinforcementFlotilla>
-    <ReinforcementSpawnParameters PhaseIndex="1">
-      <SimulationDescriptorReference Name="FlotillaReinforcementPhase1"/>
-    </ReinforcementSpawnParameters>
-    <ReinforcementSpawnParameters PhaseIndex="2">
-      <SimulationDescriptorReference Name="FlotillaReinforcementPhase2"/>
-    </ReinforcementSpawnParameters>
-    <ReinforcementSpawnParameters PhaseIndex="3">
-      <SimulationDescriptorReference Name="FlotillaReinforcementPhase3"/>
-    </ReinforcementSpawnParameters>
-  </EncounterPlayDefinition>
-
   <EncounterPlayDefinition Name="PlayDefensiveLongCooldownIncrease" FamilyName="FamilyDefensiveLong">
     <AIBattleSituations Situation="MorePowerful" Mode="Against" Value="1"/>
     <AIBattleSituations Situation="ShipToProtect" Mode="Use" Value="1"/>
@@ -309,4 +269,45 @@
     </ReinforcementSpawnParameters>
 
   </EncounterPlayDefinition>
+  
+    <EncounterPlayDefinition Name="PlayOffensiveShortMoraleBonusIncrease" FamilyName="FamilyOffensiveShort">
+        <AIBattleSituations Situation="HigherShipsNumber" Mode="Use" Value="0"/>
+        <AIBattleSituations Situation="HigherShipsNumber" Mode="Against" Value="1"/>
+		<TechnologyPrerequisite Flags="Prerequisite,Discard,Technology" UnlockHidden="true">TechnologyPlayDeck4</TechnologyPrerequisite>
+        <CounterRule FamilyName="FamilyShort"/>
+        <StatusModifier  StatusTags="Regular Counter Countered">
+            <SimulationDescriptorReference Name="PlayEffectMoraleBonusIncrease"/>
+        </StatusModifier>
+        <Flotilla Name="Flotilla01" OptimalRangeName="Short" UICommandPointsMinForUnlock="5" UIShipsMinForUnlock="2">
+            <InterpreterPrerequisite Flags="Prerequisite,Discard">$(CommandPoints) ge 5 and $(ShipsCount) ge 2</InterpreterPrerequisite>
+            <ShipSizeQuota ShipSize="ShipSizeJuggernaut" Quota="1"/>
+            <FormationReference Name="Formation03"/>
+        </Flotilla>
+        <Flotilla Name="Flotilla02" OptimalRangeName="Medium" CommandPointMin="1">
+            <ShipSizeQuota ShipSize="ShipSizeJuggernaut" Quota="1"/>
+            <FormationReference Name="Formation03"/>
+        </Flotilla>
+        <Flotilla Name="Flotilla03" OptimalRangeName="Short" UICommandPointsMinForUnlock="10" UIShipsMinForUnlock="3">
+            <InterpreterPrerequisite Flags="Prerequisite,Discard">$(CommandPoints) ge 10 and $(ShipsCount) ge 3</InterpreterPrerequisite>
+            <ShipSizeQuota ShipSize="ShipSizeJuggernaut" Quota="1"/>
+            <FormationReference Name="Formation03"/>
+        </Flotilla>
+        <ReinforcementFlotilla Name="ReinforcementFlotilla01" CommandPointMax="10">
+            <TechnologyPrerequisite Flags="Technology,Discard">TechnologyUnknown</TechnologyPrerequisite>
+            <ShipSizeQuota ShipSize="ShipSizeJuggernaut" Quota="1"/>
+            <FormationReference Name="Formation03"/>
+        </ReinforcementFlotilla>
+        <ReinforcementSpawnParameters PhaseIndex="1">
+            <SimulationDescriptorReference Name="FlotillaReinforcementPhase1"/>
+        </ReinforcementSpawnParameters>
+        <ReinforcementSpawnParameters PhaseIndex="2">
+            <SimulationDescriptorReference Name="FlotillaReinforcementPhase2"/>
+        </ReinforcementSpawnParameters>
+        <ReinforcementSpawnParameters PhaseIndex="3">
+            <SimulationDescriptorReference Name="FlotillaReinforcementPhase3"/>
+        </ReinforcementSpawnParameters>
+
+    </EncounterPlayDefinition>
+
+
 </Datatable>

--- a/Endless Space Competitive Mod/Simulation/CuriosityDroplists.xml
+++ b/Endless Space Competitive Mod/Simulation/CuriosityDroplists.xml
@@ -82,8 +82,8 @@
 		<Unlock Name="EmpireImprovementStarSystemImprovementCuriosity5" SimulationDescriptorReference="EmpireImprovementStarSystemImprovementCuriosity5"
 				Weight="3" Constrained="true" ApplyOnEmpire="true"/>
 
-		<!-- BATTLE TACTICS : 30 -->
-		<Play Name="PlayOffensiveShortMoraleBonusIncrease"			 Weight="5"/>
+		<!-- BATTLE TACTICS : 25 -->
+		<!-- <Play Name="PlayOffensiveShortMoraleBonusIncrease"			 Weight="5"/> -->
 		<Play Name="PlayDefensiveMediumMoralePenalty"				 Weight="5"/>
 		<Play Name="PlayPostLongEmpireManpowerSaving"				 Weight="5"/>
 		<Play Name="PlayDefensiveBalancedManpowerAbsorptionIncrease" Weight="5"/>
@@ -112,8 +112,8 @@
 		<Population Affinity="AffinityMavros"			Amount="1" Weight="4"/>
 		<Population Affinity="AffinityGalvrans"			Amount="1" Weight="4"/>
 
-		<!-- BATTLE TACTICS : 10 -->
-		<Play Name="PlayOffensiveShortMoraleBonusIncrease"		Weight="5"/>
+		<!-- BATTLE TACTICS : 5 -->
+		<!-- <Play Name="PlayOffensiveShortMoraleBonusIncrease"		Weight="5"/> -->
 		<Play Name="PlayDefensiveMediumMoralePenalty"			Weight="5"/>
 	</CuriosityDroplist>
 
@@ -375,8 +375,8 @@
 			<ShipDesign>MFInsectoidSmallAttackStrong</ShipDesign>
 		</Fleet>
 
-		<!-- BATTLE TACTICS : 30 -->
-		<Play Name="PlayOffensiveShortMoraleBonusIncrease"			 Weight="5"/>
+		<!-- BATTLE TACTICS : 25 -->
+		<!-- <Play Name="PlayOffensiveShortMoraleBonusIncrease"			 Weight="5"/> -->
 		<Play Name="PlayDefensiveMediumMoralePenalty"				 Weight="5"/>
 		<Play Name="PlayPostLongEmpireManpowerSaving"				 Weight="5"/>
 		<Play Name="PlayDefensiveBalancedManpowerAbsorptionIncrease" Weight="5"/>
@@ -399,8 +399,8 @@
 			<ShipDesign>MFInsectoidMediumAttackAvg</ShipDesign>
 		</Fleet>
 
-		<!-- BATTLE TACTICS : 10 -->
-		<Play Name="PlayOffensiveShortMoraleBonusIncrease"		Weight="5"/>
+		<!-- BATTLE TACTICS : 5 -->
+		<!-- <Play Name="PlayOffensiveShortMoraleBonusIncrease"		Weight="5"/> -->
 		<Play Name="PlayDefensiveMediumMoralePenalty"			Weight="5"/>
 	</CuriosityDroplist>
 
@@ -489,8 +489,8 @@
 		<Unlock Name="EmpireImprovementStarSystemImprovementCuriosity5" SimulationDescriptorReference="EmpireImprovementStarSystemImprovementCuriosity5"
 				Weight="2" Constrained="true" ApplyOnEmpire="true"/>
 
-		<!-- BATTLE TACTICS : 30 -->
-		<Play Name="PlayOffensiveShortMoraleBonusIncrease"			 Weight="5"/>
+		<!-- BATTLE TACTICS : 25 -->
+		<!-- <Play Name="PlayOffensiveShortMoraleBonusIncrease"			 Weight="5"/> -->
 		<Play Name="PlayDefensiveMediumMoralePenalty"				 Weight="5"/>
 		<Play Name="PlayPostLongEmpireManpowerSaving"				 Weight="5"/>
 		<Play Name="PlayDefensiveBalancedManpowerAbsorptionIncrease" Weight="5"/>
@@ -522,8 +522,8 @@
 		<Module Name="TechnologyDefinitionCuriosityModuleDefenseShield4Strategic6"				ModuleName="ModuleDefenseShield4Strategic6"					Weight="4" Constrained="true"/>
 		<Module Name="TechnologyDefinitionCuriosityModuleSupportCrew4Strategic6"				ModuleName="ModuleSupportCrew4Strategic6"					Weight="4" Constrained="true"/>
 
-		<!-- BATTLE TACTICS : 10 -->
-		<Play Name="PlayOffensiveShortMoraleBonusIncrease"		Weight="5"/>
+		<!-- BATTLE TACTICS : 5 -->
+		<!-- <Play Name="PlayOffensiveShortMoraleBonusIncrease"		Weight="5"/> -->
 		<Play Name="PlayDefensiveMediumMoralePenalty"			Weight="5"/>
 	</CuriosityDroplist>
 


### PR DESCRIPTION
Team Spirit is no longer available from curiosities, and Collateral Damage isn't available at all.