### PR TITLE
1090 shield regen module changes

### DIFF
--- a/Endless Space Competitive Mod/GUI/GuiElements[GameVariables].xml
+++ b/Endless Space Competitive Mod/GUI/GuiElements[GameVariables].xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Datatable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xsi:noNamespaceSchemaLocation="../Schemas/Amplitude.Unity.Gui.GuiElement.xsd">
+
+<!-- Shield regeneration per second - Flat rate, on flotilla -->
   <ExtendedGuiElement Name="ShieldRegeneratePerSecond">
     <Title>%ShieldRegeneratePerSecondTitle</Title>
     <Description>%ShieldRegeneratePerSecondDescription</Description>
@@ -192,6 +194,7 @@
     <Title>%TradingRouteSystemBaseIncome_EmpireMoneyTitle</Title>
   </GuiElement>
 
+<!-- Shield regeneration per second - percentage based, self-only -->
   <ExtendedGuiElement Name="ShieldRegeneratePerSecondDynamic">
     <Title>%ShieldRegeneratePerSecondDynamicTitle</Title>
     <TooltipElement Percent="true"/>

--- a/Endless Space Competitive Mod/Localization/english/ES2_Localization_1-3-1.xml
+++ b/Endless Space Competitive Mod/Localization/english/ES2_Localization_1-3-1.xml
@@ -96,7 +96,7 @@ Behemoth roles vary depending on the Modules you equip them with. They can focus
   <LocalizationPair Name="%ShipSizeLargeDescription">Large-sized ships require #E3BDAC#6#REVERT# [commandPoint] (Command Points) of their fleet. Hull Weakness: #E3BDAC#700#REVERT# (see defense absorption)</LocalizationPair>
 
   <LocalizationPair Name="%FailureNoMoreThanOneAntiCarrierModuleDescription">Only one Lock-on module can be equipped.</LocalizationPair>
-  <LocalizationPair Name="%FailureNoMoreThanOneShieldReloadModuleDescription">Only one Re-Shield module can be equipped.</LocalizationPair>
+  <LocalizationPair Name="%FailureNoMoreThanOneShieldReloadModuleDescription">Only one Regenerator module can be equipped.</LocalizationPair>
   <LocalizationPair Name="%FailureNoMoreThanOneFlotillaRepairOneModuleDescription">Only one Fleet repair module can be equipped.</LocalizationPair>
   <LocalizationPair Name="%FailureNoMoreThanOneSquadronOffenseEnhancerModuleDescription">Only one Strike Multiplier can be equipped.</LocalizationPair>
   <LocalizationPair Name="%FailureNoMoreThanOneSquadronDefenseEnhancerModuleDescription">Only one Squadron Shifter can be equipped.</LocalizationPair>

--- a/Endless Space Competitive Mod/Localization/english/ES2_Localization_1-3.xml
+++ b/Endless Space Competitive Mod/Localization/english/ES2_Localization_1-3.xml
@@ -384,9 +384,9 @@
   <LocalizationPair Name="%FactionTraitStartingAnomaly44Description">This Empire was cursed with bad luck and begins its story with High Gravity on their home planet.</LocalizationPair>
 
   <!-- Shield regeneration - flat rate, flotilla-wide -->
-  <LocalizationPair Name="%ModuleSupportShieldRegenerate1Strategic4Title">Antimatter Fleet Regenerator</LocalizationPair>
+  <LocalizationPair Name="%ModuleSupportShieldRegenerate1Strategic4Title">Antimatter Flotilla Regenerator</LocalizationPair>
   <LocalizationPair Name="%ModuleSupportShieldRegenerate1Strategic4Description">As the fleet takes damage in battle, this module is triggered to partially regenerate the shields of all ships.</LocalizationPair>
-  <LocalizationPair Name="%ModuleSupportShieldRegenerate2Strategic6Title">Quadrinix Fleet Regenerator</LocalizationPair>
+  <LocalizationPair Name="%ModuleSupportShieldRegenerate2Strategic6Title">Quadrinix Flotilla Regenerator</LocalizationPair>
   <LocalizationPair Name="%ModuleSupportShieldRegenerate2Strategic6Description">As the fleet takes damage in battle, this module is triggered to partially regenerate the shields of all ships.</LocalizationPair>
 
   <!-- Shield reloader - percentage-based, self-only -->

--- a/Endless Space Competitive Mod/Localization/english/ES2_Localization_1-3.xml
+++ b/Endless Space Competitive Mod/Localization/english/ES2_Localization_1-3.xml
@@ -383,7 +383,7 @@
   <LocalizationPair Name="%FactionTraitStartingAnomaly44Title">High Gravity</LocalizationPair>
   <LocalizationPair Name="%FactionTraitStartingAnomaly44Description">This Empire was cursed with bad luck and begins its story with High Gravity on their home planet.</LocalizationPair>
 
-  <!-- Reload -->
+  <!-- Shield regeneration - flat rate, flotilla-wide -->
   <LocalizationPair Name="%ModuleSupportShieldRegenerate1Strategic4Title">Antimatter Regenerator</LocalizationPair>
   <LocalizationPair Name="%ModuleSupportShieldRegenerate1Strategic4Description">After the ship has taken damage in battle, this module is triggered to partially regenerate its protective capability.</LocalizationPair>
   <LocalizationPair Name="%ModuleSupportShieldRegenerate2Strategic6Title">Quadrinix Regenerator</LocalizationPair>

--- a/Endless Space Competitive Mod/Localization/english/ES2_Localization_1-3.xml
+++ b/Endless Space Competitive Mod/Localization/english/ES2_Localization_1-3.xml
@@ -384,10 +384,16 @@
   <LocalizationPair Name="%FactionTraitStartingAnomaly44Description">This Empire was cursed with bad luck and begins its story with High Gravity on their home planet.</LocalizationPair>
 
   <!-- Shield regeneration - flat rate, flotilla-wide -->
-  <LocalizationPair Name="%ModuleSupportShieldRegenerate1Strategic4Title">Antimatter Regenerator</LocalizationPair>
-  <LocalizationPair Name="%ModuleSupportShieldRegenerate1Strategic4Description">After the ship has taken damage in battle, this module is triggered to partially regenerate its protective capability.</LocalizationPair>
-  <LocalizationPair Name="%ModuleSupportShieldRegenerate2Strategic6Title">Quadrinix Regenerator</LocalizationPair>
-  <LocalizationPair Name="%ModuleSupportShieldRegenerate2Strategic6Description">After the ship has taken damage in battle, this module can be triggered to regenerate a significant percentage of its protective capability.</LocalizationPair>
+  <LocalizationPair Name="%ModuleSupportShieldRegenerate1Strategic4Title">Antimatter Fleet Regenerator</LocalizationPair>
+  <LocalizationPair Name="%ModuleSupportShieldRegenerate1Strategic4Description">As the fleet takes damage in battle, this module is triggered to partially regenerate the shields of all ships.</LocalizationPair>
+  <LocalizationPair Name="%ModuleSupportShieldRegenerate2Strategic6Title">Quadrinix Fleet Regenerator</LocalizationPair>
+  <LocalizationPair Name="%ModuleSupportShieldRegenerate2Strategic6Description">As the fleet takes damage in battle, this module is triggered to partially regenerate the shields of all ships.</LocalizationPair>
+
+  <!-- Shield reloader - percentage-based, self-only -->
+  <LocalizationPair Name="%ModuleSupportShieldReload1Strategic4Title">Antimatter Re-Shield Capacitor</LocalizationPair>
+  <LocalizationPair Name="%ModuleSupportShieldReload1Strategic4Description">After the ship has taken damage in battle, this module is triggered to partially regenerate its protective capability. The stronger the shield, the more effective it is.</LocalizationPair>
+  <LocalizationPair Name="%ModuleSupportShieldReload2Strategic6Title">Quadrinix Re-Shield Capacitor</LocalizationPair>
+  <LocalizationPair Name="%ModuleSupportShieldReload2Strategic6Description">After the ship has taken damage in battle, this module can be triggered to regenerate a significant percentage of its protective capability. The stronger the shield, the more effective it is.</LocalizationPair>
 
   <!-- Coilgun -->
   <LocalizationPair Name="%ClassModuleIgnoresArmorTitle">Weapon ignores Hull Plating</LocalizationPair>

--- a/Endless Space Competitive Mod/Localization/english/ES2_Localization_Standalone.xml
+++ b/Endless Space Competitive Mod/Localization/english/ES2_Localization_Standalone.xml
@@ -11,9 +11,9 @@
     Stay vigilant, as a Ship with a powerful enough Cloak Detection module can even uncover your Home System if on the node.
   </LocalizationPair>
   <LocalizationPair Name="%ShieldRegeneratePerSecondDynamicTitle">Shield Regeneration per Second</LocalizationPair>
-  <LocalizationPair Name="%PanelFeatureModuleEffectsShieldRegeneratePerSecondTitle">#C48594#Shield Regeneration per Second#REVERT#</LocalizationPair>
-  <LocalizationPair Name="%ShieldRegeneratePerSecondTitle">Shield Regeneration per Second</LocalizationPair>
-  <LocalizationPair Name="%PanelFeatureModuleEffectsShieldRegeneratePerSecondDynamicTitle">Shield Regeneration per Second on Flotilla</LocalizationPair>
+  <LocalizationPair Name="%PanelFeatureModuleEffectsShieldRegeneratePerSecondTitle">#C48594#Shield Regeneration per Second on Flotilla#REVERT#</LocalizationPair>
+  <LocalizationPair Name="%ShieldRegeneratePerSecondTitle">Shield Regeneration per Second on Flotilla</LocalizationPair>
+  <LocalizationPair Name="%PanelFeatureModuleEffectsShieldRegeneratePerSecondDynamicTitle">Shield Regeneration per Second</LocalizationPair>
   <LocalizationPair Name="%PanelFeatureModuleEffectsShieldReloadPerPhaseTitle">#C48594#Shield Reloaded each Phase#REVERT#</LocalizationPair>
   <LocalizationPair Name="%StarSystemImprovementScience1Title">Public-Private Partnerships</LocalizationPair>
   <LocalizationPair Name="%ProbesCostReductionTitle">Probe Cost</LocalizationPair>

--- a/Endless Space Competitive Mod/Simulation/Battles/ModuleDefinitions[Support].xml
+++ b/Endless Space Competitive Mod/Simulation/Battles/ModuleDefinitions[Support].xml
@@ -323,13 +323,17 @@
     </CategorizedSimulationDescriptors>
   </SupportModule>
 
-  <!-- Shield Regenerator -->
+  <!-- Flotilla Shield Regenerator - flat rate shield repair -->
   <SupportModule Name="ModuleSupportShieldRegenerate1Strategic4" Family="ShieldReloadStrategic4" Level="1">
-    <Cost ResourceName="SystemProduction">60</Cost>
+    <Cost ResourceName="SystemProduction">100</Cost>
     <Cost ResourceName="Strategic4" Instant="true">1</Cost>
     <TechnologyPrerequisite Flags="Edition">TechnologySupportModule1</TechnologyPrerequisite>
+    <PathPrerequisite Flags="Edition">ClassShip,ShipRoleMediumSupport</PathPrerequisite>
+    <PathPrerequisite Flags="NoMoreThanOneShieldReloadModule,Edition,Disable" Inverted="true">ClassShip/ClassSection/ClassModule,ModuleSupportShieldReload</PathPrerequisite>
     <!--Descriptor used to apply effect-->
     <SimulationDescriptorReference Name="ClassModuleSupport"/>
+    <SimulationDescriptorReference Name="ClassModuleOnlyOnePerShip"/>
+    <SimulationDescriptorReference Name="ClassModuleSupportShipOnly"/>
     <SimulationDescriptorReference Name="ModuleTypeStrategic" />
     <CategorizedSimulationDescriptors Category="CategoryShieldRegenerate">
       <SimulationDescriptorReference Name="ModuleSupportShieldRegenerate"/>
@@ -341,11 +345,15 @@
   </SupportModule>
 
   <SupportModule Name="ModuleSupportShieldRegenerate2Strategic6" Family="ShieldReloadStrategic6" Level="2">
-    <Cost ResourceName="SystemProduction">80</Cost>
+    <Cost ResourceName="SystemProduction">120</Cost>
     <Cost ResourceName="Strategic6" Instant="true">1</Cost>
     <TechnologyPrerequisite Flags="Edition">TechnologyCuriosityModuleSupportShieldRegenerate2Strategic6</TechnologyPrerequisite>
+    <PathPrerequisite Flags="Edition">ClassShip,ShipRoleMediumSupport</PathPrerequisite>
+    <PathPrerequisite Flags="NoMoreThanOneShieldReloadModule,Edition,Disable" Inverted="true">ClassShip/ClassSection/ClassModule,ModuleSupportShieldReload</PathPrerequisite>
     <!--Descriptor used to apply effect-->
     <SimulationDescriptorReference Name="ClassModuleSupport"/>
+    <SimulationDescriptorReference Name="ClassModuleOnlyOnePerShip"/>
+    <SimulationDescriptorReference Name="ClassModuleSupportShipOnly"/>
     <SimulationDescriptorReference Name="ModuleTypeStrategic" />
     <CategorizedSimulationDescriptors Category="CategoryShieldRegenerate">
       <SimulationDescriptorReference Name="ModuleSupportShieldRegenerate"/>
@@ -356,16 +364,13 @@
     <BattleActionReference Name="Ship_ShieldRegenerationPerSecond"/>
   </SupportModule>
   
-  <!-- Flotilla Shield Reloader -->
+  <!-- Shield Reloader - self-only, percentage based -->
   <SupportModule Name="ModuleSupportShieldReload1Strategic4" Family="ShieldReloadStrategic4" Level="1">
-    <Cost ResourceName="SystemProduction">100</Cost>
+    <Cost ResourceName="SystemProduction">60</Cost>
     <Cost ResourceName="Strategic4" Instant="true">1</Cost>
     <TechnologyPrerequisite Flags="Edition">TechnologySupportModule1</TechnologyPrerequisite>
-    <PathPrerequisite Flags="Edition">ClassShip,ShipRoleMediumSupport</PathPrerequisite>
-    <PathPrerequisite Flags="NoMoreThanOneShieldReloadModule,Edition,Disable" Inverted="true">ClassShip/ClassSection/ClassModule,ModuleSupportShieldReload</PathPrerequisite>
+	
     <SimulationDescriptorReference Name="ClassModuleSupport"/>
-    <SimulationDescriptorReference Name="ClassModuleOnlyOnePerShip"/>
-    <SimulationDescriptorReference Name="ClassModuleSupportShipOnly"/>
     <SimulationDescriptorReference Name="ModuleTypeStrategic" />
     <CategorizedSimulationDescriptors Category="CategoryShieldReload">
       <SimulationDescriptorReference Name="ModuleSupportShieldReload"/>
@@ -377,14 +382,11 @@
   </SupportModule>
 
   <SupportModule Name="ModuleSupportShieldReload2Strategic6" Family="ShieldReloadStrategic6" Level="2">
-    <Cost ResourceName="SystemProduction">120</Cost>
+    <Cost ResourceName="SystemProduction">80</Cost>
     <Cost ResourceName="Strategic6" Instant="true">1</Cost>
     <TechnologyPrerequisite Flags="Edition">TechnologyCuriosityModuleSupportShieldReload2Strategic6</TechnologyPrerequisite>
-    <PathPrerequisite Flags="Edition">ClassShip,ShipRoleMediumSupport</PathPrerequisite>
-    <PathPrerequisite Flags="NoMoreThanOneShieldReloadModule,Edition,Disable" Inverted="true">ClassShip/ClassSection/ClassModule,ModuleSupportShieldReload</PathPrerequisite>
+	
     <SimulationDescriptorReference Name="ClassModuleSupport"/>
-    <SimulationDescriptorReference Name="ClassModuleOnlyOnePerShip"/>
-    <SimulationDescriptorReference Name="ClassModuleSupportShipOnly"/>
     <SimulationDescriptorReference Name="ModuleTypeStrategic" />
     <CategorizedSimulationDescriptors Category="CategoryShieldReload">
       <SimulationDescriptorReference Name="ModuleSupportShieldReload"/>

--- a/Endless Space Competitive Mod/Simulation/Battles/ModuleDefinitions[Support].xml
+++ b/Endless Space Competitive Mod/Simulation/Battles/ModuleDefinitions[Support].xml
@@ -329,7 +329,7 @@
     <Cost ResourceName="Strategic4" Instant="true">1</Cost>
     <TechnologyPrerequisite Flags="Edition">TechnologySupportModule1</TechnologyPrerequisite>
     <PathPrerequisite Flags="Edition">ClassShip,ShipRoleMediumSupport</PathPrerequisite>
-    <PathPrerequisite Flags="NoMoreThanOneShieldReloadModule,Edition,Disable" Inverted="true">ClassShip/ClassSection/ClassModule,ModuleSupportShieldReload</PathPrerequisite>
+    <PathPrerequisite Flags="NoMoreThanOneShieldReloadModule,Edition,Disable" Inverted="true">ClassShip/ClassSection/ClassModule,ModuleSupportShieldRegenerate</PathPrerequisite>
     <!--Descriptor used to apply effect-->
     <SimulationDescriptorReference Name="ClassModuleSupport"/>
     <SimulationDescriptorReference Name="ClassModuleOnlyOnePerShip"/>
@@ -349,7 +349,7 @@
     <Cost ResourceName="Strategic6" Instant="true">1</Cost>
     <TechnologyPrerequisite Flags="Edition">TechnologyCuriosityModuleSupportShieldRegenerate2Strategic6</TechnologyPrerequisite>
     <PathPrerequisite Flags="Edition">ClassShip,ShipRoleMediumSupport</PathPrerequisite>
-    <PathPrerequisite Flags="NoMoreThanOneShieldReloadModule,Edition,Disable" Inverted="true">ClassShip/ClassSection/ClassModule,ModuleSupportShieldReload</PathPrerequisite>
+    <PathPrerequisite Flags="NoMoreThanOneShieldReloadModule,Edition,Disable" Inverted="true">ClassShip/ClassSection/ClassModule,ModuleSupportShieldRegenerate</PathPrerequisite>
     <!--Descriptor used to apply effect-->
     <SimulationDescriptorReference Name="ClassModuleSupport"/>
     <SimulationDescriptorReference Name="ClassModuleOnlyOnePerShip"/>

--- a/Endless Space Competitive Mod/Simulation/Battles/SimulationDescriptors[ModuleSupport].xml
+++ b/Endless Space Competitive Mod/Simulation/Battles/SimulationDescriptors[ModuleSupport].xml
@@ -948,11 +948,11 @@
   <!-- ***** SHIELD REGENERATOR  **** -->
   <!-- ****************************** -->
 
-  <!-- Shield Regenerator -->
+  <!-- Flotilla Shield Regenerator - flat rate shield repair -->
   <SimulationDescriptor Name="ModuleSupportShieldRegenerate"                         Type="ModuleSupportShieldRegenerate">
     <Property Name="ShieldRegeneratePerSecond"                BaseValue="0"/>
     <Modifier TargetProperty="ShieldRegeneratePerSecond"      Operation="Multiplication" Value="$(Multiplier)" TooltipHidden="true"/>
-    <Modifier TargetProperty="ShieldRegeneratePerSecond"      Operation="Addition" Value="$(ShieldRegeneratePerSecond)"       Path="../ClassShip"     Priority="1"/>
+    <Modifier TargetProperty="ShieldRegeneratePerSecond"      Operation="Addition" Value="$(ShieldRegeneratePerSecond)"       Path="../ClassGarrison/ClassShip"     Priority="1"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ModuleSupportShieldRegenerate1Strategic4"              Type="ModuleSupportShieldRegenerate">
@@ -973,10 +973,10 @@
   <!-- ***** SHIELD RELOADER  **** -->
   <!-- *************************** -->
   
-  <!-- Shield Reloader -->
+  <!-- Shield Reloader - self-only, percentage based -->
   <SimulationDescriptor Name="ModuleSupportShieldReload" Type="ModuleSupportShieldReload">
     <Property Name="ShieldRegeneratePerSecondDynamic"                BaseValue="0"/>
-    <Modifier TargetProperty="ShieldRegeneratePerSecondDynamic"      Operation="Addition" Value="$(ShieldRegeneratePerSecondDynamic)"       Path="../ClassGarrison/ClassShip"     Priority="1"/>
+    <Modifier TargetProperty="ShieldRegeneratePerSecondDynamic"      Operation="Addition" Value="$(ShieldRegeneratePerSecondDynamic)"       Path="../ClassShip"     Priority="1"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ModuleSupportShieldReload1Strategic4"              Type="ModuleSupportShieldReload">


### PR DESCRIPTION
Rather than swapping the effects of the modules, I swapped the requirements and what they apply to, so `ModuleSupportShieldRegenerate1Strategic4` (and the Strategic6 version) provides flat shield regeneration flotilla-wide, while `ModuleSupportShieldReload1Strategic4` (and the Strategic6 version) provide %-based shield regeneration on self only.

I also swapped the costs, and changed the names so it's easier to remember which is which.

I have NOT adjusted the fleet strength calculations, nor have I made any AI changes to help the AI correctly use these modules.

I have done some very cursory testing, and while the effect broadly seems to work, it's hard to tell.