### PR TITLE
Added CameraAnchor SimulationDescriptors

### DIFF
--- a/Endless Space Competitive Mod/Simulation/Battles/HullDefinitions[Academy].xml
+++ b/Endless Space Competitive Mod/Simulation/Battles/HullDefinitions[Academy].xml
@@ -11,6 +11,7 @@
     <SimulationDescriptorReference Name="WeaponAvailabilityKinetic"/>
     <SimulationDescriptorReference Name="ShipSizeSmall"/>
     <SimulationDescriptorReference Name="ShipFactionVampirilis"/>
+    <SimulationDescriptorReference Name="CameraAnchorVampirilis"/>
     <SimulationDescriptorReference Name="ShipHull03"/>
     <SimulationDescriptorReference Name="CannotBeCapturedAfterBattle"/>
     <SimulationDescriptorReference Name="ShipStatBonus1InvisibleModules"/>
@@ -124,6 +125,7 @@
     <SimulationDescriptorReference Name="WeaponAvailabilityMissile"/>
     <SimulationDescriptorReference Name="ShipSizeLarge"/>
     <SimulationDescriptorReference Name="ShipFactionVampirilis"/>
+    <SimulationDescriptorReference Name="CameraAnchorVampirilis"/>
     <SimulationDescriptorReference Name="ShipHull01"/>
     <SimulationDescriptorReference Name="CannotBeCapturedAfterBattle"/>
     <SimulationDescriptorReference Name="ShipStatBonus1InvisibleModules"/>
@@ -477,6 +479,7 @@
     <SimulationDescriptorReference Name="WeaponAvailabilityMissile"/>
     <SimulationDescriptorReference Name="ShipSizeSmall"/>
     <SimulationDescriptorReference Name="ShipFactionVampirilis"/>
+    <SimulationDescriptorReference Name="CameraAnchorVampirilis"/>
     <SimulationDescriptorReference Name="ShipHull01"/>
     <SimulationDescriptorReference Name="CannotBeCapturedAfterBattle"/>
     <SimulationDescriptorReference Name="ShipStatBonus1InvisibleModules"/>
@@ -657,6 +660,7 @@
     <SimulationDescriptorReference Name="WeaponAvailabilityMissile"/>
     <SimulationDescriptorReference Name="ShipSizeMedium"/>
     <SimulationDescriptorReference Name="ShipFactionVampirilis"/>
+    <SimulationDescriptorReference Name="CameraAnchorVampirilis"/>
     <SimulationDescriptorReference Name="ShipHull02"/>
     <SimulationDescriptorReference Name="CannotBeCapturedAfterBattle"/>
     <SimulationDescriptorReference Name="ShipStatBonus1InvisibleModules"/>
@@ -826,6 +830,7 @@
     <SimulationDescriptorReference Name="WeaponAvailabilityKinetic"/>
     <SimulationDescriptorReference Name="ShipSizeSmall"/>
     <SimulationDescriptorReference Name="ShipFactionVampirilis"/>
+    <SimulationDescriptorReference Name="CameraAnchorVampirilis"/>
     <SimulationDescriptorReference Name="WeaponAvailabilityBeam"/>
     <SimulationDescriptorReference Name="WeaponAvailabilityLaser"/>
     <SimulationDescriptorReference Name="WeaponAvailabilityMissile"/>
@@ -982,6 +987,7 @@
     <SimulationDescriptorReference Name="WeaponAvailabilityMissile"/>
     <SimulationDescriptorReference Name="ShipSizeMedium"/>
     <SimulationDescriptorReference Name="ShipFactionVampirilis"/>
+    <SimulationDescriptorReference Name="CameraAnchorVampirilis"/>
     <SimulationDescriptorReference Name="ShipHull01"/>
     <SimulationDescriptorReference Name="CannotBeCapturedAfterBattle"/>
     <SimulationDescriptorReference Name="ShipStatBonus1InvisibleModules"/>
@@ -1251,6 +1257,7 @@
     <SimulationDescriptorReference Name="WeaponAvailabilityMissile"/>
     <SimulationDescriptorReference Name="ShipSizeSmall"/>
     <SimulationDescriptorReference Name="ShipFactionVampirilis"/>
+    <SimulationDescriptorReference Name="CameraAnchorVampirilis"/>
     <SimulationDescriptorReference Name="ShipHull01"/>
     <SimulationDescriptorReference Name="CannotBeCapturedAfterBattle"/>
     <SimulationDescriptorReference Name="ShipStatBonus1InvisibleModules"/>
@@ -1399,6 +1406,7 @@
     <SimulationDescriptorReference Name="WeaponAvailabilityMissile"/>
     <SimulationDescriptorReference Name="ShipSizeLarge"/>
     <SimulationDescriptorReference Name="ShipFactionNamedShipTemplars"/>
+    <SimulationDescriptorReference Name="CameraAnchorNamedShipTemplars"/>
     <SimulationDescriptorReference Name="ShipHull01"/>
     <SimulationDescriptorReference Name="CannotBeCapturedAfterBattle"/>
 
@@ -1759,6 +1767,7 @@
     <SimulationDescriptorReference Name="WeaponAvailabilityMissile"/>
     <SimulationDescriptorReference Name="ShipSizeLarge"/>
     <SimulationDescriptorReference Name="ShipFactionNamedShipSophons"/>
+    <SimulationDescriptorReference Name="CameraAnchorNamedShipSophons"/>
     <SimulationDescriptorReference Name="ShipHull01"/>
     <SimulationDescriptorReference Name="CannotBeCapturedAfterBattle"/>
     <SimulationDescriptorReference Name="ShipStatBonus1InvisibleModules"/>
@@ -2129,6 +2138,7 @@
     <SimulationDescriptorReference Name="WeaponAvailabilityMissile"/>
     <SimulationDescriptorReference Name="ShipSizeLarge"/>
     <SimulationDescriptorReference Name="ShipFactionNamedShipTerrans"/>
+    <SimulationDescriptorReference Name="CameraAnchorNamedShipTerrans"/>
     <SimulationDescriptorReference Name="ShipHull01"/>
     <SimulationDescriptorReference Name="CannotBeCapturedAfterBattle"/>
     <SimulationDescriptorReference Name="ShipStatBonus1InvisibleModules"/>
@@ -2502,6 +2512,7 @@
     <SimulationDescriptorReference Name="WeaponAvailabilityMissile"/>
     <SimulationDescriptorReference Name="ShipSizeLarge"/>
     <SimulationDescriptorReference Name="ShipFactionNamedShipCraversPrime"/>
+    <SimulationDescriptorReference Name="CameraAnchorNamedShipCraversPrime"/>
     <SimulationDescriptorReference Name="ShipHull01"/>
     <SimulationDescriptorReference Name="CannotBeCapturedAfterBattle"/>
     <SimulationDescriptorReference Name="ShipStatBonus1InvisibleModules"/>

--- a/Endless Space Competitive Mod/Simulation/Battles/HullDefinitions[Attacker].xml
+++ b/Endless Space Competitive Mod/Simulation/Battles/HullDefinitions[Attacker].xml
@@ -16,6 +16,7 @@
     <SimulationDescriptorReference Name="WeaponAvailabilityLaser"/>
     <SimulationDescriptorReference Name="ShipSizeSmall"/>
     <SimulationDescriptorReference Name="ShipFactionCravers"/>
+    <SimulationDescriptorReference Name="CameraAnchorCravers"/>
     <SimulationDescriptorReference Name="ShipHull01"/>
 
     <ShipDesignLayout>
@@ -199,6 +200,7 @@
     <SimulationDescriptorReference Name="WeaponAvailabilityLaser"/>
     <SimulationDescriptorReference Name="ShipSizeSmall"/>
     <SimulationDescriptorReference Name="ShipFactionMajorHisshos"/>
+    <SimulationDescriptorReference Name="CameraAnchorMajorHisshos"/>
     <SimulationDescriptorReference Name="ShipHull01"/>
 
     <ShipDesignLayout>
@@ -376,6 +378,7 @@
     <SimulationDescriptorReference Name="WeaponAvailabilityLaser"/>
     <SimulationDescriptorReference Name="ShipSizeSmall"/>
     <SimulationDescriptorReference Name="ShipFactionHoratio"/>
+    <SimulationDescriptorReference Name="CameraAnchorHoratio"/>
     <SimulationDescriptorReference Name="ShipHull01"/>
 
     <ShipDesignLayout>
@@ -551,6 +554,7 @@
     <SimulationDescriptorReference Name="WeaponAvailabilityLaser"/>
     <SimulationDescriptorReference Name="ShipSizeSmall"/>
     <SimulationDescriptorReference Name="ShipFactionVenetians"/>
+    <SimulationDescriptorReference Name="CameraAnchorVenetians"/>
     <SimulationDescriptorReference Name="ShipHull01"/>
 
     <ShipDesignLayout>
@@ -738,6 +742,7 @@
     <SimulationDescriptorReference Name="WeaponAvailabilityLaser"/>
     <SimulationDescriptorReference Name="ShipSizeSmall"/>
     <SimulationDescriptorReference Name="ShipFactionTemplars"/>
+    <SimulationDescriptorReference Name="CameraAnchorTemplars"/>
     <SimulationDescriptorReference Name="ShipHull01"/>
 
     <ShipDesignLayout>
@@ -934,6 +939,7 @@
     <SimulationDescriptorReference Name="WeaponAvailabilityLaser"/>
     <SimulationDescriptorReference Name="ShipSizeSmall"/>
     <SimulationDescriptorReference Name="ShipFactionTimeLords"/>
+    <SimulationDescriptorReference Name="CameraAnchorTimeLords"/>
     <SimulationDescriptorReference Name="ShipHull01"/>
 
     <ShipDesignLayout>
@@ -1124,6 +1130,7 @@
     <SimulationDescriptorReference Name="WeaponAvailabilityLaser"/>
     <SimulationDescriptorReference Name="ShipSizeSmall"/>
     <SimulationDescriptorReference Name="ShipFactionSophons"/>
+    <SimulationDescriptorReference Name="CameraAnchorSophons"/>
     <SimulationDescriptorReference Name="ShipHull01"/>
 
     <ShipDesignLayout>
@@ -1304,6 +1311,7 @@
     <SimulationDescriptorReference Name="WeaponAvailabilityLaser"/>
     <SimulationDescriptorReference Name="ShipSizeSmall"/>
     <SimulationDescriptorReference Name="ShipFactionUmbralChoir"/>
+    <SimulationDescriptorReference Name="CameraAnchorUmbralChoir"/>
     <SimulationDescriptorReference Name="ShipHull01"/>
 
     <ShipDesignLayout>
@@ -1469,6 +1477,7 @@
     <SimulationDescriptorReference Name="WeaponAvailabilityLaser"/>
     <SimulationDescriptorReference Name="ShipSizeSmall"/>
     <SimulationDescriptorReference Name="ShipFactionTerrans"/>
+    <SimulationDescriptorReference Name="CameraAnchorTerrans"/>
     <SimulationDescriptorReference Name="ShipHull01"/>
 
     <ShipDesignLayout>
@@ -1654,6 +1663,7 @@
     <SimulationDescriptorReference Name="WeaponAvailabilityLaser"/>
     <SimulationDescriptorReference Name="ShipSizeSmall"/>
     <SimulationDescriptorReference Name="ShipFactionUnfallen"/>
+    <SimulationDescriptorReference Name="CameraAnchorUnfallen"/>
     <SimulationDescriptorReference Name="ShipHull01"/>
 
     <ShipDesignLayout>
@@ -1818,6 +1828,7 @@
     <SimulationDescriptorReference Name="WeaponAvailabilityLaser"/>
     <SimulationDescriptorReference Name="ShipSizeSmall"/>
     <SimulationDescriptorReference Name="ShipFactionVaulters"/>
+    <SimulationDescriptorReference Name="CameraAnchorVaulters"/>
     <SimulationDescriptorReference Name="ShipHull01"/>
 
     <ShipDesignLayout>
@@ -1985,6 +1996,7 @@
     <SimulationDescriptorReference Name="WeaponAvailabilityLaser"/>
     <SimulationDescriptorReference Name="ShipSizeSmall"/>
     <SimulationDescriptorReference Name="ShipFactionVampirilis"/>
+    <SimulationDescriptorReference Name="CameraAnchorVampirilis"/>
     <SimulationDescriptorReference Name="ShipHull01"/>
 
     <ShipDesignLayout>

--- a/Endless Space Competitive Mod/Simulation/Battles/HullDefinitions[Behemoth].xml
+++ b/Endless Space Competitive Mod/Simulation/Battles/HullDefinitions[Behemoth].xml
@@ -19,6 +19,7 @@
     <SimulationDescriptorReference Name="ShipSizeJuggernaut"/>
     <SimulationDescriptorReference Name="ShipHull01"/>
     <SimulationDescriptorReference Name="ShipFactionJuggernauts"/>
+    <SimulationDescriptorReference Name="CameraAnchorJuggernauts"/>
     <SimulationDescriptorReference Name="WeaponAvailabilityKinetic"/>
     <SimulationDescriptorReference Name="WeaponAvailabilityBeam"/>
     <SimulationDescriptorReference Name="WeaponAvailabilityLaser"/>
@@ -208,6 +209,7 @@
     <SimulationDescriptorReference Name="ShipSizeJuggernaut"/>
     <SimulationDescriptorReference Name="ShipHull01"/>
     <SimulationDescriptorReference Name="ShipFactionJuggernauts"/>
+    <SimulationDescriptorReference Name="CameraAnchorJuggernauts"/>
     <SimulationDescriptorReference Name="WeaponAvailabilityKinetic"/>
     <SimulationDescriptorReference Name="WeaponAvailabilityBeam"/>
     <SimulationDescriptorReference Name="WeaponAvailabilityLaser"/>
@@ -445,6 +447,7 @@
     <SimulationDescriptorReference Name="ShipSizeJuggernaut"/>
     <SimulationDescriptorReference Name="ShipHull02"/>
     <SimulationDescriptorReference Name="ShipFactionJuggernauts"/>
+    <SimulationDescriptorReference Name="CameraAnchorJuggernauts"/>
     <SimulationDescriptorReference Name="WeaponAvailabilityKinetic"/>
     <SimulationDescriptorReference Name="WeaponAvailabilityBeam"/>
     <SimulationDescriptorReference Name="WeaponAvailabilityLaser"/>
@@ -775,6 +778,7 @@
     <SimulationDescriptorReference Name="ShipSizeJuggernaut"/>
     <SimulationDescriptorReference Name="ShipHull03"/>
     <SimulationDescriptorReference Name="ShipFactionJuggernauts"/>
+    <SimulationDescriptorReference Name="CameraAnchorJuggernauts"/>
     <SimulationDescriptorReference Name="WeaponAvailabilityKinetic"/>
     <SimulationDescriptorReference Name="WeaponAvailabilityBeam"/>
     <SimulationDescriptorReference Name="WeaponAvailabilityLaser"/>

--- a/Endless Space Competitive Mod/Simulation/Battles/HullDefinitions[Carrier].xml
+++ b/Endless Space Competitive Mod/Simulation/Battles/HullDefinitions[Carrier].xml
@@ -18,6 +18,7 @@
 		<SimulationDescriptorReference Name="WeaponAvailabilityMissile"/>
 		<SimulationDescriptorReference Name="ShipSizeLarge"/>
 		<SimulationDescriptorReference Name="ShipFactionCravers"/>
+		<SimulationDescriptorReference Name="CameraAnchorCravers"/>
 		<SimulationDescriptorReference Name="ShipHull01"/>
 
 		<ShipDesignLayout>
@@ -343,6 +344,7 @@
 		<SimulationDescriptorReference Name="WeaponAvailabilityMissile"/>
 		<SimulationDescriptorReference Name="ShipSizeLarge"/>
 		<SimulationDescriptorReference Name="ShipFactionMajorHisshos"/>
+		<SimulationDescriptorReference Name="CameraAnchorMajorHisshos"/>
 		<SimulationDescriptorReference Name="ShipHull01"/>
 
 		<ShipDesignLayout>
@@ -683,6 +685,7 @@
 		<SimulationDescriptorReference Name="WeaponAvailabilityMissile"/>
 		<SimulationDescriptorReference Name="ShipSizeLarge"/>
 		<SimulationDescriptorReference Name="ShipFactionHoratio"/>
+		<SimulationDescriptorReference Name="CameraAnchorHoratio"/>
 		<SimulationDescriptorReference Name="ShipHull01"/>
 
 		<ShipDesignLayout>
@@ -1040,6 +1043,8 @@
 		<SimulationDescriptorReference Name="ShipSizeLarge"/>
 
 		<SimulationDescriptorReference Name="ShipFactionVenetians"/>
+
+		<SimulationDescriptorReference Name="CameraAnchorVenetians"/>
 		<SimulationDescriptorReference Name="ShipHull01"/>
 
 		<ShipDesignLayout>
@@ -1369,6 +1374,7 @@
 		<SimulationDescriptorReference Name="WeaponAvailabilityMissile"/>
 		<SimulationDescriptorReference Name="ShipSizeLarge"/>
 		<SimulationDescriptorReference Name="ShipFactionTemplars"/>
+		<SimulationDescriptorReference Name="CameraAnchorTemplars"/>
 		<SimulationDescriptorReference Name="ShipHull01"/>
 
 		<ShipDesignLayout>
@@ -1730,6 +1736,7 @@
 		<SimulationDescriptorReference Name="WeaponAvailabilityMissile"/>
 		<SimulationDescriptorReference Name="ShipSizeLarge"/>
 		<SimulationDescriptorReference Name="ShipFactionTimeLords"/>
+		<SimulationDescriptorReference Name="CameraAnchorTimeLords"/>
 		<SimulationDescriptorReference Name="ShipHull01"/>
 
 		<ShipDesignLayout>
@@ -2072,6 +2079,7 @@
 		<SimulationDescriptorReference Name="WeaponAvailabilityMissile"/>
 		<SimulationDescriptorReference Name="ShipSizeLarge"/>
 		<SimulationDescriptorReference Name="ShipFactionSophons"/>
+		<SimulationDescriptorReference Name="CameraAnchorSophons"/>
 		<SimulationDescriptorReference Name="ShipHull01"/>
 
 		<ShipDesignLayout>
@@ -2450,6 +2458,7 @@
 		<SimulationDescriptorReference Name="WeaponAvailabilityMissile"/>
 		<SimulationDescriptorReference Name="ShipSizeLarge"/>
 		<SimulationDescriptorReference Name="ShipFactionUmbralChoir"/>
+		<SimulationDescriptorReference Name="CameraAnchorUmbralChoir"/>
 		<SimulationDescriptorReference Name="ShipHull01"/>
 
 		<ShipDesignLayout>
@@ -2772,6 +2781,7 @@
 		<SimulationDescriptorReference Name="WeaponAvailabilityMissile"/>
 		<SimulationDescriptorReference Name="ShipSizeLarge"/>
 		<SimulationDescriptorReference Name="ShipFactionTerrans"/>
+		<SimulationDescriptorReference Name="CameraAnchorTerrans"/>
 		<SimulationDescriptorReference Name="ShipHull01"/>
 
 		<ShipDesignLayout>
@@ -3146,6 +3156,8 @@
 		<SimulationDescriptorReference Name="ShipSizeLarge"/>
 
 		<SimulationDescriptorReference Name="ShipFactionUnfallen"/>
+
+		<SimulationDescriptorReference Name="CameraAnchorUnfallen"/>
 		<SimulationDescriptorReference Name="ShipHull01"/>
 
 		<ShipDesignLayout>
@@ -3463,6 +3475,7 @@
 		<SimulationDescriptorReference Name="WeaponAvailabilityMissile"/>
 		<SimulationDescriptorReference Name="ShipSizeLarge"/>
 		<SimulationDescriptorReference Name="ShipFactionVaulters"/>
+		<SimulationDescriptorReference Name="CameraAnchorVaulters"/>
 		<SimulationDescriptorReference Name="ShipHull01"/>
 
 		<ShipDesignLayout>
@@ -3800,6 +3813,7 @@
 		<SimulationDescriptorReference Name="WeaponAvailabilityMissile"/>
 		<SimulationDescriptorReference Name="ShipSizeLarge"/>
 		<SimulationDescriptorReference Name="ShipFactionVampirilis"/>
+		<SimulationDescriptorReference Name="CameraAnchorVampirilis"/>
 		<SimulationDescriptorReference Name="ShipHull01"/>
 
 		<ShipDesignLayout>

--- a/Endless Space Competitive Mod/Simulation/Battles/HullDefinitions[Colonizer].xml
+++ b/Endless Space Competitive Mod/Simulation/Battles/HullDefinitions[Colonizer].xml
@@ -18,6 +18,7 @@
     <SimulationDescriptorReference Name="ClassHullCravers"/>
     <SimulationDescriptorReference Name="ShipSizeSmall"/>
     <SimulationDescriptorReference Name="ShipFactionCravers"/>
+    <SimulationDescriptorReference Name="CameraAnchorCravers"/>
     <SimulationDescriptorReference Name="ShipHull03"/>
     <SimulationDescriptorReference Name="WeaponAvailabilityKinetic"/>
     <SimulationDescriptorReference Name="CannotHaveWeapon"/>
@@ -208,6 +209,7 @@
     <SimulationDescriptorReference Name="ClassHullSmallCivilian"/>
     <SimulationDescriptorReference Name="ShipSizeSmall"/>
     <SimulationDescriptorReference Name="ShipFactionMajorHisshos"/>
+    <SimulationDescriptorReference Name="CameraAnchorMajorHisshos"/>
     <SimulationDescriptorReference Name="ShipHull03"/>
     <SimulationDescriptorReference Name="CannotHaveWeapon"/>
 
@@ -309,6 +311,7 @@
     <SimulationDescriptorReference Name="ClassHullSmallCivilian"/>
     <SimulationDescriptorReference Name="ShipSizeSmall"/>
     <SimulationDescriptorReference Name="ShipFactionHoratio"/>
+    <SimulationDescriptorReference Name="CameraAnchorHoratio"/>
     <SimulationDescriptorReference Name="ShipHull03"/>
     <SimulationDescriptorReference Name="CannotHaveWeapon"/>
 
@@ -407,6 +410,7 @@
 		<SimulationDescriptorReference Name="ClassHullSmallCivilian"/>
 		<SimulationDescriptorReference Name="ShipSizeSmall"/>
 		<SimulationDescriptorReference Name="ShipFactionVenetians"/>
+		<SimulationDescriptorReference Name="CameraAnchorVenetians"/>
 		<SimulationDescriptorReference Name="ShipHull03"/>
 
 		<ShipDesignLayout>
@@ -520,6 +524,7 @@
 		<SimulationDescriptorReference Name="ClassHullSmallCivilian"/>
 		<SimulationDescriptorReference Name="ShipSizeSmall"/>
 		<SimulationDescriptorReference Name="ShipFactionTemplars"/>
+		<SimulationDescriptorReference Name="CameraAnchorTemplars"/>
 		<SimulationDescriptorReference Name="ShipHull03"/>
 		<SimulationDescriptorReference Name="CannotHaveWeapon"/>
 
@@ -708,6 +713,7 @@
 		<SimulationDescriptorReference Name="ClassHullSmallCivilian"/>
 		<SimulationDescriptorReference Name="ShipSizeSmall"/>
 		<SimulationDescriptorReference Name="ShipFactionTimeLords"/>
+		<SimulationDescriptorReference Name="CameraAnchorTimeLords"/>
 		<SimulationDescriptorReference Name="ShipHull03"/>
 		<SimulationDescriptorReference Name="CannotHaveWeapon"/>
 
@@ -805,6 +811,7 @@
     <SimulationDescriptorReference Name="ClassHullSmallCivilian"/>
     <SimulationDescriptorReference Name="ShipSizeSmall"/>
     <SimulationDescriptorReference Name="ShipFactionSophons"/>
+    <SimulationDescriptorReference Name="CameraAnchorSophons"/>
     <SimulationDescriptorReference Name="ShipHull03"/>
     <SimulationDescriptorReference Name="CannotHaveWeapon"/>
 
@@ -987,6 +994,7 @@
 		<SimulationDescriptorReference Name="ClassHullSmallCivilian"/>
 		<SimulationDescriptorReference Name="ShipSizeSmall"/>
 		<SimulationDescriptorReference Name="ShipFactionUmbralChoir"/>
+		<SimulationDescriptorReference Name="CameraAnchorUmbralChoir"/>
 		<SimulationDescriptorReference Name="ShipHull01"/>
 		<SimulationDescriptorReference Name="CannotHaveWeapon"/>
 
@@ -1088,6 +1096,7 @@
     <SimulationDescriptorReference Name="WeaponAvailabilityKinetic"/>
     <SimulationDescriptorReference Name="ShipSizeSmall"/>
     <SimulationDescriptorReference Name="ShipFactionTerrans"/>
+    <SimulationDescriptorReference Name="CameraAnchorTerrans"/>
     <SimulationDescriptorReference Name="ShipHull03"/>
 
     <!-- **   Terran Small Colonizer   ** -->
@@ -1202,6 +1211,7 @@
     <SimulationDescriptorReference Name="ClassHullSmallCivilian"/>
     <SimulationDescriptorReference Name="ShipSizeSmall"/>
     <SimulationDescriptorReference Name="ShipFactionUnfallen"/>
+    <SimulationDescriptorReference Name="CameraAnchorUnfallen"/>
     <SimulationDescriptorReference Name="ShipHull03"/>
     <SimulationDescriptorReference Name="CannotHaveWeapon"/>
 
@@ -1303,6 +1313,7 @@
     <SimulationDescriptorReference Name="ClassHullSmallCivilian"/>
     <SimulationDescriptorReference Name="ShipSizeSmall"/>
     <SimulationDescriptorReference Name="ShipFactionVaulters"/>
+    <SimulationDescriptorReference Name="CameraAnchorVaulters"/>
     <SimulationDescriptorReference Name="ShipHull03"/>
     <SimulationDescriptorReference Name="CannotHaveWeapon"/>
 
@@ -1405,6 +1416,7 @@
 		<SimulationDescriptorReference Name="WeaponAvailabilityKinetic"/>
 		<SimulationDescriptorReference Name="ShipSizeSmall"/>
 		<SimulationDescriptorReference Name="ShipFactionVampirilis"/>
+		<SimulationDescriptorReference Name="CameraAnchorVampirilis"/>
 		<SimulationDescriptorReference Name="ShipHull03"/>
 
 		<ShipDesignLayout>

--- a/Endless Space Competitive Mod/Simulation/Battles/HullDefinitions[Coordinator].xml
+++ b/Endless Space Competitive Mod/Simulation/Battles/HullDefinitions[Coordinator].xml
@@ -15,6 +15,7 @@
 		<SimulationDescriptorReference Name="WeaponAvailabilityLaser"/>
 		<SimulationDescriptorReference Name="ShipSizeMedium"/>
 		<SimulationDescriptorReference Name="ShipFactionCravers"/>
+		<SimulationDescriptorReference Name="CameraAnchorCravers"/>
 		<SimulationDescriptorReference Name="ShipHull02"/>
 
 		<ShipDesignLayout>
@@ -260,6 +261,7 @@
 		<SimulationDescriptorReference Name="WeaponAvailabilityLaser"/>
 		<SimulationDescriptorReference Name="ShipSizeMedium"/>
 		<SimulationDescriptorReference Name="ShipFactionMajorHisshos"/>
+		<SimulationDescriptorReference Name="CameraAnchorMajorHisshos"/>
 		<SimulationDescriptorReference Name="ShipHull02"/>
 
 		<ShipDesignLayout>
@@ -491,6 +493,7 @@
 		<SimulationDescriptorReference Name="WeaponAvailabilityLaser"/>
 		<SimulationDescriptorReference Name="ShipSizeMedium"/>
 		<SimulationDescriptorReference Name="ShipFactionHoratio"/>
+		<SimulationDescriptorReference Name="CameraAnchorHoratio"/>
 		<SimulationDescriptorReference Name="ShipHull02"/>
 
 		<ShipDesignLayout>
@@ -716,6 +719,7 @@
 		<SimulationDescriptorReference Name="WeaponAvailabilityLaser"/>
 		<SimulationDescriptorReference Name="ShipSizeMedium"/>
 		<SimulationDescriptorReference Name="ShipFactionVenetians"/>
+		<SimulationDescriptorReference Name="CameraAnchorVenetians"/>
 		<SimulationDescriptorReference Name="ShipHull02"/>
 
 		<ShipDesignLayout>
@@ -964,6 +968,7 @@
 		<SimulationDescriptorReference Name="WeaponAvailabilityLaser"/>
 		<SimulationDescriptorReference Name="ShipSizeMedium"/>
 		<SimulationDescriptorReference Name="ShipFactionTemplars"/>
+		<SimulationDescriptorReference Name="CameraAnchorTemplars"/>
 		<SimulationDescriptorReference Name="ShipHull02"/>
 
 		<ShipDesignLayout>
@@ -1201,6 +1206,7 @@
 		<SimulationDescriptorReference Name="WeaponAvailabilityLaser"/>
 		<SimulationDescriptorReference Name="ShipSizeMedium"/>
 		<SimulationDescriptorReference Name="ShipFactionTimeLords"/>
+		<SimulationDescriptorReference Name="CameraAnchorTimeLords"/>
 		<SimulationDescriptorReference Name="ShipHull02"/>
 
 		<ShipDesignLayout>
@@ -1403,6 +1409,7 @@
 		<SimulationDescriptorReference Name="WeaponAvailabilityLaser"/>
 		<SimulationDescriptorReference Name="ShipSizeMedium"/>
 		<SimulationDescriptorReference Name="ShipFactionSophons"/>
+		<SimulationDescriptorReference Name="CameraAnchorSophons"/>
 		<SimulationDescriptorReference Name="ShipHull02"/>
 
 		<ShipDesignLayout>
@@ -1626,6 +1633,7 @@
 		<SimulationDescriptorReference Name="WeaponAvailabilityLaser"/>
 		<SimulationDescriptorReference Name="ShipSizeMedium"/>
 		<SimulationDescriptorReference Name="ShipFactionUmbralChoir"/>
+		<SimulationDescriptorReference Name="CameraAnchorUmbralChoir"/>
 		<SimulationDescriptorReference Name="ShipHull02"/>
 
 		<ShipDesignLayout>
@@ -1837,6 +1845,7 @@
 		<SimulationDescriptorReference Name="WeaponAvailabilityLaser"/>
 		<SimulationDescriptorReference Name="ShipSizeMedium"/>
 		<SimulationDescriptorReference Name="ShipFactionTerrans"/>
+		<SimulationDescriptorReference Name="CameraAnchorTerrans"/>
 		<SimulationDescriptorReference Name="ShipHull02"/>
 
 		<ShipDesignLayout>
@@ -2070,6 +2079,7 @@
 		<SimulationDescriptorReference Name="WeaponAvailabilityLaser"/>
 		<SimulationDescriptorReference Name="ShipSizeMedium"/>
 		<SimulationDescriptorReference Name="ShipFactionUnfallen"/>
+		<SimulationDescriptorReference Name="CameraAnchorUnfallen"/>
 		<SimulationDescriptorReference Name="ShipHull02"/>
 
 		<ShipDesignLayout>
@@ -2302,6 +2312,7 @@
 		<SimulationDescriptorReference Name="WeaponAvailabilityLaser"/>
 		<SimulationDescriptorReference Name="ShipSizeMedium"/>
 		<SimulationDescriptorReference Name="ShipFactionVaulters"/>
+		<SimulationDescriptorReference Name="CameraAnchorVaulters"/>
 		<SimulationDescriptorReference Name="ShipHull02"/>
 
 		<ShipDesignLayout>
@@ -2536,6 +2547,7 @@
 		<SimulationDescriptorReference Name="WeaponAvailabilityLaser"/>
 		<SimulationDescriptorReference Name="ShipSizeMedium"/>
 		<SimulationDescriptorReference Name="ShipFactionVampirilis"/>
+		<SimulationDescriptorReference Name="CameraAnchorVampirilis"/>
 		<SimulationDescriptorReference Name="ShipHull02"/>
 
 		<ShipDesignLayout>

--- a/Endless Space Competitive Mod/Simulation/Battles/HullDefinitions[Defender].xml
+++ b/Endless Space Competitive Mod/Simulation/Battles/HullDefinitions[Defender].xml
@@ -14,6 +14,7 @@
     <SimulationDescriptorReference Name="WeaponAvailabilityKinetic"/>
     <SimulationDescriptorReference Name="ShipSizeSmall"/>
     <SimulationDescriptorReference Name="ShipFactionCravers"/>
+    <SimulationDescriptorReference Name="CameraAnchorCravers"/>
     <SimulationDescriptorReference Name="ShipHull02"/>
 
     <ShipDesignLayout>
@@ -166,6 +167,7 @@
     <SimulationDescriptorReference Name="WeaponAvailabilityKinetic"/>
     <SimulationDescriptorReference Name="ShipSizeSmall"/>
     <SimulationDescriptorReference Name="ShipFactionMajorHisshos"/>
+    <SimulationDescriptorReference Name="CameraAnchorMajorHisshos"/>
     <SimulationDescriptorReference Name="ShipHull02"/>
 
     <ShipDesignLayout>
@@ -331,6 +333,7 @@
     <SimulationDescriptorReference Name="WeaponAvailabilityKinetic"/>
     <SimulationDescriptorReference Name="ShipSizeSmall"/>
     <SimulationDescriptorReference Name="ShipFactionHoratio"/>
+    <SimulationDescriptorReference Name="CameraAnchorHoratio"/>
     <SimulationDescriptorReference Name="ShipHull02"/>
 
     <ShipDesignLayout>
@@ -481,6 +484,7 @@
     <SimulationDescriptorReference Name="WeaponAvailabilityKinetic"/>
     <SimulationDescriptorReference Name="ShipSizeSmall"/>
     <SimulationDescriptorReference Name="ShipFactionVenetians"/>
+    <SimulationDescriptorReference Name="CameraAnchorVenetians"/>
     <SimulationDescriptorReference Name="ShipHull02"/>
 
     <ShipDesignLayout>
@@ -650,6 +654,7 @@
     <SimulationDescriptorReference Name="WeaponAvailabilityKinetic"/>
     <SimulationDescriptorReference Name="ShipSizeSmall"/>
     <SimulationDescriptorReference Name="ShipFactionTemplars"/>
+    <SimulationDescriptorReference Name="CameraAnchorTemplars"/>
     <SimulationDescriptorReference Name="ShipHull02"/>
 
     <ShipDesignLayout>
@@ -818,6 +823,7 @@
     <SimulationDescriptorReference Name="WeaponAvailabilityKinetic"/>
     <SimulationDescriptorReference Name="ShipSizeSmall"/>
     <SimulationDescriptorReference Name="ShipFactionTimeLords"/>
+    <SimulationDescriptorReference Name="CameraAnchorTimeLords"/>
     <SimulationDescriptorReference Name="ShipHull02"/>
 
     <ShipDesignLayout>
@@ -978,6 +984,7 @@
     <SimulationDescriptorReference Name="WeaponAvailabilityKinetic"/>
     <SimulationDescriptorReference Name="ShipSizeSmall"/>
     <SimulationDescriptorReference Name="ShipFactionSophons"/>
+    <SimulationDescriptorReference Name="CameraAnchorSophons"/>
     <SimulationDescriptorReference Name="ShipHull02"/>
 
     <ShipDesignLayout>
@@ -1144,6 +1151,7 @@
     <SimulationDescriptorReference Name="WeaponAvailabilityKinetic"/>
     <SimulationDescriptorReference Name="ShipSizeSmall"/>
     <SimulationDescriptorReference Name="ShipFactionUmbralChoir"/>
+    <SimulationDescriptorReference Name="CameraAnchorUmbralChoir"/>
     <SimulationDescriptorReference Name="ShipHull02"/>
 
     <ShipDesignLayout>
@@ -1283,6 +1291,7 @@
     <SimulationDescriptorReference Name="WeaponAvailabilityKinetic"/>
     <SimulationDescriptorReference Name="ShipSizeSmall"/>
     <SimulationDescriptorReference Name="ShipFactionTerrans"/>
+    <SimulationDescriptorReference Name="CameraAnchorTerrans"/>
     <SimulationDescriptorReference Name="ShipHull02"/>
 
     <ShipDesignLayout>
@@ -1425,6 +1434,7 @@
     <SimulationDescriptorReference Name="WeaponAvailabilityKinetic"/>
     <SimulationDescriptorReference Name="ShipSizeSmall"/>
     <SimulationDescriptorReference Name="ShipFactionUnfallen"/>
+    <SimulationDescriptorReference Name="CameraAnchorUnfallen"/>
     <SimulationDescriptorReference Name="ShipHull02"/>
 
     <ShipDesignLayout>
@@ -1561,6 +1571,7 @@
     <SimulationDescriptorReference Name="WeaponAvailabilityKinetic"/>
     <SimulationDescriptorReference Name="ShipSizeSmall"/>
     <SimulationDescriptorReference Name="ShipFactionVaulters"/>
+    <SimulationDescriptorReference Name="CameraAnchorVaulters"/>
     <SimulationDescriptorReference Name="ShipHull02"/>
 
     <ShipDesignLayout>
@@ -1712,6 +1723,7 @@
     <SimulationDescriptorReference Name="WeaponAvailabilityKinetic"/>
     <SimulationDescriptorReference Name="ShipSizeSmall"/>
     <SimulationDescriptorReference Name="ShipFactionVampirilis"/>
+    <SimulationDescriptorReference Name="CameraAnchorVampirilis"/>
     <SimulationDescriptorReference Name="ShipHull02"/>
 
     <ShipDesignLayout>

--- a/Endless Space Competitive Mod/Simulation/Battles/HullDefinitions[Explorer].xml
+++ b/Endless Space Competitive Mod/Simulation/Battles/HullDefinitions[Explorer].xml
@@ -15,6 +15,7 @@
 		<SimulationDescriptorReference Name="WeaponAvailabilityKinetic"/>
 		<SimulationDescriptorReference Name="ShipSizeSmall"/>
 		<SimulationDescriptorReference Name="ShipFactionCravers"/>
+		<SimulationDescriptorReference Name="CameraAnchorCravers"/>
 		<SimulationDescriptorReference Name="ShipHull01"/>
 
 		<ShipDesignLayout>
@@ -147,6 +148,7 @@
 		<SimulationDescriptorReference Name="WeaponAvailabilityKinetic"/>
 		<SimulationDescriptorReference Name="ShipSizeSmall"/>
 		<SimulationDescriptorReference Name="ShipFactionCravers"/>
+		<SimulationDescriptorReference Name="CameraAnchorCravers"/>
 		<SimulationDescriptorReference Name="ShipHull01"/>
 
 		<ShipDesignLayout>
@@ -277,6 +279,7 @@
 		<SimulationDescriptorReference Name="WeaponAvailabilityKinetic"/>
 		<SimulationDescriptorReference Name="ShipSizeSmall"/>
 		<SimulationDescriptorReference Name="ShipFactionMajorHisshos"/>
+		<SimulationDescriptorReference Name="CameraAnchorMajorHisshos"/>
 		<SimulationDescriptorReference Name="ShipHull01"/>
 
 		<ShipDesignLayout>
@@ -420,6 +423,7 @@
 		<SimulationDescriptorReference Name="WeaponAvailabilityKinetic"/>
 		<SimulationDescriptorReference Name="ShipSizeSmall"/>
 		<SimulationDescriptorReference Name="ShipFactionMajorHisshos"/>
+		<SimulationDescriptorReference Name="CameraAnchorMajorHisshos"/>
 		<SimulationDescriptorReference Name="ShipHull01"/>
 
 		<ShipDesignLayout>
@@ -564,6 +568,7 @@
 		<SimulationDescriptorReference Name="WeaponAvailabilityKinetic"/>
 		<SimulationDescriptorReference Name="ShipSizeSmall"/>
 		<SimulationDescriptorReference Name="ShipFactionHoratio"/>
+		<SimulationDescriptorReference Name="CameraAnchorHoratio"/>
 		<SimulationDescriptorReference Name="ShipHull01"/>
 
 		<ShipDesignLayout>
@@ -679,6 +684,7 @@
 		<SimulationDescriptorReference Name="WeaponAvailabilityKinetic"/>
 		<SimulationDescriptorReference Name="ShipSizeSmall"/>
 		<SimulationDescriptorReference Name="ShipFactionHoratio"/>
+		<SimulationDescriptorReference Name="CameraAnchorHoratio"/>
 		<SimulationDescriptorReference Name="ShipHull01"/>
 
 		<ShipDesignLayout>
@@ -795,6 +801,7 @@
 		<SimulationDescriptorReference Name="WeaponAvailabilityKinetic"/>
 		<SimulationDescriptorReference Name="ShipSizeSmall"/>
 		<SimulationDescriptorReference Name="ShipFactionVenetians"/>
+		<SimulationDescriptorReference Name="CameraAnchorVenetians"/>
 		<SimulationDescriptorReference Name="ShipHull01"/>
 
 		<ShipDesignLayout>
@@ -924,6 +931,7 @@
 		<SimulationDescriptorReference Name="WeaponAvailabilityKinetic"/>
 		<SimulationDescriptorReference Name="ShipSizeSmall"/>
 		<SimulationDescriptorReference Name="ShipFactionVenetians"/>
+		<SimulationDescriptorReference Name="CameraAnchorVenetians"/>
 		<SimulationDescriptorReference Name="ShipHull01"/>
 
 		<ShipDesignLayout>
@@ -1052,6 +1060,7 @@
 		<SimulationDescriptorReference Name="WeaponAvailabilityKinetic"/>
 		<SimulationDescriptorReference Name="ShipSizeSmall"/>
 		<SimulationDescriptorReference Name="ShipFactionTemplars"/>
+		<SimulationDescriptorReference Name="CameraAnchorTemplars"/>
 		<SimulationDescriptorReference Name="ShipHull01"/>
 
 		<ShipDesignLayout>
@@ -1180,6 +1189,7 @@
 		<SimulationDescriptorReference Name="WeaponAvailabilityKinetic"/>
 		<SimulationDescriptorReference Name="ShipSizeSmall"/>
 		<SimulationDescriptorReference Name="ShipFactionTemplars"/>
+		<SimulationDescriptorReference Name="CameraAnchorTemplars"/>
 		<SimulationDescriptorReference Name="ShipHull01"/>
 
 		<ShipDesignLayout>
@@ -1300,6 +1310,7 @@
 		<SimulationDescriptorReference Name="WeaponAvailabilityKinetic"/>
 		<SimulationDescriptorReference Name="ShipSizeSmall"/>
 		<SimulationDescriptorReference Name="ShipFactionTimeLords"/>
+		<SimulationDescriptorReference Name="CameraAnchorTimeLords"/>
 		<SimulationDescriptorReference Name="ShipHull01"/>
 
 		<ShipDesignLayout>
@@ -1433,6 +1444,7 @@
 		<SimulationDescriptorReference Name="WeaponAvailabilityKinetic"/>
 		<SimulationDescriptorReference Name="ShipSizeSmall"/>
 		<SimulationDescriptorReference Name="ShipFactionTimeLords"/>
+		<SimulationDescriptorReference Name="CameraAnchorTimeLords"/>
 		<SimulationDescriptorReference Name="ShipHull01"/>
 
 		<ShipDesignLayout>
@@ -1566,6 +1578,7 @@
 		<SimulationDescriptorReference Name="WeaponAvailabilityKinetic"/>
 		<SimulationDescriptorReference Name="ShipSizeSmall"/>
 		<SimulationDescriptorReference Name="ShipFactionSophons"/>
+		<SimulationDescriptorReference Name="CameraAnchorSophons"/>
 		<SimulationDescriptorReference Name="ShipHull01"/>
 
 		<ShipDesignLayout>
@@ -1691,6 +1704,7 @@
 		<SimulationDescriptorReference Name="WeaponAvailabilityKinetic"/>
 		<SimulationDescriptorReference Name="ShipSizeSmall"/>
 		<SimulationDescriptorReference Name="ShipFactionSophons"/>
+		<SimulationDescriptorReference Name="CameraAnchorSophons"/>
 		<SimulationDescriptorReference Name="ShipHull01"/>
 
 		<ShipDesignLayout>
@@ -1814,6 +1828,7 @@
 		<SimulationDescriptorReference Name="WeaponAvailabilityKinetic"/>
 		<SimulationDescriptorReference Name="ShipSizeSmall"/>
 		<SimulationDescriptorReference Name="ShipFactionUmbralChoir"/>
+		<SimulationDescriptorReference Name="CameraAnchorUmbralChoir"/>
 		<SimulationDescriptorReference Name="ShipHull03"/>
 
 		<ShipDesignLayout>
@@ -1908,6 +1923,7 @@
 		<SimulationDescriptorReference Name="WeaponAvailabilityKinetic"/>
 		<SimulationDescriptorReference Name="ShipSizeSmall"/>
 		<SimulationDescriptorReference Name="ShipFactionUmbralChoir"/>
+		<SimulationDescriptorReference Name="CameraAnchorUmbralChoir"/>
 		<SimulationDescriptorReference Name="ShipHull03"/>
 
 		<ShipDesignLayout>
@@ -2006,6 +2022,7 @@
 		<SimulationDescriptorReference Name="WeaponAvailabilityKinetic"/>
 		<SimulationDescriptorReference Name="ShipSizeSmall"/>
 		<SimulationDescriptorReference Name="ShipFactionTerrans"/>
+		<SimulationDescriptorReference Name="CameraAnchorTerrans"/>
 		<SimulationDescriptorReference Name="ShipHull01"/>
 
 		<ShipDesignLayout>
@@ -2145,6 +2162,7 @@
 		<SimulationDescriptorReference Name="WeaponAvailabilityKinetic"/>
 		<SimulationDescriptorReference Name="ShipSizeSmall"/>
 		<SimulationDescriptorReference Name="ShipFactionTerrans"/>
+		<SimulationDescriptorReference Name="CameraAnchorTerrans"/>
 		<SimulationDescriptorReference Name="ShipHull01"/>
 
 		<ShipDesignLayout>
@@ -2279,6 +2297,7 @@
 		<SimulationDescriptorReference Name="WeaponAvailabilityKinetic"/>
 		<SimulationDescriptorReference Name="ShipSizeSmall"/>
 		<SimulationDescriptorReference Name="ShipFactionUnfallen"/>
+		<SimulationDescriptorReference Name="CameraAnchorUnfallen"/>
 		<SimulationDescriptorReference Name="ShipHull01"/>
 
 		<ShipDesignLayout>
@@ -2399,6 +2418,7 @@
 		<SimulationDescriptorReference Name="WeaponAvailabilityKinetic"/>
 		<SimulationDescriptorReference Name="ShipSizeSmall"/>
 		<SimulationDescriptorReference Name="ShipFactionUnfallen"/>
+		<SimulationDescriptorReference Name="CameraAnchorUnfallen"/>
 		<SimulationDescriptorReference Name="ShipHull01"/>
 
 		<ShipDesignLayout>
@@ -2517,6 +2537,7 @@
 		<SimulationDescriptorReference Name="WeaponAvailabilityKinetic"/>
 		<SimulationDescriptorReference Name="ShipSizeSmall"/>
 		<SimulationDescriptorReference Name="ShipFactionVaulters"/>
+		<SimulationDescriptorReference Name="CameraAnchorVaulters"/>
 		<SimulationDescriptorReference Name="ShipHull01"/>
 
 		<ShipDesignLayout>
@@ -2642,6 +2663,7 @@
 		<SimulationDescriptorReference Name="WeaponAvailabilityKinetic"/>
 		<SimulationDescriptorReference Name="ShipSizeSmall"/>
 		<SimulationDescriptorReference Name="ShipFactionVaulters"/>
+		<SimulationDescriptorReference Name="CameraAnchorVaulters"/>
 		<SimulationDescriptorReference Name="ShipHull01"/>
 
 		<ShipDesignLayout>
@@ -2768,6 +2790,7 @@
 		<SimulationDescriptorReference Name="WeaponAvailabilityKinetic"/>
 		<SimulationDescriptorReference Name="ShipSizeSmall"/>
 		<SimulationDescriptorReference Name="ShipFactionVampirilis"/>
+		<SimulationDescriptorReference Name="CameraAnchorVampirilis"/>
 		<SimulationDescriptorReference Name="ShipHull01"/>
 
 		<ShipDesignLayout>
@@ -2895,6 +2918,7 @@
 		<SimulationDescriptorReference Name="WeaponAvailabilityKinetic"/>
 		<SimulationDescriptorReference Name="ShipSizeSmall"/>
 		<SimulationDescriptorReference Name="ShipFactionVampirilis"/>
+		<SimulationDescriptorReference Name="CameraAnchorVampirilis"/>
 		<SimulationDescriptorReference Name="ShipHull01"/>
 
 		<ShipDesignLayout>

--- a/Endless Space Competitive Mod/Simulation/Battles/HullDefinitions[Hero].xml
+++ b/Endless Space Competitive Mod/Simulation/Battles/HullDefinitions[Hero].xml
@@ -15,6 +15,7 @@
     <SimulationDescriptorReference Name="WeaponAvailabilityMissile"/>
     <SimulationDescriptorReference Name="ShipSizeSmall"/>
     <SimulationDescriptorReference Name="ShipFactionHeroes"/>
+    <SimulationDescriptorReference Name="CameraAnchorHeroes"/>
     <SimulationDescriptorReference Name="ShipHull03"/>
 
     <ShipDesignLayout>
@@ -169,6 +170,7 @@
     <SimulationDescriptorReference Name="WeaponAvailabilityMissile"/>
     <SimulationDescriptorReference Name="ShipSizeSmall"/>
     <SimulationDescriptorReference Name="ShipFactionHeroes"/>
+    <SimulationDescriptorReference Name="CameraAnchorHeroes"/>
     <SimulationDescriptorReference Name="ShipHull04"/>
 
     <ShipDesignLayout>
@@ -323,6 +325,7 @@
     <SimulationDescriptorReference Name="WeaponAvailabilityMissile"/>
     <SimulationDescriptorReference Name="ShipSizeSmall"/>
     <SimulationDescriptorReference Name="ShipFactionHeroes"/>
+    <SimulationDescriptorReference Name="CameraAnchorHeroes"/>
     <SimulationDescriptorReference Name="ShipHull01"/>
     <SimulationDescriptorReference Name="ShipStatBonus2ProbeRegeneration"/>
 
@@ -489,6 +492,7 @@
     <SimulationDescriptorReference Name="WeaponAvailabilityMissile"/>
     <SimulationDescriptorReference Name="ShipSizeSmall"/>
     <SimulationDescriptorReference Name="ShipFactionHeroes"/>
+    <SimulationDescriptorReference Name="CameraAnchorHeroes"/>
     <SimulationDescriptorReference Name="ShipHull01"/>
     <SimulationDescriptorReference Name="GreenManShip2"/>
     <SimulationDescriptorReference Name="ShipStatBonus2ProbeRegeneration"/>
@@ -651,6 +655,7 @@
     <SimulationDescriptorReference Name="WeaponAvailabilityMissile"/>
     <SimulationDescriptorReference Name="ShipSizeSmall"/>
     <SimulationDescriptorReference Name="ShipFactionHeroesUCHero05"/>
+    <SimulationDescriptorReference Name="CameraAnchorHeroesUCHero05"/>
     <SimulationDescriptorReference Name="ShipHull01"/>
     <SimulationDescriptorReference Name="ShipStatBonus2ProbeRegeneration"/>
 
@@ -818,6 +823,7 @@
     <SimulationDescriptorReference Name="WeaponAvailabilityMissile"/>
     <SimulationDescriptorReference Name="ShipSizeSmall"/>
     <SimulationDescriptorReference Name="ShipFactionHeroes"/>
+    <SimulationDescriptorReference Name="CameraAnchorHeroes"/>
     <SimulationDescriptorReference Name="ShipHull02"/>
     <SimulationDescriptorReference Name="ShipStatBonus1TargetingFocus"/>
 
@@ -996,6 +1002,7 @@
     <SimulationDescriptorReference Name="WeaponAvailabilityMissile"/>
     <SimulationDescriptorReference Name="ShipSizeSmall"/>
     <SimulationDescriptorReference Name="ShipFactionHeroesPirate"/>
+    <SimulationDescriptorReference Name="CameraAnchorHeroesPirate"/>
     <SimulationDescriptorReference Name="ShipHull05"/>
     <SimulationDescriptorReference Name="ShipStatBonus1TargetingFocus"/>
 

--- a/Endless Space Competitive Mod/Simulation/Battles/HullDefinitions[Hunter].xml
+++ b/Endless Space Competitive Mod/Simulation/Battles/HullDefinitions[Hunter].xml
@@ -16,6 +16,7 @@
 		<SimulationDescriptorReference Name="WeaponAvailabilityLaser"/>
 		<SimulationDescriptorReference Name="ShipSizeMedium"/>
 		<SimulationDescriptorReference Name="ShipFactionCravers"/>
+		<SimulationDescriptorReference Name="CameraAnchorCravers"/>
 		<SimulationDescriptorReference Name="ShipHull01"/>
 
 		<ShipDesignLayout>
@@ -261,6 +262,7 @@
 		<SimulationDescriptorReference Name="WeaponAvailabilityLaser"/>
 		<SimulationDescriptorReference Name="ShipSizeMedium"/>
 		<SimulationDescriptorReference Name="ShipFactionMajorHisshos"/>
+		<SimulationDescriptorReference Name="CameraAnchorMajorHisshos"/>
 		<SimulationDescriptorReference Name="ShipHull01"/>
 
 		<ShipDesignLayout>
@@ -531,6 +533,7 @@
 		<SimulationDescriptorReference Name="WeaponAvailabilityLaser"/>
 		<SimulationDescriptorReference Name="ShipSizeMedium"/>
 		<SimulationDescriptorReference Name="ShipFactionHoratio"/>
+		<SimulationDescriptorReference Name="CameraAnchorHoratio"/>
 		<SimulationDescriptorReference Name="ShipHull01"/>
 
 		<ShipDesignLayout>
@@ -789,6 +792,7 @@
 		<SimulationDescriptorReference Name="WeaponAvailabilityLaser"/>
 		<SimulationDescriptorReference Name="ShipSizeMedium"/>
 		<SimulationDescriptorReference Name="ShipFactionVenetians"/>
+		<SimulationDescriptorReference Name="CameraAnchorVenetians"/>
 		<SimulationDescriptorReference Name="ShipHull01"/>
 
 		<ShipDesignLayout>
@@ -1055,6 +1059,7 @@
 		<SimulationDescriptorReference Name="WeaponAvailabilityLaser"/>
 		<SimulationDescriptorReference Name="ShipSizeMedium"/>
 		<SimulationDescriptorReference Name="ShipFactionTemplars"/>
+		<SimulationDescriptorReference Name="CameraAnchorTemplars"/>
 		<SimulationDescriptorReference Name="ShipHull01"/>
 
 		<ShipDesignLayout>
@@ -1320,6 +1325,7 @@
 		<SimulationDescriptorReference Name="WeaponAvailabilityLaser"/>
 		<SimulationDescriptorReference Name="ShipSizeMedium"/>
 		<SimulationDescriptorReference Name="ShipFactionTimeLords"/>
+		<SimulationDescriptorReference Name="CameraAnchorTimeLords"/>
 		<SimulationDescriptorReference Name="ShipHull01"/>
 
 		<ShipDesignLayout>
@@ -1633,6 +1639,7 @@
 		<SimulationDescriptorReference Name="WeaponAvailabilityLaser"/>
 		<SimulationDescriptorReference Name="ShipSizeMedium"/>
 		<SimulationDescriptorReference Name="ShipFactionSophons"/>
+		<SimulationDescriptorReference Name="CameraAnchorSophons"/>
 		<SimulationDescriptorReference Name="ShipHull01"/>
 
 		<ShipDesignLayout>
@@ -1886,6 +1893,7 @@
 		<SimulationDescriptorReference Name="WeaponAvailabilityLaser"/>
 		<SimulationDescriptorReference Name="ShipSizeMedium"/>
 		<SimulationDescriptorReference Name="ShipFactionUmbralChoir"/>
+		<SimulationDescriptorReference Name="CameraAnchorUmbralChoir"/>
 		<SimulationDescriptorReference Name="ShipHull01"/>
 
 		<ShipDesignLayout>
@@ -2135,6 +2143,7 @@
 		<SimulationDescriptorReference Name="WeaponAvailabilityLaser"/>
 		<SimulationDescriptorReference Name="ShipSizeMedium"/>
 		<SimulationDescriptorReference Name="ShipFactionTerrans"/>
+		<SimulationDescriptorReference Name="CameraAnchorTerrans"/>
 		<SimulationDescriptorReference Name="ShipHull01"/>
 
 		<ShipDesignLayout>
@@ -2395,6 +2404,7 @@
 		<SimulationDescriptorReference Name="WeaponAvailabilityLaser"/>
 		<SimulationDescriptorReference Name="ShipSizeMedium"/>
 		<SimulationDescriptorReference Name="ShipFactionUnfallen"/>
+		<SimulationDescriptorReference Name="CameraAnchorUnfallen"/>
 		<SimulationDescriptorReference Name="ShipHull01"/>
 
 		<ShipDesignLayout>
@@ -2649,6 +2659,7 @@
 		<SimulationDescriptorReference Name="WeaponAvailabilityLaser"/>
 		<SimulationDescriptorReference Name="ShipSizeMedium"/>
 		<SimulationDescriptorReference Name="ShipFactionVaulters"/>
+		<SimulationDescriptorReference Name="CameraAnchorVaulters"/>
 		<SimulationDescriptorReference Name="ShipHull01"/>
 
 		<ShipDesignLayout>
@@ -2902,6 +2913,7 @@
 		<SimulationDescriptorReference Name="WeaponAvailabilityLaser"/>
 		<SimulationDescriptorReference Name="ShipSizeMedium"/>
 		<SimulationDescriptorReference Name="ShipFactionVampirilis"/>
+		<SimulationDescriptorReference Name="CameraAnchorVampirilis"/>
 		<SimulationDescriptorReference Name="ShipHull01"/>
 
 		<ShipDesignLayout>

--- a/Endless Space Competitive Mod/Simulation/Battles/HullDefinitions[Leecher].xml
+++ b/Endless Space Competitive Mod/Simulation/Battles/HullDefinitions[Leecher].xml
@@ -13,6 +13,7 @@
 		<SimulationDescriptorReference Name="ClassHullCravers"/>
 		<SimulationDescriptorReference Name="ShipSizeSmall"/>
 		<SimulationDescriptorReference Name="ShipFactionCravers"/>
+		<SimulationDescriptorReference Name="CameraAnchorCravers"/>
 		<SimulationDescriptorReference Name="ShipHull03"/>
 		<SimulationDescriptorReference Name="WeaponAvailabilityKinetic"/>
 
@@ -124,6 +125,7 @@
 		<SimulationDescriptorReference Name="ClassHullSmallCivilian"/>
 		<SimulationDescriptorReference Name="ShipSizeSmall"/>
 		<SimulationDescriptorReference Name="ShipFactionMajorHisshos"/>
+		<SimulationDescriptorReference Name="CameraAnchorMajorHisshos"/>
 		<SimulationDescriptorReference Name="ShipHull03"/>
 		<SimulationDescriptorReference Name="WeaponAvailabilityKinetic"/>
 
@@ -233,6 +235,7 @@
 		<SimulationDescriptorReference Name="ClassHullSmallCivilian"/>
 		<SimulationDescriptorReference Name="ShipSizeSmall"/>
 		<SimulationDescriptorReference Name="ShipFactionHoratio"/>
+		<SimulationDescriptorReference Name="CameraAnchorHoratio"/>
 		<SimulationDescriptorReference Name="ShipHull03"/>
 		<SimulationDescriptorReference Name="WeaponAvailabilityKinetic"/>
 
@@ -344,6 +347,7 @@
 		<SimulationDescriptorReference Name="ClassHullSmallCivilian"/>
 		<SimulationDescriptorReference Name="ShipSizeSmall"/>
 		<SimulationDescriptorReference Name="ShipFactionVenetians"/>
+		<SimulationDescriptorReference Name="CameraAnchorVenetians"/>
 		<SimulationDescriptorReference Name="ShipHull03"/>
 		<SimulationDescriptorReference Name="WeaponAvailabilityKinetic"/>
 
@@ -453,6 +457,7 @@
 		<SimulationDescriptorReference Name="ClassHullSmallCivilian"/>
 		<SimulationDescriptorReference Name="ShipSizeSmall"/>
 		<SimulationDescriptorReference Name="ShipFactionTemplars"/>
+		<SimulationDescriptorReference Name="CameraAnchorTemplars"/>
 		<SimulationDescriptorReference Name="ShipHull03"/>
 		<SimulationDescriptorReference Name="WeaponAvailabilityKinetic"/>
 
@@ -562,6 +567,7 @@
 		<SimulationDescriptorReference Name="ClassHullSmallCivilian"/>
 		<SimulationDescriptorReference Name="ShipSizeSmall"/>
 		<SimulationDescriptorReference Name="ShipFactionTimeLords"/>
+		<SimulationDescriptorReference Name="CameraAnchorTimeLords"/>
 		<SimulationDescriptorReference Name="ShipHull03"/>
 		<SimulationDescriptorReference Name="WeaponAvailabilityKinetic"/>
 
@@ -672,6 +678,7 @@
 		<SimulationDescriptorReference Name="ClassHullSmallCivilian"/>
 		<SimulationDescriptorReference Name="ShipSizeSmall"/>
 		<SimulationDescriptorReference Name="ShipFactionSophons"/>
+		<SimulationDescriptorReference Name="CameraAnchorSophons"/>
 		<SimulationDescriptorReference Name="ShipHull03"/>
 		<SimulationDescriptorReference Name="WeaponAvailabilityKinetic"/>
 
@@ -782,6 +789,7 @@
 		<SimulationDescriptorReference Name="ClassHullSmallCivilian"/>
 		<SimulationDescriptorReference Name="ShipSizeSmall"/>
 		<SimulationDescriptorReference Name="ShipFactionUmbralChoir"/>
+		<SimulationDescriptorReference Name="CameraAnchorUmbralChoir"/>
 		<SimulationDescriptorReference Name="ShipHull03"/>
 		<SimulationDescriptorReference Name="WeaponAvailabilityKinetic"/>
 
@@ -891,6 +899,7 @@
 		<SimulationDescriptorReference Name="ClassHullSmallCivilian"/>
 		<SimulationDescriptorReference Name="ShipSizeSmall"/>
 		<SimulationDescriptorReference Name="ShipFactionTerrans"/>
+		<SimulationDescriptorReference Name="CameraAnchorTerrans"/>
 		<SimulationDescriptorReference Name="ShipHull03"/>
 		<SimulationDescriptorReference Name="WeaponAvailabilityKinetic"/>
 
@@ -1000,6 +1009,7 @@
 		<SimulationDescriptorReference Name="ClassHullSmallCivilian"/>
 		<SimulationDescriptorReference Name="ShipSizeSmall"/>
 		<SimulationDescriptorReference Name="ShipFactionUnfallen"/>
+		<SimulationDescriptorReference Name="CameraAnchorUnfallen"/>
 		<SimulationDescriptorReference Name="ShipHull03"/>
 		<SimulationDescriptorReference Name="WeaponAvailabilityKinetic"/>
 
@@ -1109,6 +1119,7 @@
 		<SimulationDescriptorReference Name="ClassHullSmallCivilian"/>
 		<SimulationDescriptorReference Name="ShipSizeSmall"/>
 		<SimulationDescriptorReference Name="ShipFactionVaulters"/>
+		<SimulationDescriptorReference Name="CameraAnchorVaulters"/>
 		<SimulationDescriptorReference Name="ShipHull03"/>
 		<SimulationDescriptorReference Name="WeaponAvailabilityKinetic"/>
 
@@ -1223,6 +1234,7 @@
 		<SimulationDescriptorReference Name="WeaponAvailabilityKinetic"/>
 		<SimulationDescriptorReference Name="ShipSizeSmall"/>
 		<SimulationDescriptorReference Name="ShipFactionVampirilis"/>
+		<SimulationDescriptorReference Name="CameraAnchorVampirilis"/>
 		<SimulationDescriptorReference Name="ShipHull03"/>
 
 		<ShipDesignLayout>

--- a/Endless Space Competitive Mod/Simulation/Battles/HullDefinitions[Minor].xml
+++ b/Endless Space Competitive Mod/Simulation/Battles/HullDefinitions[Minor].xml
@@ -17,6 +17,7 @@
 		<SimulationDescriptorReference Name="ClassHullSmallAttack"/>
 		<SimulationDescriptorReference Name="ShipSizeSmall"/>
 		<SimulationDescriptorReference Name="ShipFactionMinorFactionInsectoid"/>
+		<SimulationDescriptorReference Name="CameraAnchorMinorFactionInsectoid"/>
 		<SimulationDescriptorReference Name="ShipHull01"/>
 		<SimulationDescriptorReference Name="CanPrivateer"/>
 		<SimulationDescriptorReference Name="IncreasedUpkeep"/>
@@ -190,6 +191,7 @@
 		<SimulationDescriptorReference Name="ClassHullMediumAttack"/>
 		<SimulationDescriptorReference Name="ShipSizeMedium"/>
 		<SimulationDescriptorReference Name="ShipFactionMinorFactionInsectoid"/>
+		<SimulationDescriptorReference Name="CameraAnchorMinorFactionInsectoid"/>
 		<SimulationDescriptorReference Name="ShipHull01"/>
 		<SimulationDescriptorReference Name="CanPrivateer"/>
 		<SimulationDescriptorReference Name="IncreasedUpkeep"/>
@@ -439,6 +441,7 @@
 		<SimulationDescriptorReference Name="ClassHullSmallAttack"/>
 		<SimulationDescriptorReference Name="ShipSizeSmall"/>
 		<SimulationDescriptorReference Name="ShipFactionMinorFactionPirates"/>
+		<SimulationDescriptorReference Name="CameraAnchorMinorFactionPirates"/>
 		<SimulationDescriptorReference Name="ShipHull01"/>
 		<SimulationDescriptorReference Name="CanPrivateer"/>
 		<SimulationDescriptorReference Name="IncreasedUpkeep"/>
@@ -605,6 +608,7 @@
 		<SimulationDescriptorReference Name="ClassHullMediumAttack"/>
 		<SimulationDescriptorReference Name="ShipSizeMedium"/>
 		<SimulationDescriptorReference Name="ShipFactionMinorFactionPirates"/>
+		<SimulationDescriptorReference Name="CameraAnchorMinorFactionPirates"/>
 		<SimulationDescriptorReference Name="ShipHull01"/>
 		<SimulationDescriptorReference Name="CanPrivateer"/>
 		<SimulationDescriptorReference Name="IncreasedUpkeep"/>
@@ -843,6 +847,7 @@
 		<SimulationDescriptorReference Name="ClassHullSmallAttack"/>
 		<SimulationDescriptorReference Name="ShipSizeSmall"/>
 		<SimulationDescriptorReference Name="ShipFactionMinorFactionPrimitive"/>
+		<SimulationDescriptorReference Name="CameraAnchorMinorFactionPrimitive"/>
 		<SimulationDescriptorReference Name="ShipHull01"/>
 		<SimulationDescriptorReference Name="CanPrivateer"/>
 		<SimulationDescriptorReference Name="IncreasedUpkeep"/>
@@ -1005,6 +1010,7 @@
 		<SimulationDescriptorReference Name="ClassHullMediumAttack"/>
 		<SimulationDescriptorReference Name="ShipSizeMedium"/>
 		<SimulationDescriptorReference Name="ShipFactionMinorFactionPrimitive"/>
+		<SimulationDescriptorReference Name="CameraAnchorMinorFactionPrimitive"/>
 		<SimulationDescriptorReference Name="ShipHull01"/>
 		<SimulationDescriptorReference Name="CanPrivateer"/>
 		<SimulationDescriptorReference Name="IncreasedUpkeep"/>
@@ -1230,6 +1236,7 @@
 		<SimulationDescriptorReference Name="ClassHullSmallAttack"/>
 		<SimulationDescriptorReference Name="ShipSizeSmall"/>
 		<SimulationDescriptorReference Name="ShipFactionMinorFactionAdvanced"/>
+		<SimulationDescriptorReference Name="CameraAnchorMinorFactionAdvanced"/>
 		<SimulationDescriptorReference Name="ShipHull01"/>
 		<SimulationDescriptorReference Name="CanPrivateer"/>
 		<SimulationDescriptorReference Name="IncreasedUpkeep"/>
@@ -1402,6 +1409,7 @@
 		<SimulationDescriptorReference Name="ClassHullMediumAttack"/>
 		<SimulationDescriptorReference Name="ShipSizeMedium"/>
 		<SimulationDescriptorReference Name="ShipFactionMinorFactionAdvanced"/>
+		<SimulationDescriptorReference Name="CameraAnchorMinorFactionAdvanced"/>
 		<SimulationDescriptorReference Name="ShipHull01"/>
 		<SimulationDescriptorReference Name="CanPrivateer"/>
 		<SimulationDescriptorReference Name="IncreasedUpkeep"/>

--- a/Endless Space Competitive Mod/Simulation/Battles/HullDefinitions[Misc].xml
+++ b/Endless Space Competitive Mod/Simulation/Battles/HullDefinitions[Misc].xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Datatable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xsi:noNamespaceSchemaLocation="../../Schemas/HullDefinition.xsd">
+  <HullDefinition Name="HullMedium03Vaulters" ScoreProvider="CivilianShipConstructed" Category="CategoryHull" SubCategory="SubCategoryShipDesign">
+    <CostReductionReference Name="ColonyShipConstructible"/>
+    <PathPrerequisite Flags="Prerequisite,Discard,Edition">false</PathPrerequisite>
+
+    <SimulationDescriptorReference Name="ClassHullMediumSuperColonizer"/>
+    <SimulationDescriptorReference Name="ShipSizeMedium"/>
+    <SimulationDescriptorReference Name="ShipFactionVaulters"/>
+    <SimulationDescriptorReference Name="CameraAnchorVaulters"/>
+    <SimulationDescriptorReference Name="ShipHull03"/>
+    <SimulationDescriptorReference Name="CannotHaveWeapon"/>
+    <SimulationDescriptorReference Name="CannotBeCapturedAfterBattle"/>
+
+    <ShipDesignLayout>
+      <ShipRoleReference Name="ShipRoleSuperColonizer"/>
+      <SectionPattern_Eight>
+        <!-- Core Section -->
+        <CoreSection Name="CoreSection">
+          <VisualSectionName>Core</VisualSectionName>
+          <SimulationDescriptorReference Name="ClassSectionCore"/>
+          <SimulationDescriptorReference Name="ClassSectionCoreMediumSuperColonizer"/>
+          <Slot Name="DefenseSupport01">
+            <PathPrerequisite Flags="Prerequisite,Discard">../ClassEmpire,EmpireImprovementUnique11SuperColonizer</PathPrerequisite>
+            <RestrictedModuleCategory>Defense</RestrictedModuleCategory>
+            <RestrictedModuleCategory>Support</RestrictedModuleCategory>
+            <Direction X="0" Z="1"/>
+            <ModuleModifier>
+              <SimulationDescriptorReference Name="MultiplierX2"/>
+            </ModuleModifier>
+            <UISlotName>UICore04</UISlotName>
+          </Slot>
+          <Slot Name="DefenseSupport02">
+            <PathPrerequisite Flags="Prerequisite,Discard">../ClassEmpire,EmpireImprovementUnique11SuperColonizer</PathPrerequisite>
+            <RestrictedModuleCategory>Defense</RestrictedModuleCategory>
+            <RestrictedModuleCategory>Support</RestrictedModuleCategory>
+            <Direction X="0" Z="1"/>
+            <ModuleModifier>
+              <SimulationDescriptorReference Name="MultiplierX2"/>
+            </ModuleModifier>
+            <UISlotName>UICore05</UISlotName>
+          </Slot>
+        </CoreSection>
+
+        <!-- Forward Section -->
+        <Section Name="SectionN">
+          <VisualSectionName>Front</VisualSectionName>
+          <Slot Name="Support01">
+            <RestrictedModuleCategory>Support</RestrictedModuleCategory>
+            <RestrictedModuleCategory>Defense</RestrictedModuleCategory>
+            <Direction X="0" Z="1"/>
+            <ModuleModifier>
+              <SimulationDescriptorReference Name="MultiplierX2"/>
+            </ModuleModifier>
+            <UISlotName>UIFront01</UISlotName>
+          </Slot>
+        </Section>
+
+        <!-- Forward/Right Section -->
+        <Section Name="SectionNE">
+          <VisualSectionName>FrontRight</VisualSectionName>
+        </Section>
+
+        <!-- Right Section -->
+        <Section Name="SectionE">
+          <VisualSectionName>Right</VisualSectionName>
+        </Section>
+
+        <!-- Back/Right Section -->
+        <Section Name="SectionSE">
+          <VisualSectionName>BackRight</VisualSectionName>
+          <Slot Name="Support01">
+            <RestrictedModuleCategory>Support</RestrictedModuleCategory>
+            <Direction X="1" Z="0"/>
+            <ModuleModifier>
+              <SimulationDescriptorReference Name="MultiplierX2"/>
+            </ModuleModifier>
+            <UISlotName>UIBackRight02</UISlotName>
+          </Slot>
+        </Section>
+
+        <!-- Back Section -->
+        <Section Name="SectionS">
+          <VisualSectionName>Back</VisualSectionName>
+          <Slot Name="Support01">
+            <RestrictedModuleCategory>Support</RestrictedModuleCategory>
+            <Direction X="0" Z="-1"/>
+            <ModuleModifier>
+              <SimulationDescriptorReference Name="MultiplierX2"/>
+            </ModuleModifier>
+            <UISlotName>UIBack03</UISlotName>
+          </Slot>
+        </Section>
+
+        <!-- Back/Left Section -->
+        <Section Name="SectionSW">
+          <VisualSectionName>BackLeft</VisualSectionName>
+        </Section>
+
+        <!-- Left Section -->
+        <Section Name="SectionW">
+          <VisualSectionName>Left</VisualSectionName>
+        </Section>
+
+        <!-- Forward/Left Section -->
+        <Section Name="SectionNW">
+          <VisualSectionName>FrontLeft</VisualSectionName>
+        </Section>
+      </SectionPattern_Eight>
+    </ShipDesignLayout>
+
+    <BattleActionReference Name="Ship_UpdateMedalScoreAfterAttack"/>
+    <BattleActionReference Name="Ship_UpdateMedalScoreAfterDamage"/>
+    <BattleActionReference Name="Ship_Healing"/>
+    <BattleActionReference Name="Ship_OnDestruction"/>
+    <!--<BattleActionReference Name="SuperColonizer_Revive"/>-->
+
+    <LevelUpRuleReference Name="ShipLevelUpRule"/>
+  </HullDefinition>
+</Datatable>

--- a/Endless Space Competitive Mod/Simulation/Battles/HullDefinitions[Mothership].xml
+++ b/Endless Space Competitive Mod/Simulation/Battles/HullDefinitions[Mothership].xml
@@ -14,6 +14,7 @@
     <SimulationDescriptorReference Name="WeaponAvailabilityMissile"/>
     <SimulationDescriptorReference Name="ShipSizeMothership"/>
     <SimulationDescriptorReference Name="ShipFactionVampirilis"/>
+    <SimulationDescriptorReference Name="CameraAnchorVampirilis"/>
 
     <ShipDesignLayout>
       <ShipRoleReference Name="ShipRoleMothership"/>

--- a/Endless Space Competitive Mod/Simulation/Battles/HullDefinitions[QuestReward].xml
+++ b/Endless Space Competitive Mod/Simulation/Battles/HullDefinitions[QuestReward].xml
@@ -20,6 +20,7 @@
     <SimulationDescriptorReference Name="WeaponAvailabilityLaser"/>
     <SimulationDescriptorReference Name="ShipSizeSmall"/>
     <SimulationDescriptorReference Name="ShipFactionTemplars"/>
+    <SimulationDescriptorReference Name="CameraAnchorTemplars"/>
     <SimulationDescriptorReference Name="ShipHull01"/>
     <SimulationDescriptorReference Name="CanPrivateer"/>
 
@@ -225,6 +226,7 @@
     <SimulationDescriptorReference Name="WeaponAvailabilityLaser"/>
     <SimulationDescriptorReference Name="ShipSizeSmall"/>
     <SimulationDescriptorReference Name="ShipFactionVampirilis"/>
+    <SimulationDescriptorReference Name="CameraAnchorVampirilis"/>
 		<SimulationDescriptorReference Name="ShipHull01"/>
 		<SimulationDescriptorReference Name="CanPrivateer"/>
 
@@ -400,6 +402,7 @@
     <SimulationDescriptorReference Name="WeaponAvailabilityLaser"/>
     <SimulationDescriptorReference Name="ShipSizeMedium"/>
     <SimulationDescriptorReference Name="ShipFactionUmbralChoir"/>
+    <SimulationDescriptorReference Name="CameraAnchorUmbralChoir"/>
     <SimulationDescriptorReference Name="ShipHull02"/>
     <SimulationDescriptorReference Name="CanPrivateer"/>
 		<SimulationDescriptorReference Name="ShipStatBonus1InnateInvisibility"/>
@@ -622,6 +625,7 @@
     <SimulationDescriptorReference Name="WeaponAvailabilityMissile"/>
     <SimulationDescriptorReference Name="ShipSizeLarge"/>
     <SimulationDescriptorReference Name="ShipFactionVampirilis"/>
+    <SimulationDescriptorReference Name="CameraAnchorVampirilis"/>
     <SimulationDescriptorReference Name="ShipHull01"/>
     <SimulationDescriptorReference Name="ShipStatBonus1InvisibleModules"/>
     <SimulationDescriptorReference Name="CanPrivateer"/>

--- a/Endless Space Competitive Mod/Simulation/Battles/HullDefinitions[Vineship].xml
+++ b/Endless Space Competitive Mod/Simulation/Battles/HullDefinitions[Vineship].xml
@@ -19,6 +19,7 @@
 		<SimulationDescriptorReference Name="ClassHullCravers"/>
 		<SimulationDescriptorReference Name="ShipSizeSmall"/>
 		<SimulationDescriptorReference Name="ShipFactionCravers"/>
+		<SimulationDescriptorReference Name="CameraAnchorCravers"/>
 		<SimulationDescriptorReference Name="ShipHull03"/>
 		<SimulationDescriptorReference Name="CannotHaveWeapon"/>
 
@@ -120,6 +121,7 @@
 		<SimulationDescriptorReference Name="ClassHullSmallCivilian"/>
 		<SimulationDescriptorReference Name="ShipSizeSmall"/>
 		<SimulationDescriptorReference Name="ShipFactionMajorHisshos"/>
+		<SimulationDescriptorReference Name="CameraAnchorMajorHisshos"/>
 		<SimulationDescriptorReference Name="ShipHull03"/>
 		<SimulationDescriptorReference Name="CannotHaveWeapon"/>
 
@@ -220,6 +222,7 @@
 		<SimulationDescriptorReference Name="ClassHullSmallCivilian"/>
 		<SimulationDescriptorReference Name="ShipSizeSmall"/>
 		<SimulationDescriptorReference Name="ShipFactionHoratio"/>
+		<SimulationDescriptorReference Name="CameraAnchorHoratio"/>
 		<SimulationDescriptorReference Name="ShipHull03"/>
 		<SimulationDescriptorReference Name="CannotHaveWeapon"/>
 
@@ -320,6 +323,7 @@
 		<SimulationDescriptorReference Name="ClassHullSmallCivilian"/>
 		<SimulationDescriptorReference Name="ShipSizeSmall"/>
 		<SimulationDescriptorReference Name="ShipFactionVenetians"/>
+		<SimulationDescriptorReference Name="CameraAnchorVenetians"/>
 		<SimulationDescriptorReference Name="ShipHull03"/>
 		<SimulationDescriptorReference Name="CannotHaveWeapon"/>
 
@@ -420,6 +424,7 @@
 		<SimulationDescriptorReference Name="ClassHullSmallCivilian"/>
 		<SimulationDescriptorReference Name="ShipSizeSmall"/>
 		<SimulationDescriptorReference Name="ShipFactionTemplars"/>
+		<SimulationDescriptorReference Name="CameraAnchorTemplars"/>
 		<SimulationDescriptorReference Name="ShipHull03"/>
 		<SimulationDescriptorReference Name="CannotHaveWeapon"/>
 
@@ -520,6 +525,7 @@
 		<SimulationDescriptorReference Name="ClassHullSmallCivilian"/>
 		<SimulationDescriptorReference Name="ShipSizeSmall"/>
 		<SimulationDescriptorReference Name="ShipFactionTimeLords"/>
+		<SimulationDescriptorReference Name="CameraAnchorTimeLords"/>
 		<SimulationDescriptorReference Name="ShipHull03"/>
 		<SimulationDescriptorReference Name="CannotHaveWeapon"/>
 
@@ -621,6 +627,7 @@
 		<SimulationDescriptorReference Name="ClassHullSmallCivilian"/>
 		<SimulationDescriptorReference Name="ShipSizeSmall"/>
 		<SimulationDescriptorReference Name="ShipFactionSophons"/>
+		<SimulationDescriptorReference Name="CameraAnchorSophons"/>
 		<SimulationDescriptorReference Name="ShipHull03"/>
 		<SimulationDescriptorReference Name="CannotHaveWeapon"/>
 
@@ -721,6 +728,7 @@
 		<SimulationDescriptorReference Name="ClassHullSmallCivilian"/>
 		<SimulationDescriptorReference Name="ShipSizeSmall"/>
 		<SimulationDescriptorReference Name="ShipFactionUmbralChoir"/>
+		<SimulationDescriptorReference Name="CameraAnchorUmbralChoir"/>
 		<SimulationDescriptorReference Name="ShipHull03"/>
 		<SimulationDescriptorReference Name="CannotHaveWeapon"/>
 
@@ -821,6 +829,7 @@
 		<SimulationDescriptorReference Name="ClassHullSmallCivilian"/>
 		<SimulationDescriptorReference Name="ShipSizeSmall"/>
 		<SimulationDescriptorReference Name="ShipFactionTerrans"/>
+		<SimulationDescriptorReference Name="CameraAnchorTerrans"/>
 		<SimulationDescriptorReference Name="ShipHull03"/>
 		<SimulationDescriptorReference Name="CannotHaveWeapon"/>
 
@@ -920,6 +929,7 @@
 		<SimulationDescriptorReference Name="ClassHullSmallCivilian"/>
 		<SimulationDescriptorReference Name="ShipSizeSmall"/>
 		<SimulationDescriptorReference Name="ShipFactionUnfallen"/>
+		<SimulationDescriptorReference Name="CameraAnchorUnfallen"/>
 		<SimulationDescriptorReference Name="ShipHull03"/>
 		<SimulationDescriptorReference Name="CannotHaveWeapon"/>
 
@@ -1023,6 +1033,7 @@
 		<SimulationDescriptorReference Name="ClassHullSmallCivilian"/>
 		<SimulationDescriptorReference Name="ShipSizeSmall"/>
 		<SimulationDescriptorReference Name="ShipFactionVaulters"/>
+		<SimulationDescriptorReference Name="CameraAnchorVaulters"/>
 		<SimulationDescriptorReference Name="ShipHull03"/>
 		<SimulationDescriptorReference Name="CannotHaveWeapon"/>
 
@@ -1122,6 +1133,7 @@
 		<SimulationDescriptorReference Name="ClassHullSmallCivilian"/>
 		<SimulationDescriptorReference Name="ShipSizeSmall"/>
 		<SimulationDescriptorReference Name="ShipFactionVampirilis"/>
+		<SimulationDescriptorReference Name="CameraAnchorVampirilis"/>
 		<SimulationDescriptorReference Name="ShipHull03"/>
 		<SimulationDescriptorReference Name="CannotHaveWeapon"/>
 

--- a/Endless Space Competitive Mod/Simulation/SimulationDescriptors[Ship].xml
+++ b/Endless Space Competitive Mod/Simulation/SimulationDescriptors[Ship].xml
@@ -1,32 +1,32 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Datatable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xsi:noNamespaceSchemaLocation="../../Schemas/Amplitude.Unity.Simulation.SimulationDescriptor.xsd">
 
-	<SimulationDescriptorReference Name="CameraAnchorCravers"		Type="CameraAnchor"/>
-	<SimulationDescriptorReference Name="CameraAnchorMajorHisshos"	Type="CameraAnchor"/>
-	<SimulationDescriptorReference Name="CameraAnchorHoratio"		Type="CameraAnchor"/>
-	<SimulationDescriptorReference Name="CameraAnchorVenetians"		Type="CameraAnchor"/>
-	<SimulationDescriptorReference Name="CameraAnchorTemplars"		Type="CameraAnchor"/>
-	<SimulationDescriptorReference Name="CameraAnchorTimeLords"		Type="CameraAnchor"/>
-	<SimulationDescriptorReference Name="CameraAnchorSophons"		Type="CameraAnchor"/>
-	<SimulationDescriptorReference Name="CameraAnchorUmbralChoir"	Type="CameraAnchor"/>
-	<SimulationDescriptorReference Name="CameraAnchorTerrans"		Type="CameraAnchor"/>
-	<SimulationDescriptorReference Name="CameraAnchorUnfallen"		Type="CameraAnchor"/>
-	<SimulationDescriptorReference Name="CameraAnchorVaulters"		Type="CameraAnchor"/>
-	<SimulationDescriptorReference Name="CameraAnchorVampirilis"	Type="CameraAnchor"/>
+	<SimulationDescriptor Name="CameraAnchorCravers"		Type="CameraAnchor"/>
+	<SimulationDescriptor Name="CameraAnchorMajorHisshos"	Type="CameraAnchor"/>
+	<SimulationDescriptor Name="CameraAnchorHoratio"		Type="CameraAnchor"/>
+	<SimulationDescriptor Name="CameraAnchorVenetians"		Type="CameraAnchor"/>
+	<SimulationDescriptor Name="CameraAnchorTemplars"		Type="CameraAnchor"/>
+	<SimulationDescriptor Name="CameraAnchorTimeLords"		Type="CameraAnchor"/>
+	<SimulationDescriptor Name="CameraAnchorSophons"		Type="CameraAnchor"/>
+	<SimulationDescriptor Name="CameraAnchorUmbralChoir"	Type="CameraAnchor"/>
+	<SimulationDescriptor Name="CameraAnchorTerrans"		Type="CameraAnchor"/>
+	<SimulationDescriptor Name="CameraAnchorUnfallen"		Type="CameraAnchor"/>
+	<SimulationDescriptor Name="CameraAnchorVaulters"		Type="CameraAnchor"/>
+	<SimulationDescriptor Name="CameraAnchorVampirilis"	Type="CameraAnchor"/>
 	
-	<SimulationDescriptorReference Name="CameraAnchorJuggernauts"		Type="CameraAnchor"/>
-	<SimulationDescriptorReference Name="CameraAnchorHeroes"			Type="CameraAnchor"/>
-	<SimulationDescriptorReference Name="CameraAnchorHeroesUCHero05"	Type="CameraAnchor"/>
-	<SimulationDescriptorReference Name="CameraAnchorHeroesPirate"		Type="CameraAnchor"/>
+	<SimulationDescriptor Name="CameraAnchorJuggernauts"		Type="CameraAnchor"/>
+	<SimulationDescriptor Name="CameraAnchorHeroes"			Type="CameraAnchor"/>
+	<SimulationDescriptor Name="CameraAnchorHeroesUCHero05"	Type="CameraAnchor"/>
+	<SimulationDescriptor Name="CameraAnchorHeroesPirate"		Type="CameraAnchor"/>
 	
-	<SimulationDescriptorReference Name="CameraAnchorMinorFactionInsectoid"	Type="CameraAnchor"/>
-	<SimulationDescriptorReference Name="CameraAnchorMinorFactionPirates"	Type="CameraAnchor"/>
-	<SimulationDescriptorReference Name="CameraAnchorMinorFactionPrimitive"	Type="CameraAnchor"/>
-	<SimulationDescriptorReference Name="CameraAnchorMinorFactionAdvanced"	Type="CameraAnchor"/>
+	<SimulationDescriptor Name="CameraAnchorMinorFactionInsectoid"	Type="CameraAnchor"/>
+	<SimulationDescriptor Name="CameraAnchorMinorFactionPirates"	Type="CameraAnchor"/>
+	<SimulationDescriptor Name="CameraAnchorMinorFactionPrimitive"	Type="CameraAnchor"/>
+	<SimulationDescriptor Name="CameraAnchorMinorFactionAdvanced"	Type="CameraAnchor"/>
 	
-	<SimulationDescriptorReference Name="CameraAnchorNamedShipTemplars"		Type="CameraAnchor"/>
-	<SimulationDescriptorReference Name="CameraAnchorNamedShipSophons"		Type="CameraAnchor"/>
-	<SimulationDescriptorReference Name="CameraAnchorNamedShipTerrans"		Type="CameraAnchor"/>
-	<SimulationDescriptorReference Name="CameraAnchorNamedShipCraversPrime"	Type="CameraAnchor"/>
+	<SimulationDescriptor Name="CameraAnchorNamedShipTemplars"		Type="CameraAnchor"/>
+	<SimulationDescriptor Name="CameraAnchorNamedShipSophons"		Type="CameraAnchor"/>
+	<SimulationDescriptor Name="CameraAnchorNamedShipTerrans"		Type="CameraAnchor"/>
+	<SimulationDescriptor Name="CameraAnchorNamedShipCraversPrime"	Type="CameraAnchor"/>
 
 </Datatable>

--- a/Endless Space Competitive Mod/Simulation/SimulationDescriptors[Ship].xml
+++ b/Endless Space Competitive Mod/Simulation/SimulationDescriptors[Ship].xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Datatable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xsi:noNamespaceSchemaLocation="../../Schemas/Amplitude.Unity.Simulation.SimulationDescriptor.xsd">
+
+	<SimulationDescriptorReference Name="CameraAnchorCravers"		Type="CameraAnchor"/>
+	<SimulationDescriptorReference Name="CameraAnchorMajorHisshos"	Type="CameraAnchor"/>
+	<SimulationDescriptorReference Name="CameraAnchorHoratio"		Type="CameraAnchor"/>
+	<SimulationDescriptorReference Name="CameraAnchorVenetians"		Type="CameraAnchor"/>
+	<SimulationDescriptorReference Name="CameraAnchorTemplars"		Type="CameraAnchor"/>
+	<SimulationDescriptorReference Name="CameraAnchorTimeLords"		Type="CameraAnchor"/>
+	<SimulationDescriptorReference Name="CameraAnchorSophons"		Type="CameraAnchor"/>
+	<SimulationDescriptorReference Name="CameraAnchorUmbralChoir"	Type="CameraAnchor"/>
+	<SimulationDescriptorReference Name="CameraAnchorTerrans"		Type="CameraAnchor"/>
+	<SimulationDescriptorReference Name="CameraAnchorUnfallen"		Type="CameraAnchor"/>
+	<SimulationDescriptorReference Name="CameraAnchorVaulters"		Type="CameraAnchor"/>
+	<SimulationDescriptorReference Name="CameraAnchorVampirilis"	Type="CameraAnchor"/>
+	
+	<SimulationDescriptorReference Name="CameraAnchorJuggernauts"		Type="CameraAnchor"/>
+	<SimulationDescriptorReference Name="CameraAnchorHeroes"			Type="CameraAnchor"/>
+	<SimulationDescriptorReference Name="CameraAnchorHeroesUCHero05"	Type="CameraAnchor"/>
+	<SimulationDescriptorReference Name="CameraAnchorHeroesPirate"		Type="CameraAnchor"/>
+	
+	<SimulationDescriptorReference Name="CameraAnchorMinorFactionInsectoid"	Type="CameraAnchor"/>
+	<SimulationDescriptorReference Name="CameraAnchorMinorFactionPirates"	Type="CameraAnchor"/>
+	<SimulationDescriptorReference Name="CameraAnchorMinorFactionPrimitive"	Type="CameraAnchor"/>
+	<SimulationDescriptorReference Name="CameraAnchorMinorFactionAdvanced"	Type="CameraAnchor"/>
+	
+	<SimulationDescriptorReference Name="CameraAnchorNamedShipTemplars"		Type="CameraAnchor"/>
+	<SimulationDescriptorReference Name="CameraAnchorNamedShipSophons"		Type="CameraAnchor"/>
+	<SimulationDescriptorReference Name="CameraAnchorNamedShipTerrans"		Type="CameraAnchor"/>
+	<SimulationDescriptorReference Name="CameraAnchorNamedShipCraversPrime"	Type="CameraAnchor"/>
+
+</Datatable>


### PR DESCRIPTION
These are added for compatibility with mods that use non-standard ship colour schemes, such as the Unfallen "Firekeepers" or Cravers "Prime" skins.