### PR TITLE
Replace Shield Interference Beams with Shield Interference Missiles

### DIFF
--- a/Endless Space Competitive Mod/GUI/GUIElements[Modules].xml
+++ b/Endless Space Competitive Mod/GUI/GUIElements[Modules].xml
@@ -134,6 +134,18 @@
     </Sounds>
   </ExtendedGuiElement>
 
+  <!-- Shield Interference missiles -->
+    <ExtendedGuiElement Name="ModuleWeaponMissileEMPShield1Strategic3">
+        <Title>%ModuleWeaponMissileEMPShield1Strategic3Title</Title>
+        <Icons>
+            <Icon Size="Small" Path="Bitmaps/Dynamic/Modules/ModuleWeaponBeamEMP1Strategic3" />
+        </Icons>
+        <Sounds>
+            <Sound EventName="Play_ES2_GUI_ShipDesignScreen_AddSupportModule" Type="OnEquipModule" />
+            <Sound EventName="Play_ES2_GUI_ShipDesignScreen_RemoveModule" Type="OnUnequipModule" />
+        </Sounds>
+    </ExtendedGuiElement>
+    
   <GuiElement Name="ClassModuleAntiCrewExplication">
     <Title>%ClassModuleAntiCrewExplicationTitle</Title>
   </GuiElement>

--- a/Endless Space Competitive Mod/Localization/english/ES2_Localization_Locales.xml
+++ b/Endless Space Competitive Mod/Localization/english/ES2_Localization_Locales.xml
@@ -87,6 +87,8 @@ Nakalim Ground Battle Offense Strategy Unlocked: Manipular Formation Tactics (im
 +10 [foodcolored] on System
 +10 [industrycolored] on System
 -15% System Improvement [industrycolored] Cost on System</LocalizationPair>
+
+  <LocalizationPair Name="%ModuleWeaponMissileEMPShield1Strategic3Title">Shield Interference Missiles</LocalizationPair>
   
   <!-- Custom Module -->
   <LocalizationPair Name="%ModuleSupportCrew-1Title">Troop Irritator</LocalizationPair>

--- a/Endless Space Competitive Mod/Simulation/Battles/ModuleDefinitions[Weapon].xml
+++ b/Endless Space Competitive Mod/Simulation/Battles/ModuleDefinitions[Weapon].xml
@@ -2263,6 +2263,80 @@
     </TargetSortingCriterion_PropertyMultiplier>
   </WeaponModule>
 
+<!-- New "Shield interference missile" -->
+  <WeaponModule Name="ModuleWeaponMissileEMPShield1Strategic3" Type="Missile" Family="MissileEMP" Level="4">
+    <Cost ResourceName="SystemProduction">50</Cost>
+    <Cost ResourceName="Strategic3" Instant="true">1</Cost>
+    <!-- ** START AI DATA ** -->
+    <!-- Weapons types -->
+    <AIBattleSituations Situation="ProjectileWeapon" Mode="Use" Value="1"/>
+    <AIBattleSituations Situation="Emp" Mode="Use" Value="1"/>
+    <!-- Armor types -->
+    <AIBattleSituations Situation="EnergyDefense" Mode="Against" Value="1"/>
+    <AIBattleSituations Situation="ProjectileDefense" Mode="Against" Value="-0.5"/>
+    <!-- Specific weapons -->
+    <AIBattleSituations Situation="Missile" Mode="Against" Value="1"/>
+    <AIBattleSituations Situation="Kinetic" Mode="Against" Value="-1"/>
+    <AIBattleSituations Situation="Laser" Mode="Against" Value="0.75"/>
+    <AIBattleSituations Situation="Beam" Mode="Use" Value="1"/>
+    <!--Specific situations-->
+    <AIBattleSituations Situation="MorePowerful" Mode="Against" Value="1"/>
+    <!-- Ranges -->
+    <AIBattleSituations Situation="Short" Mode="Use" Value="0.25"/>
+    <AIBattleSituations Situation="Medium" Mode="Use" Value="0.5"/>
+    <AIBattleSituations Situation="Long" Mode="Use" Value="1"/>
+    <AIBattleSituations Situation="Short" Mode="Against" Value="0.25"/>
+    <AIBattleSituations Situation="Medium" Mode="Against" Value="0.5"/>
+    <AIBattleSituations Situation="Long" Mode="Against" Value="1"/>
+    <!-- ** END AI DATA ** -->
+    <!-- DLC restriction temporarily removed for testing -->
+    <DownloadableContentPrerequisite Flags="Prerequisite,Edition,UnlockAvailability">DLCVaulters</DownloadableContentPrerequisite>
+    <TechnologyPrerequisite Flags="Edition">TechnologyDefenseModule2</TechnologyPrerequisite>
+    <PathPrerequisite Flags="Edition" Inverted="true">ClassShip,CannotHaveWeapon</PathPrerequisite>
+    <PathPrerequisite Flags="ShipHasDestructionModule,Edition,Disable" Inverted="true">ClassShip/ClassSection/ClassModuleDestruction</PathPrerequisite>
+    <SimulationDescriptorReference Name="ClassModuleWeapon"/>
+    <SimulationDescriptorReference Name="ClassModuleEMPExplication"/>
+    <SimulationDescriptorReference Name="ModuleTypeStrategic" />
+    <CategorizedSimulationDescriptors Category="CategoryModuleWeaponMissile">
+      <SimulationDescriptorReference Name="ClassModuleWeaponMissile"/>
+      <SimulationDescriptorReference Name="ModuleWeaponEMP"/>
+    </CategorizedSimulationDescriptors>
+    <CategorizedSimulationDescriptors Category="CategoryBaseWeapon">
+      <SimulationDescriptorReference Name="ModuleWeaponMissileEMPShield1"/>
+    </CategorizedSimulationDescriptors>
+    <CategorizedSimulationDescriptors Category="CategoryModuleWeaponStrategic3">
+      <SimulationDescriptorReference Name="ModuleWeaponStrategic3"/>
+    </CategorizedSimulationDescriptors>
+    <BattleActionReference Name="Weapon_Initialize"/>
+    <BattleActionReference Name="Weapon_SalvoHitFlotillaShield"/>
+    <BattleActionReference Name="Weapon_SalvoHitShipShield"/>
+    <BattleActionReference Name="Weapon_SalvoApplyShieldDamage"/>
+    <BattleActionReference Name="Weapon_SalvoLaunched"/>
+    <BattleActionReference Name="Weapon_SalvoPrepareHitTarget"/>
+    <BattleActionReference Name="Weapon_SalvoHitTarget"/>
+    <BattleActionReference Name="Weapon_SalvoPostHitTarget"/>
+    <BattleActionReference Name="Weapon_SalvoPostHitTarget_StatisticsRecording"/>
+    <BattleActionReference Name="WeaponMissile_SalvoPostHitTarget_StatisticsRecording"/>
+    <BattleActionReference Name="Weapon_UpdateAccuracyAfterMiss"/>
+    <BattleActionReference Name="WeaponEMP_SalvoLaunched_SetEMPDurations"/>
+    <BattleActionReference Name="WeaponEMP_SalvoPrepareHitTarget_ComputeShieldDeactivationTime"/>
+    <BattleActionReference Name="WeaponEMP_SalvoHitTarget_DeactivateShield"/>
+	<!-- Currently uses an identical salvo to the weapon disabling missile -->
+    <SalvoReference Name="SalvoMissileEMP1"/>
+    <AvailableRange RangeName="Short" PenaltyPropertyName="ShortRangePenalty"/>
+    <AvailableRange RangeName="Medium" PenaltyPropertyName="MediumRangePenalty"/>
+    <AvailableRange RangeName="Long" PenaltyPropertyName="LongRangePenalty"/>
+    <TargetSortingCriterion Name="Type">
+      <ScoreModifier Name="Ship">1</ScoreModifier>
+    </TargetSortingCriterion>
+    <TargetSortingCriterion Name="Role" ScoreModifiersDefaultValue="1" IgnoredWhenCheckingTargetValidity="true"/>
+    <TargetSortingCriterion_PropertyMultiplier Name="PropertyMultiplier">
+      <ScoreModifier Name="OffensiveMilitaryPowerIfWeakestTargeting">-1</ScoreModifier>
+      <ScoreModifier Name="TargetersCount">-50</ScoreModifier>
+      <ScoreModifier Name="TargetingWeightBonus">1</ScoreModifier>
+    </TargetSortingCriterion_PropertyMultiplier>
+  </WeaponModule>
+
   <!--################################-->
   <!--###             AOE          ###-->
   <!--################################-->

--- a/Endless Space Competitive Mod/Simulation/Battles/SimulationDescriptors[ModuleWeapon].xml
+++ b/Endless Space Competitive Mod/Simulation/Battles/SimulationDescriptors[ModuleWeapon].xml
@@ -1032,6 +1032,18 @@
     <Modifier TargetProperty="EMPTargetShields"         Operation="Addition"    Value="1"           Path="ClassModule"      TooltipHidden="true"/>
   </SimulationDescriptor>
 
+  <!-- "Shield Interference missiles" -->
+  <SimulationDescriptor Name="ModuleWeaponMissileEMPShield1" Type="ModuleWeapon">
+    <Modifier TargetProperty="EMPDurationForShields"    Operation="Addition"    Value="6"         Path="ClassModule"       TooltipHidden="true"/>
+    <Modifier TargetProperty="Damage"                       Operation="Addition" Value="250"   Path="ClassModule" TooltipHidden="true"/>
+    <!--<Modifier TargetProperty="Cooldown"                 Operation="Percent"  Value="0.5"   Path="ClassModule" TooltipHidden="true"/>-->
+    <BinaryModifier TargetProperty="TotalIndustryCost"    Operation="Addition" Left="$(WeaponIndustryTier3)" BinaryOperation="Multiplication" Right="$(Multiplier)" Path="ClassModuleWeapon" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="TotalStrategic3Cost"    Operation="Addition" Left="1" BinaryOperation="Multiplication" Right="$(Multiplier)" Path="ClassModuleWeapon" TooltipHidden="true"/>
+
+    <!-- Feedback -->
+    <Modifier TargetProperty="EMPTargetShields"         Operation="Addition"    Value="1"           Path="ClassModule"      TooltipHidden="true"/>
+  </SimulationDescriptor>
+
   <!--################################-->
   <!--###             AOE          ###-->
   <!--################################-->


### PR DESCRIPTION
Please note this has NOT been tested. I don't have the Vaulters DLC, so while it didn't appear that the EMP effect was working, that might be due to the lack of the DLC rather than a problem with the code.