### PR TITLE
1236 BAIE Integration

### DIFF
--- a/Endless Space Competitive Mod/Simulation/Battles/HullDefinitions[Colonizer].xml
+++ b/Endless Space Competitive Mod/Simulation/Battles/HullDefinitions[Colonizer].xml
@@ -204,7 +204,7 @@
     <PathPrerequisite Flags="Prerequisite,Discard,Edition" Inverted="true">../ClassEmpire,FactionTraitManualHomeSystem</PathPrerequisite>
     <PathPrerequisite Flags="Prerequisite,Discard,Edition" Inverted="true">../ClassEmpire,AffinityGameplayUmbralChoir</PathPrerequisite>
     <PathPrerequisite Flags="Prerequisite,Discard,Edition" Inverted="true">../ClassEmpire,FactionTraitSedentary</PathPrerequisite>
-    <InterpreterPrerequisite Flags="Prerequisite,AIError" Inverted="true">(Property(Context,@'../ClassEmpire',IsAIControlled) eq 1) and (Property(Context,@'../ClassEmpire',PotentiallyOverColonizationThreshold) eq 1)</InterpreterPrerequisite>
+    
 
     <SimulationDescriptorReference Name="ClassHullSmallCivilian"/>
     <SimulationDescriptorReference Name="ShipSizeSmall"/>

--- a/Endless Space Competitive Mod/Simulation/EntityActions.xml
+++ b/Endless Space Competitive Mod/Simulation/EntityActions.xml
@@ -482,7 +482,7 @@
     <EntityPrerequisites Location="Self">
       <PathPrerequisite Flags="Prerequisite,SystemIsBeingGuarded" Inverted="true">BlockadedColonizedStarSystem</PathPrerequisite>
       <PathPrerequisite Flags="Prerequisite,SystemIsBeingDecolonized" Inverted="true">DecolonizedColonizedStarSystem</PathPrerequisite>
-      <InterpreterPrerequisite Flags="Prerequisite,AIError" Inverted="true">(Property(Context,@'../ClassEmpire',IsAIControlled) eq 1) and (Property(Context,@'../ClassEmpire',PotentiallyOverColonizationThreshold) eq 1)</InterpreterPrerequisite>
+      
     </EntityPrerequisites>
 
     <CustomCost Instant="true" ResourceName="EmpireHonor">Min(Max(Exp(4.4 - (Property(Context,@'ClassStarSystem',SystemGrowthStock) / (100 * Property(Context,@'../ClassEmpire',GameSpeedMultiplier)))), 10 + Max(5 * (Property(Context,@'../ClassEmpire',ColonizedStarSystemStateColonyCount) - Property(Context,@'../ClassEmpire',OverColonizationThreshold)), 0)), 75)</CustomCost>

--- a/Endless Space Competitive Mod/Simulation/SimulationDescriptors[Empire].xml
+++ b/Endless Space Competitive Mod/Simulation/SimulationDescriptors[Empire].xml
@@ -175,6 +175,16 @@
 		<Property Name="BomberIndustryTier1"				BaseValue="110"	MinValue="0"/>
 		<Property Name="BomberIndustryTier2"				BaseValue="140"	MinValue="0"/>
 
+		<!-- Better AI Empires Tweaks -->		
+
+		<Property Name="BetterHisshoTweak"  BaseValue="0" />
+		<Property Name="BetterVaultersTweak"  BaseValue="0" />
+		<Property Name="BetterNakalimTweak"  BaseValue="0" />
+		<Property Name="BetterSophonsTweak"  BaseValue="0" />
+		<Property Name="BetterHoratioTweak"  BaseValue="0" />
+		<Property Name="BetterUnfallenTweak"  BaseValue="0" />
+
+
 		<!-- ########################################################## -->
 		<!-- ######################## PROPERTY ######################## -->
 		<!-- ########################################################## -->

--- a/Endless Space Competitive Mod/Simulation/SimulationDescriptors[Empire].xml
+++ b/Endless Space Competitive Mod/Simulation/SimulationDescriptors[Empire].xml
@@ -183,7 +183,7 @@
 		<Property Name="BetterSophonsTweak"  BaseValue="0" />
 		<Property Name="BetterHoratioTweak"  BaseValue="0" />
 		<Property Name="BetterUnfallenTweak"  BaseValue="0" />
-
+		<Property Name="BetterCraversTweak"  BaseValue="0" />
 
 		<!-- ########################################################## -->
 		<!-- ######################## PROPERTY ######################## -->

--- a/Endless Space Competitive Mod/Simulation/SimulationDescriptors[FactionTrait].xml
+++ b/Endless Space Competitive Mod/Simulation/SimulationDescriptors[FactionTrait].xml
@@ -114,6 +114,24 @@
         <Modifier TargetProperty="PlanetInitialFIDSPenalty"     Operation="Force"       Value="0"   Path="ClassEmpire/ClassColonizedStarSystem/PlanetTypeFake"      TooltipHidden="true"/>
   </SimulationDescriptor>
 
+  <SimulationDescriptor Name="AffinityGameplayCravers" Type="AffinityGameplay">
+
+		<!-- Better AI Empires Tweaks -->
+
+		<Property Name="BetterCraversTweak"  BaseValue="1" />
+
+		<Modifier TargetProperty="BetterCraversTweak" Operation="Force" Value="1" Path="ClassEmpire" TooltipHidden="true"/>
+
+
+        <Modifier TargetProperty="PlanetInitialFIDSPenalty"        Operation="Force"     Value="0"    Path="ClassEmpire/ClassColonizedStarSystem/PlanetTypeForest" TooltipHidden="true"/>
+        <Modifier TargetProperty="PlanetInitialFIDSPenalty"        Operation="Force"     Value="0"    Path="ClassEmpire/ClassColonizedStarSystem/PlanetTypeTerran" TooltipHidden="true"/>
+        <Modifier TargetProperty="PlanetInitialFIDSPenalty"        Operation="Force"     Value="0"    Path="ClassEmpire/ClassColonizedStarSystem/PlanetTypeMonsoon" TooltipHidden="true"/>
+        <Modifier TargetProperty="PlanetInitialFIDSPenalty"        Operation="Force"     Value="0"    Path="ClassEmpire/ClassColonizedStarSystem/PlanetTypeOcean" TooltipHidden="true"/>
+        <Modifier TargetProperty="PlanetInitialFIDSPenalty"        Operation="Force"     Value="0"    Path="ClassEmpire/ClassColonizedStarSystem/PlanetTypeAtoll" TooltipHidden="true"/>
+        <Modifier TargetProperty="PlanetInitialFIDSPenalty"        Operation="Force"     Value="0"    Path="ClassEmpire/ClassColonizedStarSystem/PlanetTypeBoreal" TooltipHidden="true"/>
+        <Modifier TargetProperty="PlanetInitialFIDSPenalty"        Operation="Force"     Value="0"    Path="ClassEmpire/ClassColonizedStarSystem/PlanetTypeJungle" TooltipHidden="true"/>
+  </SimulationDescriptor>
+
 	<!-- Better AI Empires Additions END - EXCEPT for Unfallen below -->
 
   <SimulationDescriptor Name="AffinityGameplayVenetians" Type="AffinityGameplay">

--- a/Endless Space Competitive Mod/Simulation/SimulationDescriptors[FactionTrait].xml
+++ b/Endless Space Competitive Mod/Simulation/SimulationDescriptors[FactionTrait].xml
@@ -1,6 +1,121 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Datatable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns:xsd="http://www.w3.org/2001/XMLSchema" xsi:noNamespaceSchemaLocation="../Schemas/Amplitude.Unity.Simulation.SimulationDescriptor.xsd">
+
+	<!-- Better AI Empires Additions START -->
+
+  <SimulationDescriptor Name="AffinityGameplaySophons" Type="AffinityGameplay">
+        <Property Name="ResearchOmniscienceMultiplier"  BaseValue="0"/>
+        <Property Name="ResearchOmniscienceBonus"       BaseValue="0"/>
+
+
+        <BinaryModifier       TargetProperty="ResearchOmniscienceBonus"   Operation="Addition"  Left="$(ResearchOmniscienceMultiplier)" BinaryOperation="Multiplication"  Right="$(EmpireResearch)"                       Path="ClassEmpire" />
+        <Modifier             TargetProperty="NetEmpireResearch"               Operation="Addition" Value="$(ResearchOmniscienceBonus)"                        Path="ClassEmpire" />
+
+		<!-- Better AI Empires Tweaks -->
+
+		<Property Name="BetterSophonsTweak"  BaseValue="1" />
+
+		<Modifier TargetProperty="BetterSophonsTweak" Operation="Force" Value="1" Path="ClassEmpire" TooltipHidden="true"/>
+
+
+		<Modifier TargetProperty="PlanetInitialFIDSPenalty"        Operation="Force"     Value="0"    Path="ClassEmpire/ClassColonizedStarSystem/PlanetTypeForest" TooltipHidden="true"/>
+        <Modifier TargetProperty="PlanetInitialFIDSPenalty"        Operation="Force"     Value="0"    Path="ClassEmpire/ClassColonizedStarSystem/PlanetTypeTerran" TooltipHidden="true"/>
+        <Modifier TargetProperty="PlanetInitialFIDSPenalty"        Operation="Force"     Value="0"    Path="ClassEmpire/ClassColonizedStarSystem/PlanetTypeMonsoon" TooltipHidden="true"/>
+        <Modifier TargetProperty="PlanetInitialFIDSPenalty"        Operation="Force"     Value="0"    Path="ClassEmpire/ClassColonizedStarSystem/PlanetTypeOcean" TooltipHidden="true"/>
+        <Modifier TargetProperty="PlanetInitialFIDSPenalty"        Operation="Force"     Value="0"    Path="ClassEmpire/ClassColonizedStarSystem/PlanetTypeAtoll" TooltipHidden="true"/>
+        <Modifier TargetProperty="PlanetInitialFIDSPenalty"        Operation="Force"     Value="0"    Path="ClassEmpire/ClassColonizedStarSystem/PlanetTypeBoreal" TooltipHidden="true"/>
+        <Modifier TargetProperty="PlanetInitialFIDSPenalty"        Operation="Force"     Value="0"    Path="ClassEmpire/ClassColonizedStarSystem/PlanetTypeJungle" TooltipHidden="true"/>
+    </SimulationDescriptor>
+
+    <SimulationDescriptor Name="AffinityGameplayHoratio" Type="AffinityGameplay">       
+
+        <Modifier TargetProperty="HasAffinityGeneHunter"        Operation="Force"     Value="1"    Path="ClassEmpire" TooltipHidden="true"/>
+        <Modifier TargetProperty="HasAffinityGeneHunter"        Operation="Force"     Value="1"    Path="ClassEmpire/ClassColonizedStarSystem" TooltipHidden="true"/>
+
+
+		<!-- Better AI Empires Tweaks -->
+		<Property Name="BetterHoratioTweak"  BaseValue="1" />
+
+		<Modifier TargetProperty="BetterHoratioTweak" Operation="Force" Value="0.25" Path="ClassEmpire" TooltipHidden="true"/>		
+
+        <Modifier TargetProperty="PlanetInitialFIDSPenalty"        Operation="Force"     Value="0"    Path="ClassEmpire/ClassColonizedStarSystem/PlanetTypeForest" TooltipHidden="true"/>
+        <Modifier TargetProperty="PlanetInitialFIDSPenalty"        Operation="Force"     Value="0"    Path="ClassEmpire/ClassColonizedStarSystem/PlanetTypeTerran" TooltipHidden="true"/>
+        <Modifier TargetProperty="PlanetInitialFIDSPenalty"        Operation="Force"     Value="0"    Path="ClassEmpire/ClassColonizedStarSystem/PlanetTypeMonsoon" TooltipHidden="true"/>
+        <Modifier TargetProperty="PlanetInitialFIDSPenalty"        Operation="Force"     Value="0"    Path="ClassEmpire/ClassColonizedStarSystem/PlanetTypeOcean" TooltipHidden="true"/>
+        <Modifier TargetProperty="PlanetInitialFIDSPenalty"        Operation="Force"     Value="0"    Path="ClassEmpire/ClassColonizedStarSystem/PlanetTypeAtoll" TooltipHidden="true"/>
+        <Modifier TargetProperty="PlanetInitialFIDSPenalty"        Operation="Force"     Value="0"    Path="ClassEmpire/ClassColonizedStarSystem/PlanetTypeBoreal" TooltipHidden="true"/>
+        <Modifier TargetProperty="PlanetInitialFIDSPenalty"        Operation="Force"     Value="0"    Path="ClassEmpire/ClassColonizedStarSystem/PlanetTypeJungle" TooltipHidden="true"/>
+    </SimulationDescriptor>
+
+    <SimulationDescriptor Name="AffinityGameplayVaulters" Type="AffinityGameplay">
+
+		<!-- Better AI Empires Tweaks -->
+
+		<Property Name="BetterVaultersTweak"  BaseValue="1" />
+
+		<Modifier TargetProperty="BetterVaultersTweak" Operation="Force" Value="1" Path="ClassEmpire" TooltipHidden="true"/>		
+		
+		
+        <Modifier TargetProperty="PlanetInitialFIDSPenalty"        Operation="Force"     Value="0"    Path="ClassEmpire/ClassColonizedStarSystem/PlanetTypeForest" TooltipHidden="true"/>
+        <Modifier TargetProperty="PlanetInitialFIDSPenalty"        Operation="Force"     Value="0"    Path="ClassEmpire/ClassColonizedStarSystem/PlanetTypeTerran" TooltipHidden="true"/>
+        <Modifier TargetProperty="PlanetInitialFIDSPenalty"        Operation="Force"     Value="0"    Path="ClassEmpire/ClassColonizedStarSystem/PlanetTypeMonsoon" TooltipHidden="true"/>
+        <Modifier TargetProperty="PlanetInitialFIDSPenalty"        Operation="Force"     Value="0"    Path="ClassEmpire/ClassColonizedStarSystem/PlanetTypeOcean" TooltipHidden="true"/>
+        <Modifier TargetProperty="PlanetInitialFIDSPenalty"        Operation="Force"     Value="0"    Path="ClassEmpire/ClassColonizedStarSystem/PlanetTypeAtoll" TooltipHidden="true"/>
+        <Modifier TargetProperty="PlanetInitialFIDSPenalty"        Operation="Force"     Value="0"    Path="ClassEmpire/ClassColonizedStarSystem/PlanetTypeBoreal" TooltipHidden="true"/>
+        <Modifier TargetProperty="PlanetInitialFIDSPenalty"        Operation="Force"     Value="0"    Path="ClassEmpire/ClassColonizedStarSystem/PlanetTypeJungle" TooltipHidden="true"/>
+
+        <Modifier TargetProperty="CanUsePortals"                   Operation="Addition"    Value="1" Path="ClassEmpire,EmpireTypeMajor" TooltipHidden="true"/>
+  </SimulationDescriptor>
+
+  <SimulationDescriptor Name="AffinityGameplayMajorHisshos" Type="AffinityGameplay">        
+        <Property Name="CanUseHonor"       BaseValue="1"/>
+		
+		<!-- Better AI Empires Tweaks -->
+
+		<Property Name="BetterHisshoTweak"  BaseValue="1" />
+
+		<Modifier TargetProperty="BetterHisshoTweak" Operation="Force" Value="0.025" Path="ClassEmpire" TooltipHidden="true"/>		
+		
+        <Modifier TargetProperty="CanUseHonor" Operation="Addition" Value="1" TooltipHidden="true"/>
+        <Modifier TargetProperty="GovernmentChangeHappinessMultiplier" Operation="Force" Value="0" TooltipHidden="true"/>
+
+        <Modifier TargetProperty="RebellionStarSystemIncreasePerTurn" Operation="Force" Value="0" Path="ClassEmpire/ClassSenate" TooltipHidden="true"/>
+        
+        <Modifier TargetProperty="PlanetInitialFIDSPenalty"        Operation="Force"     Value="0"    Path="ClassEmpire/ClassColonizedStarSystem/PlanetTypeForest" TooltipHidden="true"/>
+        <Modifier TargetProperty="PlanetInitialFIDSPenalty"        Operation="Force"     Value="0"    Path="ClassEmpire/ClassColonizedStarSystem/PlanetTypeTerran" TooltipHidden="true"/>
+        <Modifier TargetProperty="PlanetInitialFIDSPenalty"        Operation="Force"     Value="0"    Path="ClassEmpire/ClassColonizedStarSystem/PlanetTypeMonsoon" TooltipHidden="true"/>
+        <Modifier TargetProperty="PlanetInitialFIDSPenalty"        Operation="Force"     Value="0"    Path="ClassEmpire/ClassColonizedStarSystem/PlanetTypeOcean" TooltipHidden="true"/>
+        <Modifier TargetProperty="PlanetInitialFIDSPenalty"        Operation="Force"     Value="0"    Path="ClassEmpire/ClassColonizedStarSystem/PlanetTypeAtoll" TooltipHidden="true"/>
+        <Modifier TargetProperty="PlanetInitialFIDSPenalty"        Operation="Force"     Value="0"    Path="ClassEmpire/ClassColonizedStarSystem/PlanetTypeBoreal" TooltipHidden="true"/>
+        <Modifier TargetProperty="PlanetInitialFIDSPenalty"        Operation="Force"     Value="0"    Path="ClassEmpire/ClassColonizedStarSystem/PlanetTypeJungle" TooltipHidden="true"/>        
+
+        <Modifier TargetProperty="AutomaticallyTurnsIntoColony" Operation="Force" Value="0" Path="ClassEmpire/ClassColonizedStarSystem" TooltipHidden="true"/>
+  </SimulationDescriptor>
+
+  <SimulationDescriptor Name="AffinityGameplayTemplars" Type="AffinityGameplay">
+
+		<!-- Better AI Empires Tweaks -->
+
+		<Property Name="BetterNakalimTweak"  BaseValue="1" />
+
+		<Modifier TargetProperty="BetterNakalimTweak" Operation="Force" Value="15" Path="ClassEmpire" TooltipHidden="true"/>
+
+
+		<Property Name="SystemsGivenToAcademy" BaseValue="0" MinValue="0"/>
+        <Modifier TargetProperty="CanUseTemples" Operation="Addition" Value="1" TooltipHidden="true"/>
+        <Modifier TargetProperty="PlanetInitialFIDSPenalty"     Operation="Force"       Value="0"   Path="ClassEmpire/ClassColonizedStarSystem/PlanetTypeForest"    TooltipHidden="true"/>
+        <Modifier TargetProperty="PlanetInitialFIDSPenalty"     Operation="Force"       Value="0"   Path="ClassEmpire/ClassColonizedStarSystem/PlanetTypeTerran"    TooltipHidden="true"/>
+        <Modifier TargetProperty="PlanetInitialFIDSPenalty"     Operation="Force"       Value="0"   Path="ClassEmpire/ClassColonizedStarSystem/PlanetTypeMonsoon"   TooltipHidden="true"/>
+        <Modifier TargetProperty="PlanetInitialFIDSPenalty"     Operation="Force"       Value="0"   Path="ClassEmpire/ClassColonizedStarSystem/PlanetTypeOcean"     TooltipHidden="true"/>
+        <Modifier TargetProperty="PlanetInitialFIDSPenalty"     Operation="Force"       Value="0"   Path="ClassEmpire/ClassColonizedStarSystem/PlanetTypeAtoll"     TooltipHidden="true"/>
+        <Modifier TargetProperty="PlanetInitialFIDSPenalty"     Operation="Force"       Value="0"   Path="ClassEmpire/ClassColonizedStarSystem/PlanetTypeBoreal"    TooltipHidden="true"/>
+        <Modifier TargetProperty="PlanetInitialFIDSPenalty"     Operation="Force"       Value="0"   Path="ClassEmpire/ClassColonizedStarSystem/PlanetTypeJungle"    TooltipHidden="true"/>
+        <Modifier TargetProperty="PlanetInitialFIDSPenalty"     Operation="Force"       Value="0"   Path="ClassEmpire/ClassColonizedStarSystem/PlanetTypeFake"      TooltipHidden="true"/>
+  </SimulationDescriptor>
+
+	<!-- Better AI Empires Additions END - EXCEPT for Unfallen below -->
+
   <SimulationDescriptor Name="AffinityGameplayVenetians" Type="AffinityGameplay">
     <!-- CanBuyoutAllOutposts = even if not colonizable -->
     <Modifier TargetProperty="CanBuyoutOutposts" Operation="Addition" Value="1" Path="ClassEmpire" TooltipHidden="true"/>
@@ -97,6 +212,13 @@
 		<Modifier TargetProperty="HostileRootLaneCostMultiplier"     	Operation="Force"		Value="2"		TooltipHidden="true"/>
 
 		<Modifier TargetProperty="CanRootSystems"    Operation="Force"   Value="1"   Path="EmpireTypeMajor" TooltipHidden="true"/>
+
+        <!-- Better AI Empires Tweaks -->
+
+		<Property Name="BetterUnfallenTweak"  BaseValue="1" />
+
+		<Modifier TargetProperty="BetterUnfallenTweak" Operation="Force" Value="1" Path="ClassEmpire" TooltipHidden="true"/>
+
 		
 		<Modifier TargetProperty="PlanetInitialFIDSPenalty"        Operation="Force"     Value="0"    Path="ClassEmpire/ClassColonizedStarSystem/PlanetTypeForest" TooltipHidden="true"/>
 		<Modifier TargetProperty="PlanetInitialFIDSPenalty"        Operation="Force"     Value="0"    Path="ClassEmpire/ClassColonizedStarSystem/PlanetTypeTerran" TooltipHidden="true"/>

--- a/Endless Space Competitive Mod/Simulation/SimulationDescriptors[GameDifficulty].xml
+++ b/Endless Space Competitive Mod/Simulation/SimulationDescriptors[GameDifficulty].xml
@@ -68,6 +68,10 @@
     <Modifier TargetProperty="DepositValue"         Operation="Addition"  Value="1.5"  Path="ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet/ClassResourceDeposit,ResourceTypeStrategic" Priority="100"/>
     <BinaryModifier TargetProperty="SiegePower"                         Operation="Addition" Left="6" BinaryOperation="Multiplication" Right="$(CommandPoints)" SearchValueFromPath="true" Path="ClassEmpire//ClassGarrisonFleet"/>
 
+	<!--Better AI Empires General OVERCOL FIX-->
+	<Modifier TargetProperty="OverColonizationThresholdHissho"          Operation="Addition"    Value="50" Path="ClassEmpire"    Priority="100" /> 
+
+
     <Modifier TargetProperty="IsAIControlled"                           Operation="Addition"        Value="1"       Path="ClassEmpire"/>
   </SimulationDescriptor>
 
@@ -103,6 +107,10 @@
     <Modifier TargetProperty="DepositValue"         Operation="Addition"  Value="2"  Path="ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet/ClassResourceDeposit,ResourceTypeStrategic" Priority="100"/>
     <BinaryModifier TargetProperty="SiegePower"                         Operation="Addition" Left="7" BinaryOperation="Multiplication" Right="$(CommandPoints)" SearchValueFromPath="true" Path="ClassEmpire//ClassGarrisonFleet"/>
     <Modifier TargetProperty="RootingIncreasePerTurn" Operation="Addition" Value="0.1" Path="ClassEmpire//ClassShip,ShipRoleRootCreator"/>
+
+	<!--Better AI Empires General OVERCOL FIX-->
+	<Modifier TargetProperty="OverColonizationThresholdHissho"          Operation="Addition"    Value="50" Path="ClassEmpire"    Priority="100" /> 
+
     
     <Modifier TargetProperty="IsAIControlled"                           Operation="Addition"        Value="1"       Path="ClassEmpire"/>
   </SimulationDescriptor>
@@ -142,6 +150,41 @@
     <Modifier TargetProperty="DepositValue"         Operation="Addition"  Value="2.5"  Path="ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet/ClassResourceDeposit,ResourceTypeStrategic" Priority="100"/>
     <BinaryModifier TargetProperty="SiegePower"                         Operation="Addition" Left="8" BinaryOperation="Multiplication" Right="$(CommandPoints)" SearchValueFromPath="true" Path="ClassEmpire//ClassGarrisonFleet"/>
     <Modifier TargetProperty="RootingIncreasePerTurn" Operation="Addition" Value="0.2" Path="ClassEmpire//ClassShip,ShipRoleRootCreator"/>
+
+	<!--Better AI Empires General OVERCOL FIX-->
+	<Modifier TargetProperty="OverColonizationThreshold"                Operation="Addition"    Value="50" Path="ClassEmpire"    Priority="100" />
+	<Modifier TargetProperty="OverColonizationThresholdHissho"          Operation="Addition"    Value="50" Path="ClassEmpire"    Priority="100" /> 
+	  
+	<!--Better AI Empires SCIENCE JUGGERNAUGHT FIX--> 
+	  <BinaryModifier TargetProperty="TechnologyCostReduction"       Operation="Addition"     Left="$(JuggernautResearchModulesCount)"  BinaryOperation="Multiplication"    Right="-0.03"   Priority="-1"   Path="ClassEmpire/ClassResearch"/>
+
+	<!--Better AI Empires General SEIGE FIX-->
+	<Modifier TargetProperty="MaximumSystemManpower"        Operation="Addition" Value="100" Path="./ColonizedStarSystemStateColony,ClassColonizedStarSystem"/>
+	<Modifier TargetProperty="MaximumManpowerPerGroundBattleTurn"        Operation="Addition" Value="50" Path="../ClassEmpire"/>  	    
+	  	  
+	<!--Better AI Empires Hissho Tweak MINING PROBE COMPENSATION-->	  
+	<BinaryModifier TargetProperty="SystemFIDSPercent"            Operation="Addition"     Left="$(BetterHisshoTweak)"  BinaryOperation="Multiplication"    Right="$(OwnedSystems)"   Priority="-1"   Path="../ClassEmpire/ClassColonizedStarSystem"/>
+
+	<!--Better AI Empires Vaulters Tweak INDUSTRY FIX-->
+	<Modifier TargetProperty="BaseTurnsBeforeNextFreeSuperColonization"	        Operation="Subtraction"    Value="6" Path="ClassEmpire"    Priority="100" />
+	  <BinaryModifier TargetProperty="PlanetRawIndustry"    Operation="Addition"     Left="$(BetterVaultersTweak)"  BinaryOperation="Multiplication"    Right="4"   Priority="-1"   Path="../ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet"/>
+	  <BinaryModifier TargetProperty="PlanetRawResearch"    Operation="Addition"     Left="$(BetterVaultersTweak)"  BinaryOperation="Multiplication"    Right="1"   Priority="-1"   Path="../ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet"/>
+	  
+	<!--Better AI Empires Nakalim Tweak INDUSTRY FIX-->
+	<BinaryModifier TargetProperty="SystemProduction"       Operation="Addition"     Left="$(BetterNakalimTweak)"  BinaryOperation="Multiplication"    Right="$(NetEmpireRelics)"   Priority="-1"   Path="../ClassEmpire/ClassColonizedStarSystem"/>
+	  <BinaryModifier TargetProperty="ProbeSpeed"       Operation="Addition"     Left="$(BetterNakalimTweak)"  BinaryOperation="Subtraction"    Right="14"   Priority="-1"   Path="../ClassEmpire"/>
+	  <BinaryModifier TargetProperty="ProbeVisionRange"       Operation="Addition"     Left="$(BetterNakalimTweak)"  BinaryOperation="Subtraction"    Right="12"   Priority="-1"   Path="../ClassEmpire"/>
+	  
+	<!--Better AI Empires Sophons Tweak INDUSTRY FIX-->
+	<BinaryModifier TargetProperty="PlanetRawIndustry"    Operation="Addition"     Left="$(BetterSophonsTweak)"  BinaryOperation="Multiplication"    Right="3"   Priority="-1"   Path="../ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet"/>
+	  <BinaryModifier TargetProperty="PlanetRawResearch"    Operation="Addition"     Left="$(BetterSophonsTweak)"  BinaryOperation="Multiplication"    Right="2"   Priority="-1"   Path="../ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet"/>
+	  	  
+	<!--Better AI Empires Horatio Tweak FOOD USE FIX-->
+	<BinaryModifier TargetProperty="SystemProduction"    Operation="Addition"    Left="$(BetterHoratioTweak)"  BinaryOperation="Multiplication"    Right="$(Population)"   Priority="-1"   Path="../ClassEmpire/ClassColonizedStarSystem"/>	  
+
+	<!--Better AI Empires Unfallen Tweak INDUSTRY FIX-->
+	<BinaryModifier TargetProperty="PlanetRawIndustry"    Operation="Addition"     Left="$(BetterUnfallenTweak)"  BinaryOperation="Multiplication"    Right="5"   Priority="-1"   Path="../ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet"/> 
+
     
     <Modifier TargetProperty="IsAIControlled"                           Operation="Addition"        Value="1"       Path="ClassEmpire"/>
   </SimulationDescriptor>
@@ -176,12 +219,50 @@
     <Modifier TargetProperty="HackingSpeedPercentMultiplier"            Operation="Percent"     Value="0.05"    Path="ClassEmpire"                                      Priority="100"/>
     <Modifier TargetProperty="MaximumEmpireProcessingPowerStock"        Operation="Addition"    Value="30"      Path="ClassEmpire"                                      Priority="100"/>
     <!--Treaties-->
-    <Modifier TargetProperty="TreatiesUpkeep"                           Operation="Multiplication"  Value="0.5"     Path="ClassEmpire"                                      Priority="100"/>
-    <Modifier TargetProperty="ScienceAgreementUpkeep"                   Operation="Multiplication"  Value="0.5"     Path="ClassEmpire"                                      Priority="100"/>
-    <Modifier TargetProperty="TradeAgreementUpkeep"                     Operation="Multiplication"  Value="0.5"     Path="ClassEmpire"                                      Priority="100"/>
+    <Modifier TargetProperty="TreatiesUpkeep"                           Operation="Multiplication"  Value="0.25"     Path="ClassEmpire"                                      Priority="100"/>
+    <Modifier TargetProperty="ScienceAgreementUpkeep"                   Operation="Multiplication"  Value="0.25"     Path="ClassEmpire"                                      Priority="100"/>
+    <Modifier TargetProperty="TradeAgreementUpkeep"                     Operation="Multiplication"  Value="0.25"     Path="ClassEmpire"                                      Priority="100"/>
     <Modifier TargetProperty="DepositValue"         Operation="Addition"  Value="3"  Path="ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet/ClassResourceDeposit,ResourceTypeStrategic" Priority="100"/>
 	  <BinaryModifier TargetProperty="SiegePower"                         Operation="Addition" Left="9" BinaryOperation="Multiplication" Right="$(CommandPoints)" SearchValueFromPath="true" Path="ClassEmpire//ClassGarrisonFleet"/>
     <Modifier TargetProperty="RootingIncreasePerTurn" Operation="Addition" Value="0.3" Path="ClassEmpire//ClassShip,ShipRoleRootCreator"/>
+
+	<!--Better AI Empires AI IMPOSSIBLE Quickstart-->
+	<Modifier TargetProperty="SystemFIDSFlat"        Operation="Addition"     Value="20"   Priority="-1"   Path="../ClassEmpire/ClassColonizedStarSystem"/>	  
+	  
+	<!--Better AI Empires General OVERCOL FIX-->
+	<Modifier TargetProperty="OverColonizationThreshold"                Operation="Addition"    Value="50" Path="ClassEmpire"    Priority="100" />
+	<Modifier TargetProperty="OverColonizationThresholdHissho"          Operation="Addition"    Value="50" Path="ClassEmpire"    Priority="100" /> 
+	  
+	<!--Better AI Empires SCIENCE JUGGERNAUGHT FIX--> 
+	  <BinaryModifier TargetProperty="TechnologyCostReduction"       Operation="Addition"     Left="$(JuggernautResearchModulesCount)"  BinaryOperation="Multiplication"    Right="-0.04"   Priority="-1"   Path="ClassEmpire/ClassResearch"/>
+
+	<!--Better AI Empires General SEIGE FIX-->
+	<Modifier TargetProperty="MaximumSystemManpower"        Operation="Addition" Value="200" Path="./ColonizedStarSystemStateColony,ClassColonizedStarSystem"/>
+	<Modifier TargetProperty="MaximumManpowerPerGroundBattleTurn"        Operation="Addition" Value="100" Path="../ClassEmpire"/>  	    
+	  	  
+	<!--Better AI Empires Hissho Tweak MINING PROBE COMPENSATION-->	  
+	<BinaryModifier TargetProperty="SystemFIDSPercent"            Operation="Addition"     Left="$(BetterHisshoTweak)"  BinaryOperation="Multiplication"    Right="$(OwnedSystems)"   Priority="-1"   Path="../ClassEmpire/ClassColonizedStarSystem"/>
+
+	<!--Better AI Empires Vaulters Tweak INDUSTRY FIX-->
+	<Modifier TargetProperty="BaseTurnsBeforeNextFreeSuperColonization"	        Operation="Subtraction"    Value="6" Path="ClassEmpire"    Priority="100" />
+	  <BinaryModifier TargetProperty="PlanetRawIndustry"    Operation="Addition"     Left="$(BetterVaultersTweak)"  BinaryOperation="Multiplication"    Right="6"   Priority="-1"   Path="../ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet"/>
+	  <BinaryModifier TargetProperty="PlanetRawResearch"    Operation="Addition"     Left="$(BetterVaultersTweak)"  BinaryOperation="Multiplication"    Right="1"   Priority="-1"   Path="../ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet"/>
+	  
+	<!--Better AI Empires Nakalim Tweak INDUSTRY FIX-->
+	<BinaryModifier TargetProperty="SystemProduction"       Operation="Addition"     Left="$(BetterNakalimTweak)"  BinaryOperation="Multiplication"    Right="$(NetEmpireRelics)"   Priority="-1"   Path="../ClassEmpire/ClassColonizedStarSystem"/>
+	  <BinaryModifier TargetProperty="ProbeSpeed"       Operation="Addition"     Left="$(BetterNakalimTweak)"  BinaryOperation="Subtraction"    Right="14"   Priority="-1"   Path="../ClassEmpire"/>
+	  <BinaryModifier TargetProperty="ProbeVisionRange"       Operation="Addition"     Left="$(BetterNakalimTweak)"  BinaryOperation="Subtraction"    Right="12"   Priority="-1"   Path="../ClassEmpire"/>
+	  
+	<!--Better AI Empires Sophons Tweak INDUSTRY FIX-->
+	<BinaryModifier TargetProperty="PlanetRawIndustry"    Operation="Addition"     Left="$(BetterSophonsTweak)"  BinaryOperation="Multiplication"    Right="5"   Priority="-1"   Path="../ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet"/>
+	  <BinaryModifier TargetProperty="PlanetRawResearch"    Operation="Addition"     Left="$(BetterSophonsTweak)"  BinaryOperation="Multiplication"    Right="2"   Priority="-1"   Path="../ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet"/>
+	  	  
+	<!--Better AI Empires Horatio Tweak FOOD USE FIX-->
+	<BinaryModifier TargetProperty="SystemProduction"    Operation="Addition"    Left="$(BetterHoratioTweak)"  BinaryOperation="Multiplication"    Right="$(Population)"   Priority="-1"   Path="../ClassEmpire/ClassColonizedStarSystem"/>	  
+
+	<!--Better AI Empires Unfallen Tweak INDUSTRY FIX-->
+	<BinaryModifier TargetProperty="PlanetRawIndustry"    Operation="Addition"     Left="$(BetterUnfallenTweak)"  BinaryOperation="Multiplication"    Right="7"   Priority="-1"   Path="../ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet"/>
+
     
     <Modifier TargetProperty="IsAIControlled"                           Operation="Addition"        Value="1"       Path="ClassEmpire"/>
   </SimulationDescriptor>
@@ -202,11 +283,11 @@
     <Modifier TargetProperty="NetShipProbe"                              Operation="Multiplication" Value="2"    Path="../ClassEmpire/ClassGarrison/ClassShip,!ShipRoleBehemoth" Priority="999"/>
     <Modifier TargetProperty="MaximumMovement"                           Operation="Multiplication" Value="2"    Path="../ClassEmpire/ClassGarrison/ClassShip,ShipRoleExploration" Priority="999"/>
 
-    <Modifier TargetProperty="NetEmpireHonor"                            Operation="Addition"       Value="2"    Path="ClassEmpire"                                      Priority="100" />
+    <Modifier TargetProperty="NetEmpireHonor"                            Operation="Addition"       Value="5"    Path="ClassEmpire"                                      Priority="100" />
     <BinaryModifier TargetProperty="NetEmpireHonor"                      Operation="Addition"       Left="2"     BinaryOperation="Multiplication"   Right="$(IsOverColonizationThreshold)"  Path="ClassEmpire"  Priority="100" SearchValueFromPath="true" />
     <!-- Lifeforce compensation -->
     <Modifier TargetProperty="NetEmpireLifeforce_AIBonus"   Operation="Addition"          Value="$(MothershipCount)"  Path="ClassEmpire" />
-    <Modifier TargetProperty="NetEmpireLifeforce_AIBonus"   Operation="Multiplication"    Value="45"  Path="ClassEmpire" />
+    <Modifier TargetProperty="NetEmpireLifeforce_AIBonus"   Operation="Multiplication"    Value="80"  Path="ClassEmpire" />
     <Modifier TargetProperty="NetEmpireLifeforce_AIBonus"   Operation="Division"          Value="$(LeechingFleetsCount)"  Path="ClassEmpire" />
     <Modifier TargetProperty="NetEmpireLifeforce"           Operation="Addition"          Value="$(NetEmpireLifeforce_AIBonus)"  Path="ClassEmpire" />
     <!-- Simplified battle -->
@@ -217,12 +298,52 @@
     <Modifier TargetProperty="HackingSpeedPercentMultiplier"            Operation="Percent"     Value="0.1"    Path="ClassEmpire"                                      Priority="100"/>
     <Modifier TargetProperty="MaximumEmpireProcessingPowerStock"        Operation="Addition"    Value="40"     Path="ClassEmpire"                                      Priority="100"/>
     <!--Treaties-->
-    <Modifier TargetProperty="TreatiesUpkeep"                           Operation="Multiplication"  Value="0.5"     Path="ClassEmpire"                                      Priority="100"/>
-    <Modifier TargetProperty="ScienceAgreementUpkeep"                   Operation="Multiplication"  Value="0.5"     Path="ClassEmpire"                                      Priority="100"/>
-    <Modifier TargetProperty="TradeAgreementUpkeep"                     Operation="Multiplication"  Value="0.5"     Path="ClassEmpire"                                      Priority="100"/>
+    <Modifier TargetProperty="TreatiesUpkeep"                           Operation="Multiplication"  Value="0.2"     Path="ClassEmpire"                                      Priority="100"/>
+    <Modifier TargetProperty="ScienceAgreementUpkeep"                   Operation="Multiplication"  Value="0.2"     Path="ClassEmpire"                                      Priority="100"/>
+    <Modifier TargetProperty="TradeAgreementUpkeep"                     Operation="Multiplication"  Value="0.2"     Path="ClassEmpire"                                      Priority="100"/>
     <Modifier TargetProperty="DepositValue"         Operation="Addition"  Value="3"  Path="ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet/ClassResourceDeposit,ResourceTypeStrategic" Priority="100"/>
-	  <BinaryModifier TargetProperty="SiegePower"                         Operation="Addition" Left="10" BinaryOperation="Multiplication" Right="$(CommandPoints)" SearchValueFromPath="true" Path="ClassEmpire//ClassGarrisonFleet"/>
+	  <BinaryModifier TargetProperty="SiegePower"                         Operation="Addition" Left="12" BinaryOperation="Multiplication" Right="$(CommandPoints)" SearchValueFromPath="true" Path="ClassEmpire//ClassGarrisonFleet"/>
     <Modifier TargetProperty="RootingIncreasePerTurn" Operation="Addition" Value="0.5" Path="ClassEmpire//ClassShip,ShipRoleRootCreator"/>
+
+	<!--Better AI Empires - AI ENDLESS QUICKSTART-->
+	<Modifier TargetProperty="SystemFIDSFlat"        Operation="Addition"       Value="50"      Priority="-1"   Path="../ClassEmpire/ClassColonizedStarSystem"/>
+	<Modifier TargetProperty="MaximumMovement"       Operation="Addition"       Value="1"       Path="ClassEmpire/ClassGarrisonFleet/ClassShip" Priority="-100" />
+	  
+	<!--Better AI Empires General OVERCOL FIX-->
+	<Modifier TargetProperty="OverColonizationThreshold"                Operation="Addition"    Value="50" Path="ClassEmpire"    Priority="100" />
+	<Modifier TargetProperty="OverColonizationThresholdHissho"          Operation="Addition"    Value="50" Path="ClassEmpire"    Priority="100" /> 
+	  
+	<!--Better AI Empires SCIENCE JUGGERNAUGHT FIX--> 
+	  <BinaryModifier TargetProperty="TechnologyCostReduction"       Operation="Addition"     Left="$(JuggernautResearchModulesCount)"  BinaryOperation="Multiplication"    Right="-0.04"   Priority="-1"   Path="ClassEmpire/ClassResearch"/>
+
+	<!--Better AI Empires General SEIGE FIX-->
+	<Modifier TargetProperty="MaximumSystemManpower"        Operation="Addition" Value="300" Path="./ColonizedStarSystemStateColony,ClassColonizedStarSystem"/>
+	<Modifier TargetProperty="EmpireManpower"            Operation="Addition"    Value="50"  Priority="-1"   Path="../ClassEmpire"/>
+	<Modifier TargetProperty="MaximumManpowerPerGroundBattleTurn"        Operation="Addition" Value="300" Path="../ClassEmpire"/>  	    
+	  	  
+	<!--Better AI Empires Hissho Tweak MINING PROBE COMPENSATION-->	  
+	<BinaryModifier TargetProperty="SystemFIDSPercent"            Operation="Addition"     Left="$(BetterHisshoTweak)"  BinaryOperation="Multiplication"    Right="$(OwnedSystems)"   Priority="-1"   Path="../ClassEmpire/ClassColonizedStarSystem"/>
+
+	<!--Better AI Empires Vaulters Tweak INDUSTRY FIX-->
+	<Modifier TargetProperty="BaseTurnsBeforeNextFreeSuperColonization"	        Operation="Subtraction"    Value="7" Path="ClassEmpire"    Priority="100" />
+	  <BinaryModifier TargetProperty="PlanetRawIndustry"    Operation="Addition"     Left="$(BetterVaultersTweak)"  BinaryOperation="Multiplication"    Right="6"   Priority="-1"   Path="../ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet"/>
+	  <BinaryModifier TargetProperty="PlanetRawResearch"    Operation="Addition"     Left="$(BetterVaultersTweak)"  BinaryOperation="Multiplication"    Right="1"   Priority="-1"   Path="../ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet"/>
+	  
+	<!--Better AI Empires Nakalim Tweak INDUSTRY FIX-->  
+	<BinaryModifier TargetProperty="SystemProduction"       Operation="Addition"     Left="$(BetterNakalimTweak)"  BinaryOperation="Multiplication"    Right="$(NetEmpireRelics)"   Priority="-1"   Path="../ClassEmpire/ClassColonizedStarSystem"/>
+	  <BinaryModifier TargetProperty="ProbeSpeed"       Operation="Addition"     Left="$(BetterNakalimTweak)"  BinaryOperation="Subtraction"    Right="13"   Priority="-1"   Path="../ClassEmpire"/>
+	  <BinaryModifier TargetProperty="ProbeVisionRange"       Operation="Addition"     Left="$(BetterNakalimTweak)"  BinaryOperation="Subtraction"    Right="11"   Priority="-1"   Path="../ClassEmpire"/>
+	  
+	<!--Better AI Empires Sophons Tweak INDUSTRY FIX-->
+	<BinaryModifier TargetProperty="PlanetRawIndustry"    Operation="Addition"     Left="$(BetterSophonsTweak)"  BinaryOperation="Multiplication"    Right="5"   Priority="-1"   Path="../ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet"/>
+	  <BinaryModifier TargetProperty="PlanetRawResearch"    Operation="Addition"     Left="$(BetterSophonsTweak)"  BinaryOperation="Multiplication"    Right="2"   Priority="-1"   Path="../ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet"/>
+	  	  
+	<!--Better AI Empires Horatio Tweak FOOD USE FIX-->
+	<BinaryModifier TargetProperty="SystemProduction"    Operation="Addition"    Left="$(BetterHoratioTweak)"  BinaryOperation="Multiplication"    Right="$(Population)"   Priority="-1"   Path="../ClassEmpire/ClassColonizedStarSystem"/>	  
+
+	<!--Better AI Empires Unfallen Tweak INDUSTRY FIX-->
+	<BinaryModifier TargetProperty="PlanetRawIndustry"    Operation="Addition"     Left="$(BetterUnfallenTweak)"  BinaryOperation="Multiplication"    Right="7"   Priority="-1"   Path="../ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet"/>
+
     
     <Modifier TargetProperty="IsAIControlled"                           Operation="Addition"        Value="1"       Path="ClassEmpire"/>
   </SimulationDescriptor>

--- a/Endless Space Competitive Mod/Simulation/SimulationDescriptors[GameDifficulty].xml
+++ b/Endless Space Competitive Mod/Simulation/SimulationDescriptors[GameDifficulty].xml
@@ -148,7 +148,7 @@
     <Modifier TargetProperty="ScienceAgreementUpkeep"                   Operation="Multiplication"  Value="0.5"     Path="ClassEmpire"                                      Priority="100"/>
     <Modifier TargetProperty="TradeAgreementUpkeep"                     Operation="Multiplication"  Value="0.5"     Path="ClassEmpire"                                      Priority="100"/>
     <Modifier TargetProperty="DepositValue"         Operation="Addition"  Value="2.5"  Path="ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet/ClassResourceDeposit,ResourceTypeStrategic" Priority="100"/>
-    <BinaryModifier TargetProperty="SiegePower"                         Operation="Addition" Left="8" BinaryOperation="Multiplication" Right="$(CommandPoints)" SearchValueFromPath="true" Path="ClassEmpire//ClassGarrisonFleet"/>
+    <BinaryModifier TargetProperty="SiegePower"                         Operation="Addition" Left="10" BinaryOperation="Multiplication" Right="$(CommandPoints)" SearchValueFromPath="true" Path="ClassEmpire//ClassGarrisonFleet"/>
     <Modifier TargetProperty="RootingIncreasePerTurn" Operation="Addition" Value="0.2" Path="ClassEmpire//ClassShip,ShipRoleRootCreator"/>
 
 	<!--Better AI Empires General OVERCOL FIX-->
@@ -159,8 +159,10 @@
 	  <BinaryModifier TargetProperty="TechnologyCostReduction"       Operation="Addition"     Left="$(JuggernautResearchModulesCount)"  BinaryOperation="Multiplication"    Right="-0.03"   Priority="-1"   Path="ClassEmpire/ClassResearch"/>
 
 	<!--Better AI Empires General SEIGE FIX-->
-	<Modifier TargetProperty="MaximumSystemManpower"        Operation="Addition" Value="100" Path="./ColonizedStarSystemStateColony,ClassColonizedStarSystem"/>
-	<Modifier TargetProperty="MaximumManpowerPerGroundBattleTurn"        Operation="Addition" Value="50" Path="../ClassEmpire"/>  	    
+    <Modifier TargetProperty="MaximumManpowerPerGroundBattleTurn"        Operation="Addition" Value="100" Path="../ClassEmpire"/>
+    <Modifier TargetProperty="MaximumShipManpower"                        Operation="Addition"    Value="120"     Path="../ClassEmpire//ClassShip"/>
+    <Modifier TargetProperty="AdditionalGroundBattleManpowerLimit"  Operation="Addition"    Value="60"      Path="../ClassEmpire//ClassShip"/>  
+	<Modifier TargetProperty="EmpireManpower"            Operation="Addition"    Value="300"  Priority="-1"   Path="../ClassEmpire"/>	    
 	  	  
 	<!--Better AI Empires Hissho Tweak MINING PROBE COMPENSATION-->	  
 	<BinaryModifier TargetProperty="SystemFIDSPercent"            Operation="Addition"     Left="$(BetterHisshoTweak)"  BinaryOperation="Multiplication"    Right="$(OwnedSystems)"   Priority="-1"   Path="../ClassEmpire/ClassColonizedStarSystem"/>
@@ -185,6 +187,9 @@
 	<!--Better AI Empires Unfallen Tweak INDUSTRY FIX-->
 	<BinaryModifier TargetProperty="PlanetRawIndustry"    Operation="Addition"     Left="$(BetterUnfallenTweak)"  BinaryOperation="Multiplication"    Right="5"   Priority="-1"   Path="../ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet"/> 
 
+	<!--Better AI Empires Craver SHIP COST FIX-->
+	<BinaryModifier TargetProperty="ShipProductionCostReduction"    Operation="Addition"     Left="$(BetterCraversTweak)"  BinaryOperation="Multiplication"    Right="-0.07" Priority="-1"   Path="ClassEmpire/ClassColonizedStarSystem"/>
+    
     
     <Modifier TargetProperty="IsAIControlled"                           Operation="Addition"        Value="1"       Path="ClassEmpire"/>
   </SimulationDescriptor>
@@ -223,7 +228,7 @@
     <Modifier TargetProperty="ScienceAgreementUpkeep"                   Operation="Multiplication"  Value="0.25"     Path="ClassEmpire"                                      Priority="100"/>
     <Modifier TargetProperty="TradeAgreementUpkeep"                     Operation="Multiplication"  Value="0.25"     Path="ClassEmpire"                                      Priority="100"/>
     <Modifier TargetProperty="DepositValue"         Operation="Addition"  Value="3"  Path="ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet/ClassResourceDeposit,ResourceTypeStrategic" Priority="100"/>
-	  <BinaryModifier TargetProperty="SiegePower"                         Operation="Addition" Left="9" BinaryOperation="Multiplication" Right="$(CommandPoints)" SearchValueFromPath="true" Path="ClassEmpire//ClassGarrisonFleet"/>
+	  <BinaryModifier TargetProperty="SiegePower"                         Operation="Addition" Left="18" BinaryOperation="Multiplication" Right="$(CommandPoints)" SearchValueFromPath="true" Path="ClassEmpire//ClassGarrisonFleet"/>
     <Modifier TargetProperty="RootingIncreasePerTurn" Operation="Addition" Value="0.3" Path="ClassEmpire//ClassShip,ShipRoleRootCreator"/>
 
 	<!--Better AI Empires AI IMPOSSIBLE Quickstart-->
@@ -237,8 +242,10 @@
 	  <BinaryModifier TargetProperty="TechnologyCostReduction"       Operation="Addition"     Left="$(JuggernautResearchModulesCount)"  BinaryOperation="Multiplication"    Right="-0.04"   Priority="-1"   Path="ClassEmpire/ClassResearch"/>
 
 	<!--Better AI Empires General SEIGE FIX-->
-	<Modifier TargetProperty="MaximumSystemManpower"        Operation="Addition" Value="200" Path="./ColonizedStarSystemStateColony,ClassColonizedStarSystem"/>
-	<Modifier TargetProperty="MaximumManpowerPerGroundBattleTurn"        Operation="Addition" Value="100" Path="../ClassEmpire"/>  	    
+    <Modifier TargetProperty="MaximumManpowerPerGroundBattleTurn"           Operation="Addition" Value="100" Path="../ClassEmpire"/>
+    <Modifier TargetProperty="MaximumShipManpower"                          Operation="Addition"    Value="150"     Path="../ClassEmpire//ClassShip"/>
+    <Modifier TargetProperty="AdditionalGroundBattleManpowerLimit"          Operation="Addition"    Value="75"      Path="../ClassEmpire//ClassShip"/>  
+	<Modifier TargetProperty="EmpireManpower"                               Operation="Addition"    Value="400"  Priority="-1"   Path="../ClassEmpire"/>
 	  	  
 	<!--Better AI Empires Hissho Tweak MINING PROBE COMPENSATION-->	  
 	<BinaryModifier TargetProperty="SystemFIDSPercent"            Operation="Addition"     Left="$(BetterHisshoTweak)"  BinaryOperation="Multiplication"    Right="$(OwnedSystems)"   Priority="-1"   Path="../ClassEmpire/ClassColonizedStarSystem"/>
@@ -263,6 +270,8 @@
 	<!--Better AI Empires Unfallen Tweak INDUSTRY FIX-->
 	<BinaryModifier TargetProperty="PlanetRawIndustry"    Operation="Addition"     Left="$(BetterUnfallenTweak)"  BinaryOperation="Multiplication"    Right="7"   Priority="-1"   Path="../ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet"/>
 
+	<!--Better AI Empires Craver SHIP COST FIX-->
+	<BinaryModifier TargetProperty="ShipProductionCostReduction"    Operation="Addition"     Left="$(BetterCraversTweak)"  BinaryOperation="Multiplication"    Right="-0.10" Priority="-1"   Path="ClassEmpire/ClassColonizedStarSystem"/>
     
     <Modifier TargetProperty="IsAIControlled"                           Operation="Addition"        Value="1"       Path="ClassEmpire"/>
   </SimulationDescriptor>
@@ -283,11 +292,11 @@
     <Modifier TargetProperty="NetShipProbe"                              Operation="Multiplication" Value="2"    Path="../ClassEmpire/ClassGarrison/ClassShip,!ShipRoleBehemoth" Priority="999"/>
     <Modifier TargetProperty="MaximumMovement"                           Operation="Multiplication" Value="2"    Path="../ClassEmpire/ClassGarrison/ClassShip,ShipRoleExploration" Priority="999"/>
 
-    <Modifier TargetProperty="NetEmpireHonor"                            Operation="Addition"       Value="5"    Path="ClassEmpire"                                      Priority="100" />
+    <Modifier TargetProperty="NetEmpireHonor"                            Operation="Addition"       Value="2"    Path="ClassEmpire"                                      Priority="100" />
     <BinaryModifier TargetProperty="NetEmpireHonor"                      Operation="Addition"       Left="2"     BinaryOperation="Multiplication"   Right="$(IsOverColonizationThreshold)"  Path="ClassEmpire"  Priority="100" SearchValueFromPath="true" />
     <!-- Lifeforce compensation -->
     <Modifier TargetProperty="NetEmpireLifeforce_AIBonus"   Operation="Addition"          Value="$(MothershipCount)"  Path="ClassEmpire" />
-    <Modifier TargetProperty="NetEmpireLifeforce_AIBonus"   Operation="Multiplication"    Value="80"  Path="ClassEmpire" />
+    <Modifier TargetProperty="NetEmpireLifeforce_AIBonus"   Operation="Multiplication"    Value="45"  Path="ClassEmpire" />
     <Modifier TargetProperty="NetEmpireLifeforce_AIBonus"   Operation="Division"          Value="$(LeechingFleetsCount)"  Path="ClassEmpire" />
     <Modifier TargetProperty="NetEmpireLifeforce"           Operation="Addition"          Value="$(NetEmpireLifeforce_AIBonus)"  Path="ClassEmpire" />
     <!-- Simplified battle -->
@@ -302,7 +311,7 @@
     <Modifier TargetProperty="ScienceAgreementUpkeep"                   Operation="Multiplication"  Value="0.2"     Path="ClassEmpire"                                      Priority="100"/>
     <Modifier TargetProperty="TradeAgreementUpkeep"                     Operation="Multiplication"  Value="0.2"     Path="ClassEmpire"                                      Priority="100"/>
     <Modifier TargetProperty="DepositValue"         Operation="Addition"  Value="3"  Path="ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet/ClassResourceDeposit,ResourceTypeStrategic" Priority="100"/>
-	  <BinaryModifier TargetProperty="SiegePower"                         Operation="Addition" Left="12" BinaryOperation="Multiplication" Right="$(CommandPoints)" SearchValueFromPath="true" Path="ClassEmpire//ClassGarrisonFleet"/>
+	  <BinaryModifier TargetProperty="SiegePower"                         Operation="Addition" Left="20" BinaryOperation="Multiplication" Right="$(CommandPoints)" SearchValueFromPath="true" Path="ClassEmpire//ClassGarrisonFleet"/>
     <Modifier TargetProperty="RootingIncreasePerTurn" Operation="Addition" Value="0.5" Path="ClassEmpire//ClassShip,ShipRoleRootCreator"/>
 
 	<!--Better AI Empires - AI ENDLESS QUICKSTART-->
@@ -317,9 +326,10 @@
 	  <BinaryModifier TargetProperty="TechnologyCostReduction"       Operation="Addition"     Left="$(JuggernautResearchModulesCount)"  BinaryOperation="Multiplication"    Right="-0.04"   Priority="-1"   Path="ClassEmpire/ClassResearch"/>
 
 	<!--Better AI Empires General SEIGE FIX-->
-	<Modifier TargetProperty="MaximumSystemManpower"        Operation="Addition" Value="300" Path="./ColonizedStarSystemStateColony,ClassColonizedStarSystem"/>
-	<Modifier TargetProperty="EmpireManpower"            Operation="Addition"    Value="50"  Priority="-1"   Path="../ClassEmpire"/>
-	<Modifier TargetProperty="MaximumManpowerPerGroundBattleTurn"        Operation="Addition" Value="300" Path="../ClassEmpire"/>  	    
+    <Modifier TargetProperty="MaximumManpowerPerGroundBattleTurn"           Operation="Addition" Value="100" Path="../ClassEmpire"/>
+    <Modifier TargetProperty="MaximumShipManpower"                          Operation="Addition"    Value="150"     Path="../ClassEmpire//ClassShip"/>
+    <Modifier TargetProperty="AdditionalGroundBattleManpowerLimit"          Operation="Addition"    Value="75"      Path="../ClassEmpire//ClassShip"/>  
+	<Modifier TargetProperty="EmpireManpower"                               Operation="Addition"    Value="400"  Priority="-1"   Path="../ClassEmpire"/>   
 	  	  
 	<!--Better AI Empires Hissho Tweak MINING PROBE COMPENSATION-->	  
 	<BinaryModifier TargetProperty="SystemFIDSPercent"            Operation="Addition"     Left="$(BetterHisshoTweak)"  BinaryOperation="Multiplication"    Right="$(OwnedSystems)"   Priority="-1"   Path="../ClassEmpire/ClassColonizedStarSystem"/>
@@ -331,8 +341,8 @@
 	  
 	<!--Better AI Empires Nakalim Tweak INDUSTRY FIX-->  
 	<BinaryModifier TargetProperty="SystemProduction"       Operation="Addition"     Left="$(BetterNakalimTweak)"  BinaryOperation="Multiplication"    Right="$(NetEmpireRelics)"   Priority="-1"   Path="../ClassEmpire/ClassColonizedStarSystem"/>
-	  <BinaryModifier TargetProperty="ProbeSpeed"       Operation="Addition"     Left="$(BetterNakalimTweak)"  BinaryOperation="Subtraction"    Right="13"   Priority="-1"   Path="../ClassEmpire"/>
-	  <BinaryModifier TargetProperty="ProbeVisionRange"       Operation="Addition"     Left="$(BetterNakalimTweak)"  BinaryOperation="Subtraction"    Right="11"   Priority="-1"   Path="../ClassEmpire"/>
+	  <BinaryModifier TargetProperty="ProbeSpeed"       Operation="Addition"     Left="$(BetterNakalimTweak)"  BinaryOperation="Subtraction"    Right="14"   Priority="-1"   Path="../ClassEmpire"/>
+	  <BinaryModifier TargetProperty="ProbeVisionRange"       Operation="Addition"     Left="$(BetterNakalimTweak)"  BinaryOperation="Subtraction"    Right="12"   Priority="-1"   Path="../ClassEmpire"/>
 	  
 	<!--Better AI Empires Sophons Tweak INDUSTRY FIX-->
 	<BinaryModifier TargetProperty="PlanetRawIndustry"    Operation="Addition"     Left="$(BetterSophonsTweak)"  BinaryOperation="Multiplication"    Right="5"   Priority="-1"   Path="../ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet"/>
@@ -344,6 +354,9 @@
 	<!--Better AI Empires Unfallen Tweak INDUSTRY FIX-->
 	<BinaryModifier TargetProperty="PlanetRawIndustry"    Operation="Addition"     Left="$(BetterUnfallenTweak)"  BinaryOperation="Multiplication"    Right="7"   Priority="-1"   Path="../ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet"/>
 
+	<!--Better AI Empires Craver SHIP COST FIX-->
+	<BinaryModifier TargetProperty="ShipProductionCostReduction"    Operation="Addition"     Left="$(BetterCraversTweak)"  BinaryOperation="Multiplication"    Right="-0.10" Priority="-1"   Path="ClassEmpire/ClassColonizedStarSystem"/>
+    
     
     <Modifier TargetProperty="IsAIControlled"                           Operation="Addition"        Value="1"       Path="ClassEmpire"/>
   </SimulationDescriptor>

--- a/Endless Space Competitive Mod/Simulation/SimulationDescriptors[GameDifficulty].xml
+++ b/Endless Space Competitive Mod/Simulation/SimulationDescriptors[GameDifficulty].xml
@@ -69,7 +69,7 @@
     <BinaryModifier TargetProperty="SiegePower"                         Operation="Addition" Left="6" BinaryOperation="Multiplication" Right="$(CommandPoints)" SearchValueFromPath="true" Path="ClassEmpire//ClassGarrisonFleet"/>
 
 	<!--Better AI Empires General OVERCOL FIX-->
-	<Modifier TargetProperty="OverColonizationThresholdHissho"          Operation="Addition"    Value="50" Path="ClassEmpire"    Priority="100" /> 
+	<Modifier TargetProperty="OverColonizationThresholdHissho"          Operation="Addition"    Value="10" Path="ClassEmpire"    Priority="100" />                
 
 
     <Modifier TargetProperty="IsAIControlled"                           Operation="Addition"        Value="1"       Path="ClassEmpire"/>
@@ -109,7 +109,7 @@
     <Modifier TargetProperty="RootingIncreasePerTurn" Operation="Addition" Value="0.1" Path="ClassEmpire//ClassShip,ShipRoleRootCreator"/>
 
 	<!--Better AI Empires General OVERCOL FIX-->
-	<Modifier TargetProperty="OverColonizationThresholdHissho"          Operation="Addition"    Value="50" Path="ClassEmpire"    Priority="100" /> 
+	<Modifier TargetProperty="OverColonizationThresholdHissho"          Operation="Addition"    Value="10" Path="ClassEmpire"    Priority="100" /> 
 
     
     <Modifier TargetProperty="IsAIControlled"                           Operation="Addition"        Value="1"       Path="ClassEmpire"/>
@@ -152,14 +152,13 @@
     <Modifier TargetProperty="RootingIncreasePerTurn" Operation="Addition" Value="0.2" Path="ClassEmpire//ClassShip,ShipRoleRootCreator"/>
 
 	<!--Better AI Empires General OVERCOL FIX-->
-	<Modifier TargetProperty="OverColonizationThreshold"                Operation="Addition"    Value="50" Path="ClassEmpire"    Priority="100" />
-	<Modifier TargetProperty="OverColonizationThresholdHissho"          Operation="Addition"    Value="50" Path="ClassEmpire"    Priority="100" /> 
+	<Modifier TargetProperty="OverColonizationThreshold"                Operation="Addition"    Value="13" Path="ClassEmpire"    Priority="100" />
+	<Modifier TargetProperty="OverColonizationThresholdHissho"          Operation="Addition"    Value="13" Path="ClassEmpire"    Priority="100" /> 
 	  
 	<!--Better AI Empires SCIENCE JUGGERNAUGHT FIX--> 
 	  <BinaryModifier TargetProperty="TechnologyCostReduction"       Operation="Addition"     Left="$(JuggernautResearchModulesCount)"  BinaryOperation="Multiplication"    Right="-0.03"   Priority="-1"   Path="ClassEmpire/ClassResearch"/>
 
 	<!--Better AI Empires General SEIGE FIX-->
-    <Modifier TargetProperty="MaximumManpowerPerGroundBattleTurn"        Operation="Addition" Value="100" Path="../ClassEmpire"/>
     <Modifier TargetProperty="MaximumShipManpower"                        Operation="Addition"    Value="120"     Path="../ClassEmpire//ClassShip"/>
     <Modifier TargetProperty="AdditionalGroundBattleManpowerLimit"  Operation="Addition"    Value="60"      Path="../ClassEmpire//ClassShip"/>  
 	<Modifier TargetProperty="EmpireManpower"            Operation="Addition"    Value="300"  Priority="-1"   Path="../ClassEmpire"/>	    
@@ -235,14 +234,14 @@
 	<Modifier TargetProperty="SystemFIDSFlat"        Operation="Addition"     Value="20"   Priority="-1"   Path="../ClassEmpire/ClassColonizedStarSystem"/>	  
 	  
 	<!--Better AI Empires General OVERCOL FIX-->
-	<Modifier TargetProperty="OverColonizationThreshold"                Operation="Addition"    Value="50" Path="ClassEmpire"    Priority="100" />
-	<Modifier TargetProperty="OverColonizationThresholdHissho"          Operation="Addition"    Value="50" Path="ClassEmpire"    Priority="100" /> 
+	<Modifier TargetProperty="OverColonizationThreshold"                Operation="Addition"    Value="16" Path="ClassEmpire"    Priority="100" />
+	<Modifier TargetProperty="OverColonizationThresholdHissho"          Operation="Addition"    Value="16" Path="ClassEmpire"    Priority="100" /> 
 	  
 	<!--Better AI Empires SCIENCE JUGGERNAUGHT FIX--> 
 	  <BinaryModifier TargetProperty="TechnologyCostReduction"       Operation="Addition"     Left="$(JuggernautResearchModulesCount)"  BinaryOperation="Multiplication"    Right="-0.04"   Priority="-1"   Path="ClassEmpire/ClassResearch"/>
 
 	<!--Better AI Empires General SEIGE FIX-->
-    <Modifier TargetProperty="MaximumManpowerPerGroundBattleTurn"           Operation="Addition" Value="100" Path="../ClassEmpire"/>
+
     <Modifier TargetProperty="MaximumShipManpower"                          Operation="Addition"    Value="150"     Path="../ClassEmpire//ClassShip"/>
     <Modifier TargetProperty="AdditionalGroundBattleManpowerLimit"          Operation="Addition"    Value="75"      Path="../ClassEmpire//ClassShip"/>  
 	<Modifier TargetProperty="EmpireManpower"                               Operation="Addition"    Value="400"  Priority="-1"   Path="../ClassEmpire"/>
@@ -319,14 +318,14 @@
 	<Modifier TargetProperty="MaximumMovement"       Operation="Addition"       Value="1"       Path="ClassEmpire/ClassGarrisonFleet/ClassShip" Priority="-100" />
 	  
 	<!--Better AI Empires General OVERCOL FIX-->
-	<Modifier TargetProperty="OverColonizationThreshold"                Operation="Addition"    Value="50" Path="ClassEmpire"    Priority="100" />
-	<Modifier TargetProperty="OverColonizationThresholdHissho"          Operation="Addition"    Value="50" Path="ClassEmpire"    Priority="100" /> 
+	<Modifier TargetProperty="OverColonizationThreshold"                Operation="Addition"    Value="19" Path="ClassEmpire"    Priority="100" />
+	<Modifier TargetProperty="OverColonizationThresholdHissho"          Operation="Addition"    Value="19" Path="ClassEmpire"    Priority="100" /> 
 	  
 	<!--Better AI Empires SCIENCE JUGGERNAUGHT FIX--> 
 	  <BinaryModifier TargetProperty="TechnologyCostReduction"       Operation="Addition"     Left="$(JuggernautResearchModulesCount)"  BinaryOperation="Multiplication"    Right="-0.04"   Priority="-1"   Path="ClassEmpire/ClassResearch"/>
 
 	<!--Better AI Empires General SEIGE FIX-->
-    <Modifier TargetProperty="MaximumManpowerPerGroundBattleTurn"           Operation="Addition" Value="100" Path="../ClassEmpire"/>
+
     <Modifier TargetProperty="MaximumShipManpower"                          Operation="Addition"    Value="150"     Path="../ClassEmpire//ClassShip"/>
     <Modifier TargetProperty="AdditionalGroundBattleManpowerLimit"          Operation="Addition"    Value="75"      Path="../ClassEmpire//ClassShip"/>  
 	<Modifier TargetProperty="EmpireManpower"                               Operation="Addition"    Value="400"  Priority="-1"   Path="../ClassEmpire"/>   


### PR DESCRIPTION
Resolves #1236 

Integrates about half of the changes from my mod Better AI Empires into ESG.  

https://steamcommunity.com/sharedfiles/filedetails/?id=2602129157

ONLY changes AI Empires.  Basically, removes colonization cap for AI, Gives the "we wont build industry" races an industry buff, and and adds some other minor tweaks that are lore-friendlyish, and fixes science Behemoths for AI races.

Details are in the issue.