### PR TITLE
some adjustments to the spawn conditions

### DIFF
--- a/Endless Space Competitive Mod/Simulation/Anomaly/AnomalyDefinitions.xml
+++ b/Endless Space Competitive Mod/Simulation/Anomaly/AnomalyDefinitions.xml
@@ -170,7 +170,6 @@
         <GeneratorInfo>
             <PlanetFilterNot>PlanetTypeFake</PlanetFilterNot>
             <PlanetFilterNot>PlanetTypeDestroyed</PlanetFilterNot>
-            <PlanetFilterNot>PlanetTypeGasWarm</PlanetFilterNot>
             <PlanetFilterNot>PlanetGameplayTypeTeeming</PlanetFilterNot>
             <PlanetFilterNot>PlanetGameplayTypeHot</PlanetFilterNot>
             <PlanetFilterNot>PlanetGameplayTypeTemperate</PlanetFilterNot>
@@ -192,9 +191,14 @@
             <PlanetFilterNot>PlanetTypeFake</PlanetFilterNot>
             <PlanetFilterNot>PlanetTypeDestroyed</PlanetFilterNot>
             <PlanetFilterNot>PlanetGameplayTypeGas</PlanetFilterNot>
-            <PlanetFilterNot>PlanetGameplayTypeMeager</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeBarren</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeIce</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeArctic</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeSnow</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeLava</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeAsh</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeDesert</PlanetFilterNot>
             <PlanetFilterNot>PlanetTypeArid</PlanetFilterNot>
-            <PlanetFilterNot>PlanetTypeTropical</PlanetFilterNot>
             <PlanetFilterNot>PlanetTypeVeldt</PlanetFilterNot>
             <PlanetFilterNot>PlanetTypeSteppes</PlanetFilterNot>
         </GeneratorInfo>
@@ -212,12 +216,13 @@
         <SimulationDescriptorReference Name="PlanetAnomalyMixed"/>
         <GeneratorInfo>
             <PlanetFilterNot>PlanetTypeDestroyed</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeFake</PlanetFilterNot>
             <PlanetFilterNot>PlanetGameplayTypeGas</PlanetFilterNot>
             <PlanetFilterNot>PlanetTypeBarren</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeIce</PlanetFilterNot>
             <PlanetFilterNot>PlanetTypeLava</PlanetFilterNot>
             <PlanetFilterNot>PlanetTypeAsh</PlanetFilterNot>
             <PlanetFilterNot>PlanetTypeDesert</PlanetFilterNot>
-            <PlanetFilterNot>PlanetTypeFake</PlanetFilterNot>
             <PlanetFilterNot>PlanetTypeArid</PlanetFilterNot>
         </GeneratorInfo>
     </AnomalyDefinition>
@@ -235,6 +240,7 @@
         <GeneratorInfo>
             <PlanetFilterNot>PlanetTypeFake</PlanetFilterNot>
             <PlanetFilterNot>PlanetTypeDestroyed</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeBarren</PlanetFilterNot>
         </GeneratorInfo>
     </AnomalyDefinition>
 
@@ -397,6 +403,7 @@
         <GeneratorInfo>
             <PlanetFilterNot>PlanetTypeFake</PlanetFilterNot>
             <PlanetFilterNot>PlanetTypeDestroyed</PlanetFilterNot>
+            <PlanetFilterNot>PlanetTypeBarren</PlanetFilterNot>
         </GeneratorInfo>
     </AnomalyDefinition>
 
@@ -927,7 +934,6 @@
             <PlanetFilterNot>PlanetGameplayTypeMeager</PlanetFilterNot>
             <PlanetFilterNot>PlanetTypeArid</PlanetFilterNot>
             <PlanetFilterNot>PlanetTypeSnow</PlanetFilterNot>
-            <PlanetFilterNot>PlanetTypeTundra</PlanetFilterNot>
         </GeneratorInfo>
     </AnomalyDefinition>
 


### PR DESCRIPTION
after seeing the changes in game i have some adjustments
removed pointless limiter in ice-10 (doesn't change anything)
allowed permanent monsoon to spawn on swamp and mediterranean and prevented it on snow
prevented metallic water from spawning on ice (the game's visual effect for this shows liquid water so it doesnt make sense to have it on ice)
prevented aurora waves from spawning on barren cuz no atmosphere
prevented acid rain on barren cuz no atmosphere
allowed tree of world on tundra cuz why not