### PR TITLE
Fix Academy relations defaulting to hostile

### DIFF
--- a/Endless Space Competitive Mod/Diplomacy/DiplomaticRelationStates[Academy].xml
+++ b/Endless Space Competitive Mod/Diplomacy/DiplomaticRelationStates[Academy].xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Datatable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xsi:noNamespaceSchemaLocation="../Schemas/DiplomaticRelationState.xsd">
 	<!-- Neutral / Unmet -->
-	<DiplomaticRelationState Name="AcademyDiplomaticRelationStateNeutral">
+	<DiplomaticRelationState Name="AcademyDiplomaticRelationStateNeutral" MinimumRelationPoints="-15" Type="Academy">
 		<!-- Can -->
 		<DiplomaticAbilityChange Operation="Add"    DiplomaticAbilityReference="IsKnown" />
 		<DiplomaticAbilityChange Operation="Add"    DiplomaticAbilityReference="AcademyToMajorHackInitiate"/>
@@ -30,8 +30,8 @@
 		<DiplomaticAbilityChange Operation="Remove" DiplomaticAbilityReference="UnitRecovery" />
 	</DiplomaticRelationState>
 
-	<!-- Hostile -->
-	<DiplomaticRelationState Name="AcademyDiplomaticRelationStateWar">
+	<!-- War -->
+	<DiplomaticRelationState Name="AcademyDiplomaticRelationStateWar" MinimumRelationPoints="-101" Type="Academy">
 		<!-- Can -->
 		<DiplomaticAbilityChange Operation="Add"    DiplomaticAbilityReference="IsKnown" />
 		<DiplomaticAbilityChange Operation="Add"    DiplomaticAbilityReference="AttackOwnedFleets" />
@@ -60,7 +60,7 @@
 	</DiplomaticRelationState>
 
 	<!-- Allied -->
-	<DiplomaticRelationState Name="AcademyDiplomaticRelationStateAlly">
+	<DiplomaticRelationState Name="AcademyDiplomaticRelationStateAlly" MinimumRelationPoints="50" Type="Academy">
 		<!-- Can -->
 		<DiplomaticAbilityChange Operation="Add"    DiplomaticAbilityReference="IsKnown" />
 		<DiplomaticAbilityChange Operation="Add"    DiplomaticAbilityReference="RelayTradingRoutes" />


### PR DESCRIPTION
Academy relations default to 'Hostile' after an Academy request is over, even if you end up in the lead. This is due to the missing attributes `MinimumRelationPoints` and `Type` on the DiplomaticRelationState objects in the DiplomaticRelationState[Academy].xml file.

As the `AcademyDiplomaticRelationStateHostile` is not defined in the mod (thus taking default ES2 parameters, with the expected attributes), the game would default to this state.

This pull request aims to reintroduce these missing attributes, thus fixing the bug.