### PR TITLE
Custom Faction Changes

### DIFF
--- a/Endless Space Competitive Mod/Simulation/Traits/PopulationModifiersTraits[1_Food].xml
+++ b/Endless Space Competitive Mod/Simulation/Traits/PopulationModifiersTraits[1_Food].xml
@@ -1507,7 +1507,7 @@
 
   <!-- Food on Strategic -->
   <!-- +2 FoodOnStrategic -->
-  <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomFoodOnStrategic00" SubCategory="Secondary" ShowInCustom="true" Cost="15">
+  <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomFoodOnStrategic00" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>HappinessStatusStarSystem3,BonusPopulationFood</Tags>
     <Modifiers>
       <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">

--- a/Endless Space Competitive Mod/Simulation/Traits/PopulationModifiersTraits[2_Industry].xml
+++ b/Endless Space Competitive Mod/Simulation/Traits/PopulationModifiersTraits[2_Industry].xml
@@ -1507,7 +1507,7 @@
 
   <!-- Industry on Strategic -->
   <!-- +2 IndustryOnStrategic -->
-  <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomIndustryOnStrategic00" SubCategory="Secondary" ShowInCustom="true" Cost="15">
+  <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomIndustryOnStrategic00" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>HappinessStatusStarSystem3,BonusPopulationIndustry</Tags>
     <Modifiers>
       <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">

--- a/Endless Space Competitive Mod/Simulation/Traits/PopulationModifiersTraits[3_Dust].xml
+++ b/Endless Space Competitive Mod/Simulation/Traits/PopulationModifiersTraits[3_Dust].xml
@@ -1507,7 +1507,7 @@
   
   <!-- Dust on Strategic -->
   <!-- +2 DustOnStrategic -->
-  <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDustOnStrategic00" SubCategory="Secondary" ShowInCustom="false" Cost="15">
+  <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDustOnStrategic00" SubCategory="Secondary" ShowInCustom="false" Cost="5">
     <Tags>HappinessStatusStarSystem3,BonusPopulationDust</Tags>
     <Modifiers>
       <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">

--- a/Endless Space Competitive Mod/Simulation/Traits/PopulationModifiersTraits[4_Science].xml
+++ b/Endless Space Competitive Mod/Simulation/Traits/PopulationModifiersTraits[4_Science].xml
@@ -1507,7 +1507,7 @@
 
   <!-- Science on Strategic -->
   <!-- +2 ScienceOnStrategic -->
-  <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomScienceOnStrategic00" SubCategory="Secondary" ShowInCustom="true" Cost="15">
+  <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomScienceOnStrategic00" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>HappinessStatusStarSystem3,BonusPopulationScience</Tags>
     <Modifiers>
       <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">

--- a/Endless Space Competitive Mod/Simulation/Traits/PopulationModifiersTraits[5_Influence].xml
+++ b/Endless Space Competitive Mod/Simulation/Traits/PopulationModifiersTraits[5_Influence].xml
@@ -840,7 +840,7 @@
 
   <!-- Prestige on Strategic -->
   <!-- +1 PrestigeOnStrategic -->
-  <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomPrestigeOnStrategic00" SubCategory="Secondary" ShowInCustom="true" Cost="15">
+  <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomPrestigeOnStrategic00" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>HappinessStatusStarSystem3,BonusPopulationPrestige</Tags>
     <Modifiers>
       <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">

--- a/Endless Space Competitive Mod/Simulation/Traits/PopulationModifiersTraits[6_Happiness].xml
+++ b/Endless Space Competitive Mod/Simulation/Traits/PopulationModifiersTraits[6_Happiness].xml
@@ -1463,7 +1463,7 @@
 
   <!-- Happiness on Strategic -->
   <!-- +2 HappinessOnStrategic -->
-  <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomHappinessOnStrategic00" SubCategory="Secondary" ShowInCustom="true" Cost="15">
+  <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomHappinessOnStrategic00" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>HappinessStatusStarSystem3,BonusPopulationHappiness</Tags>
     <Modifiers>
       <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">

--- a/Endless Space Competitive Mod/Simulation/Traits/PopulationModifiersTraits[7_Military].xml
+++ b/Endless Space Competitive Mod/Simulation/Traits/PopulationModifiersTraits[7_Military].xml
@@ -1067,7 +1067,7 @@
   
   <!-- EmpireManpower on Strategic -->
   <!-- +2 EmpireManpowerOnStrategic -->
-  <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnStrategic00" SubCategory="Secondary" ShowInCustom="true" Cost="15">
+  <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnStrategic00" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>HappinessStatusStarSystem3,BonusPopulationEmpireManpower</Tags>
     <Modifiers>
       <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
@@ -2066,7 +2066,7 @@
 
   <!-- GroundBattleBombardmentAttackerDamages on Strategic -->
   <!-- +25 GroundBattleBombardmentAttackerDamagesOnStrategic -->
-  <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnStrategic00" SubCategory="Secondary" ShowInCustom="true" Cost="15">
+  <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnStrategic00" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>HappinessStatusStarSystem3,BonusPopulationGroundBattleBombardmentAttackerDamages</Tags>
     <Modifiers>
       <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
@@ -3065,7 +3065,7 @@
 
   <!-- Defense on Strategic -->
   <!-- +25 DefenseOnStrategic -->
-  <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnStrategic00" SubCategory="Secondary" ShowInCustom="true" Cost="15">
+  <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnStrategic00" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>HappinessStatusStarSystem3,BonusPopulationDefense</Tags>
     <Modifiers>
       <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">

--- a/Endless Space Competitive Mod/Simulation/Traits/SimulationDescriptors[1_Food].xml
+++ b/Endless Space Competitive Mod/Simulation/Traits/SimulationDescriptors[1_Food].xml
@@ -915,8 +915,8 @@
   <!-- Food on Strategic -->
   <!-- +2 FoodOnStrategic -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnStrategic00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetHasDepositStrategic"/>
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet,PlanetHasDepositStrategic/ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnStrategic00" TooltipHidden="true"/>
+    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetHasDepositStrategic"/>
+    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet,PlanetHasDepositStrategic/ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnStrategic00" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnStrategic00" Type="ClassPopulationPlanet">
@@ -925,7 +925,7 @@
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationAssimilatedSecondaryCustomFoodOnStrategic00" Type="ClassPopulationAssimilated">
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="3" Path="ClassPopulation"/>
+    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="1" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
   <!-- Food on Luxury -->

--- a/Endless Space Competitive Mod/Simulation/Traits/SimulationDescriptors[2_Industry].xml
+++ b/Endless Space Competitive Mod/Simulation/Traits/SimulationDescriptors[2_Industry].xml
@@ -918,8 +918,8 @@
   <!-- Industry on Strategic -->
   <!-- +2 IndustryOnStrategic -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnStrategic00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetHasDepositStrategic"/>
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet,PlanetHasDepositStrategic/ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnStrategic00" TooltipHidden="true"/>
+    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetHasDepositStrategic"/>
+    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet,PlanetHasDepositStrategic/ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnStrategic00" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnStrategic00" Type="ClassPopulationPlanet">
@@ -928,7 +928,7 @@
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationAssimilatedSecondaryCustomIndustryOnStrategic00" Type="ClassPopulationAssimilated">
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="3" Path="ClassPopulation"/>
+    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="1" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
   <!-- Industry on Luxury -->

--- a/Endless Space Competitive Mod/Simulation/Traits/SimulationDescriptors[3_Dust].xml
+++ b/Endless Space Competitive Mod/Simulation/Traits/SimulationDescriptors[3_Dust].xml
@@ -921,8 +921,8 @@
   <!-- Dust on Strategic -->
   <!-- +2 DustOnStrategic -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnStrategic00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetHasDepositStrategic"/>
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet,PlanetHasDepositStrategic/ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnStrategic00" TooltipHidden="true"/>
+    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetHasDepositStrategic"/>
+    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet,PlanetHasDepositStrategic/ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnStrategic00" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnStrategic00" Type="ClassPopulationPlanet">
@@ -931,7 +931,7 @@
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationAssimilatedSecondaryCustomDustOnStrategic00" Type="ClassPopulationAssimilated">
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="3" Path="ClassPopulation"/>
+    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="1" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
   <!-- Dust on Luxury -->

--- a/Endless Space Competitive Mod/Simulation/Traits/SimulationDescriptors[4_Science].xml
+++ b/Endless Space Competitive Mod/Simulation/Traits/SimulationDescriptors[4_Science].xml
@@ -913,8 +913,8 @@
   <!-- Science on Strategic -->
   <!-- +2 ScienceOnStrategic -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnStrategic00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetHasDepositStrategic"/>
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet,PlanetHasDepositStrategic/ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnStrategic00" TooltipHidden="true"/>
+    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetHasDepositStrategic"/>
+    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet,PlanetHasDepositStrategic/ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnStrategic00" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnStrategic00" Type="ClassPopulationPlanet">
@@ -923,7 +923,7 @@
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationAssimilatedSecondaryCustomScienceOnStrategic00" Type="ClassPopulationAssimilated">
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="3" Path="ClassPopulation"/>
+    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="1" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
   <!-- Science on Luxury -->

--- a/Endless Space Competitive Mod/Simulation/Traits/SimulationDescriptors[5_Influence].xml
+++ b/Endless Space Competitive Mod/Simulation/Traits/SimulationDescriptors[5_Influence].xml
@@ -555,17 +555,17 @@
   <!-- Prestige on Strategic -->
   <!-- +1 PrestigeOnStrategic -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnStrategic00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetHasDepositStrategic"/>
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet,PlanetHasDepositStrategic/ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnStrategic00" TooltipHidden="true"/>
+    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetHasDepositStrategic"/>
+    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet,PlanetHasDepositStrategic/ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnStrategic00" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnStrategic00" Type="ClassPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetHasDepositStrategic"/>
-    <BinaryModifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Left="1" BinaryOperation="Multiplication" Right="$(PlanetHasStrategicDeposit)" TooltipHidden="true"/>
+    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetHasDepositStrategic"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Left="2" BinaryOperation="Multiplication" Right="$(PlanetHasStrategicDeposit)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationAssimilatedSecondaryCustomPrestigeOnStrategic00" Type="ClassPopulationAssimilated">
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="2" Path="ClassPopulation"/>
+    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="1" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
   <!-- Prestige on Luxury -->

--- a/Endless Space Competitive Mod/Simulation/Traits/SimulationDescriptors[6_Happiness].xml
+++ b/Endless Space Competitive Mod/Simulation/Traits/SimulationDescriptors[6_Happiness].xml
@@ -875,8 +875,8 @@
   <!-- Happiness on Strategic -->
   <!-- +2 HappinessOnStrategic -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnStrategic00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetHasDepositStrategic"/>
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet,PlanetHasDepositStrategic/ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnStrategic00" TooltipHidden="true"/>
+    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetHasDepositStrategic"/>
+    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet,PlanetHasDepositStrategic/ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnStrategic00" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnStrategic00" Type="ClassPopulationPlanet">
@@ -885,7 +885,7 @@
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationAssimilatedSecondaryCustomHappinessOnStrategic00" Type="ClassPopulationAssimilated">
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="2" Path="ClassPopulation"/>
+    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="1" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
   <!-- Happiness on Luxury -->


### PR DESCRIPTION
reverting a change someone made a long time ago to the strategic traits that didn't match up with the other population modifiers. Shouldn't be in use by any major or minor factions so I'm not going to bother documenting this.