### PR TITLE
Fix to population boosts

### DIFF
--- a/Endless Space Competitive Mod/Simulation/PopulationModifiersTraits.xml
+++ b/Endless Space Competitive Mod/Simulation/PopulationModifiersTraits.xml
@@ -3,7 +3,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryInfluenceFertile" SubCategory="Secondary" ShowInCustom="false" Cost="0">
     <Tags>PlanetGameplayTypeTeeming,BonusPopulationPrestige</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryInfluenceFertile"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">

--- a/Endless Space Competitive Mod/Simulation/SimulationDescriptors[PopulationCount].xml
+++ b/Endless Space Competitive Mod/Simulation/SimulationDescriptors[PopulationCount].xml
@@ -1,0 +1,346 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Datatable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xsi:noNamespaceSchemaLocation="../Schemas/Amplitude.Unity.Simulation.SimulationDescriptor.xsd">
+
+    <SimulationDescriptor Name="ClassPopulationEmpireAffinityCraversCount" Type="ClassPopulationEmpire">
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityCraversCount,ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="!ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityCraversCount,!ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+		<Modifier TargetProperty="PopulationIsBoosted" Operation="Addition" Value="${IsBoosted}" Path="../ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulation,ClassPopulationPlanetAffinityCraversCount" TooltipHidden="true"/>
+    </SimulationDescriptor>
+
+    <SimulationDescriptor Name="ClassPopulationEmpireAffinitySophonsCount" Type="ClassPopulationEmpire">
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinitySophonsCount,ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="!ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinitySophonsCount,!ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+		<Modifier TargetProperty="PopulationIsBoosted" Operation="Addition" Value="${IsBoosted}" Path="../ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulation,ClassPopulationPlanetAffinitySophonsCount" TooltipHidden="true"/>
+    </SimulationDescriptor>
+
+    <SimulationDescriptor Name="ClassPopulationEmpireAffinityVenetiansCount" Type="ClassPopulationEmpire">
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityVenetiansCount,ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="!ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityVenetiansCount,!ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+		<Modifier TargetProperty="PopulationIsBoosted" Operation="Addition" Value="${IsBoosted}" Path="../ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulation,ClassPopulationPlanetAffinityVenetiansCount" TooltipHidden="true"/>
+    </SimulationDescriptor>
+
+    <SimulationDescriptor Name="ClassPopulationEmpireAffinityVampirilisCount" Type="ClassPopulationEmpire">
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityVampirilisCount,ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="!ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityVampirilisCount,!ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+		<Modifier TargetProperty="PopulationIsBoosted" Operation="Addition" Value="${IsBoosted}" Path="../ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulation,ClassPopulationPlanetModifiersTraitPrimarySlowGrowthFIDSCount" TooltipHidden="true"/>
+    </SimulationDescriptor>
+
+    <SimulationDescriptor Name="ClassPopulationEmpireAffinityTerransCount" Type="ClassPopulationEmpire">
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityTerransCount,ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="!ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityTerransCount,!ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+		<Modifier TargetProperty="PopulationIsBoosted" Operation="Addition" Value="${IsBoosted}" Path="../ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulation,ClassPopulationPlanetAffinityTerransCount" TooltipHidden="true"/>
+    </SimulationDescriptor>
+
+    <SimulationDescriptor Name="ClassPopulationEmpireAffinityMezariCount" Type="ClassPopulationEmpire">
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityMezariCount,ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="!ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityMezariCount,!ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+		<Modifier TargetProperty="PopulationIsBoosted" Operation="Addition" Value="${IsBoosted}" Path="../ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulation,ClassPopulationPlanetAffinityMezariCount" TooltipHidden="true"/>
+    </SimulationDescriptor>
+
+    <SimulationDescriptor Name="ClassPopulationEmpireAffinitySheredynCount" Type="ClassPopulationEmpire">
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinitySheredynCount,ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="!ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinitySheredynCount,!ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+		<Modifier TargetProperty="PopulationIsBoosted" Operation="Addition" Value="${IsBoosted}" Path="../ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulation,ClassPopulationPlanetAffinitySheredynCount" TooltipHidden="true"/>
+    </SimulationDescriptor>
+
+    <SimulationDescriptor Name="ClassPopulationEmpireAffinityUnfallenCount" Type="ClassPopulationEmpire">
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityUnfallenCount,ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="!ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityUnfallenCount,!ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+		<Modifier TargetProperty="PopulationIsBoosted" Operation="Addition" Value="${IsBoosted}" Path="../ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulation,ClassPopulationPlanetAffinityUnfallenCount" TooltipHidden="true"/>
+    </SimulationDescriptor>
+
+    <SimulationDescriptor Name="ClassPopulationEmpireAffinityHoratioCount" Type="ClassPopulationEmpire">
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityHoratioCount,ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="!ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityHoratioCount,!ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+		<Modifier TargetProperty="PopulationIsBoosted" Operation="Addition" Value="${IsBoosted}" Path="../ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulation,ClassPopulationPlanetAffinityHoratioCount" TooltipHidden="true"/>
+    </SimulationDescriptor>
+
+    <SimulationDescriptor Name="ClassPopulationEmpireAffinityTimeLordsCount" Type="ClassPopulationEmpire">
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityTimeLordsCount,ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="!ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityTimeLordsCount,!ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+		<Modifier TargetProperty="PopulationIsBoosted" Operation="Addition" Value="${IsBoosted}" Path="../ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulation,ClassPopulationPlanetAffinityTimeLordsCount" TooltipHidden="true"/>
+    </SimulationDescriptor>
+
+    <SimulationDescriptor Name="ClassPopulationEmpireAffinityHaroshemsCount" Type="ClassPopulationEmpire">
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityHaroshemsCount,ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="!ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityHaroshemsCount,!ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+		<Modifier TargetProperty="PopulationIsBoosted" Operation="Addition" Value="${IsBoosted}" Path="../ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulation,ClassPopulationPlanetAffinityHaroshemsCount" TooltipHidden="true"/>
+    </SimulationDescriptor>
+
+    <SimulationDescriptor Name="ClassPopulationEmpireAffinityHisshosCount" Type="ClassPopulationEmpire">
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityHisshosCount,ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="!ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityHisshosCount,!ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+		<Modifier TargetProperty="PopulationIsBoosted" Operation="Addition" Value="${IsBoosted}" Path="../ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulation,ClassPopulationPlanetAffinityHisshosCount" TooltipHidden="true"/>
+    </SimulationDescriptor>
+
+    <SimulationDescriptor Name="ClassPopulationEmpireAffinityBenthysCount" Type="ClassPopulationEmpire">
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityBenthysCount,ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="!ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityBenthysCount,!ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+		<Modifier TargetProperty="PopulationIsBoosted" Operation="Addition" Value="${IsBoosted}" Path="../ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulation,ClassPopulationPlanetAffinityBenthysCount" TooltipHidden="true"/>
+    </SimulationDescriptor>
+
+    <SimulationDescriptor Name="ClassPopulationEmpireAffinityBotsCount" Type="ClassPopulationEmpire">
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityBotsCount,ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="!ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityBotsCount,!ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+		<Modifier TargetProperty="PopulationIsBoosted" Operation="Addition" Value="${IsBoosted}" Path="../ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulation,ClassPopulationPlanetAffinityBotsCount" TooltipHidden="true"/>
+    </SimulationDescriptor>
+
+    <SimulationDescriptor Name="ClassPopulationEmpireAffinityMavrosCount" Type="ClassPopulationEmpire">
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityMavrosCount,ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="!ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityMavrosCount,!ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+		<Modifier TargetProperty="PopulationIsBoosted" Operation="Addition" Value="${IsBoosted}" Path="../ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulation,ClassPopulationPlanetAffinityMavrosCount" TooltipHidden="true"/>
+    </SimulationDescriptor>
+
+    <SimulationDescriptor Name="ClassPopulationEmpireAffinityDeuyivansCount" Type="ClassPopulationEmpire">
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityDeuyivansCount,ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="!ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityDeuyivansCount,!ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+		<Modifier TargetProperty="PopulationIsBoosted" Operation="Addition" Value="${IsBoosted}" Path="../ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulation,ClassPopulationPlanetAffinityDeuyivansCount" TooltipHidden="true"/>
+    </SimulationDescriptor>
+
+    <SimulationDescriptor Name="ClassPopulationEmpireAffinityAmoebaCount" Type="ClassPopulationEmpire">
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityAmoebaCount,ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="!ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityAmoebaCount,!ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+		<Modifier TargetProperty="PopulationIsBoosted" Operation="Addition" Value="${IsBoosted}" Path="../ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulation,ClassPopulationPlanetAffinityAmoebaCount" TooltipHidden="true"/>
+    </SimulationDescriptor>
+
+    <SimulationDescriptor Name="ClassPopulationEmpireAffinityPilgrimsCount" Type="ClassPopulationEmpire">
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityPilgrimsCount,ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="!ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityPilgrimsCount,!ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+		<Modifier TargetProperty="PopulationIsBoosted" Operation="Addition" Value="${IsBoosted}" Path="../ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulation,ClassPopulationPlanetAffinityPilgrimsCount" TooltipHidden="true"/>
+    </SimulationDescriptor>
+
+    <SimulationDescriptor Name="ClassPopulationEmpireAffinityZvaliCount" Type="ClassPopulationEmpire">
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityZvaliCount,ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="!ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityZvaliCount,!ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+		<Modifier TargetProperty="PopulationIsBoosted" Operation="Addition" Value="${IsBoosted}" Path="../ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulation,ClassPopulationPlanetAffinityZvaliCount" TooltipHidden="true"/>
+    </SimulationDescriptor>
+
+    <SimulationDescriptor Name="ClassPopulationEmpireAffinityTikanansCount" Type="ClassPopulationEmpire">
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityTikanansCount,ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="!ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityTikanansCount,!ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+		<Modifier TargetProperty="PopulationIsBoosted" Operation="Addition" Value="${IsBoosted}" Path="../ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulation,ClassPopulationPlanetAffinityTikanansCount" TooltipHidden="true"/>
+    </SimulationDescriptor>
+
+    <SimulationDescriptor Name="ClassPopulationEmpireAffinityGnashastsCount" Type="ClassPopulationEmpire">
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityGnashastsCount,ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="!ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityGnashastsCount,!ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+		<Modifier TargetProperty="PopulationIsBoosted" Operation="Addition" Value="${IsBoosted}" Path="../ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulation,ClassPopulationPlanetAffinityGnashastsCount" TooltipHidden="true"/>
+    </SimulationDescriptor>
+
+    <SimulationDescriptor Name="ClassPopulationEmpireAffinityEydersCount" Type="ClassPopulationEmpire">
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityEydersCount,ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="!ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityEydersCount,!ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+		<Modifier TargetProperty="PopulationIsBoosted" Operation="Addition" Value="${IsBoosted}" Path="../ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulation,ClassPopulationPlanetAffinityEydersCount" TooltipHidden="true"/>
+    </SimulationDescriptor>
+
+    <SimulationDescriptor Name="ClassPopulationEmpireAffinityNirisCount" Type="ClassPopulationEmpire">
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityNirisCount,ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="!ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityNirisCount,!ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+		<Modifier TargetProperty="PopulationIsBoosted" Operation="Addition" Value="${IsBoosted}" Path="../ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulation,ClassPopulationPlanetAffinityNirisCount" TooltipHidden="true"/>
+    </SimulationDescriptor>
+
+    <SimulationDescriptor Name="ClassPopulationEmpireAffinityBhagabasCount" Type="ClassPopulationEmpire">
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityBhagabasCount,ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="!ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityBhagabasCount,!ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+		<Modifier TargetProperty="PopulationIsBoosted" Operation="Addition" Value="${IsBoosted}" Path="../ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulation,ClassPopulationPlanetAffinityBhagabasCount" TooltipHidden="true"/>
+    </SimulationDescriptor>
+
+    <SimulationDescriptor Name="ClassPopulationEmpireAffinityRemnantCount" Type="ClassPopulationEmpire">
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityRemnantCount,ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="!ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityRemnantCount,!ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+		<Modifier TargetProperty="PopulationIsBoosted" Operation="Addition" Value="${IsBoosted}" Path="../ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulation,ClassPopulationPlanetAffinityRemnantCount" TooltipHidden="true"/>
+    </SimulationDescriptor>
+
+    <SimulationDescriptor Name="ClassPopulationEmpireAffinityPulsosCount" Type="ClassPopulationEmpire">
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityPulsosCount,ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="!ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityPulsosCount,!ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+		<Modifier TargetProperty="PopulationIsBoosted" Operation="Addition" Value="${IsBoosted}" Path="../ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulation,ClassPopulationPlanetAffinityPulsosCount" TooltipHidden="true"/>
+    </SimulationDescriptor>
+
+    <SimulationDescriptor Name="ClassPopulationEmpireAffinityGreenmanCount" Type="ClassPopulationEmpire">
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityGreenmanCount,ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="!ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityGreenmanCount,!ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+		<Modifier TargetProperty="PopulationIsBoosted" Operation="Addition" Value="${IsBoosted}" Path="../ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulation,ClassPopulationPlanetAffinityGreenmanCount" TooltipHidden="true"/>
+    </SimulationDescriptor>
+
+    <SimulationDescriptor Name="ClassPopulationEmpireAffinityBasryxoCount" Type="ClassPopulationEmpire">
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityBasryxoCount,ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="!ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityBasryxoCount,!ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+		<Modifier TargetProperty="PopulationIsBoosted" Operation="Addition" Value="${IsBoosted}" Path="../ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulation,ClassPopulationPlanetAffinityBasryxoCount" TooltipHidden="true"/>
+    </SimulationDescriptor>
+
+    <SimulationDescriptor Name="ClassPopulationEmpireAffinityGuardiansCount" Type="ClassPopulationEmpire">
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityGuardiansCount,ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="!ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityGuardiansCount,!ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+		<Modifier TargetProperty="PopulationIsBoosted" Operation="Addition" Value="${IsBoosted}" Path="../ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulation,ClassPopulationPlanetAffinityGuardiansCount" TooltipHidden="true"/>
+    </SimulationDescriptor>
+
+    <SimulationDescriptor Name="ClassPopulationEmpireAffinitySuperGuardiansCount" Type="ClassPopulationEmpire">
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinitySuperGuardiansCount,ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="!ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinitySuperGuardiansCount,!ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+		<Modifier TargetProperty="PopulationIsBoosted" Operation="Addition" Value="${IsBoosted}" Path="../ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulation,ClassPopulationPlanetAffinitySuperGuardiansCount" TooltipHidden="true"/>
+    </SimulationDescriptor>
+
+    <SimulationDescriptor Name="ClassPopulationEmpireAffinityCustom0Count" Type="ClassPopulationEmpire">
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityCustom0Count,ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="!ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityCustom0Count,!ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+		<Modifier TargetProperty="PopulationIsBoosted" Operation="Addition" Value="${IsBoosted}" Path="../ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulation,ClassPopulationPlanetAffinityCustom0Count" TooltipHidden="true"/>
+    </SimulationDescriptor>
+
+    <SimulationDescriptor Name="ClassPopulationEmpireAffinityCustom1Count" Type="ClassPopulationEmpire">
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityCustom1Count,ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="!ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityCustom1Count,!ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+		<Modifier TargetProperty="PopulationIsBoosted" Operation="Addition" Value="${IsBoosted}" Path="../ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulation,ClassPopulationPlanetAffinityCustom1Count" TooltipHidden="true"/>
+    </SimulationDescriptor>
+
+    <SimulationDescriptor Name="ClassPopulationEmpireAffinityCustom2Count" Type="ClassPopulationEmpire">
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityCustom2Count,ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="!ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityCustom2Count,!ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+		<Modifier TargetProperty="PopulationIsBoosted" Operation="Addition" Value="${IsBoosted}" Path="../ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulation,ClassPopulationPlanetAffinityCustom2Count" TooltipHidden="true"/>
+    </SimulationDescriptor>
+
+    <SimulationDescriptor Name="ClassPopulationEmpireAffinityCustom3Count" Type="ClassPopulationEmpire">
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityCustom3Count,ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="!ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityCustom3Count,!ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+		<Modifier TargetProperty="PopulationIsBoosted" Operation="Addition" Value="${IsBoosted}" Path="../ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulation,ClassPopulationPlanetAffinityCustom3Count" TooltipHidden="true"/>
+    </SimulationDescriptor>
+
+    <SimulationDescriptor Name="ClassPopulationEmpireAffinityCustom4Count" Type="ClassPopulationEmpire">
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityCustom4Count,ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="!ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityCustom4Count,!ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+		<Modifier TargetProperty="PopulationIsBoosted" Operation="Addition" Value="${IsBoosted}" Path="../ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulation,ClassPopulationPlanetAffinityCustom4Count" TooltipHidden="true"/>
+    </SimulationDescriptor>
+
+    <SimulationDescriptor Name="ClassPopulationEmpireAffinityCustom5Count" Type="ClassPopulationEmpire">
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityCustom5Count,ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="!ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityCustom5Count,!ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+		<Modifier TargetProperty="PopulationIsBoosted" Operation="Addition" Value="${IsBoosted}" Path="../ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulation,ClassPopulationPlanetAffinityCustom5Count" TooltipHidden="true"/>
+    </SimulationDescriptor>
+
+    <SimulationDescriptor Name="ClassPopulationEmpireAffinityCustom6Count" Type="ClassPopulationEmpire">
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityCustom6Count,ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="!ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityCustom6Count,!ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+		<Modifier TargetProperty="PopulationIsBoosted" Operation="Addition" Value="${IsBoosted}" Path="../ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulation,ClassPopulationPlanetAffinityCustom6Count" TooltipHidden="true"/>
+    </SimulationDescriptor>
+
+    <SimulationDescriptor Name="ClassPopulationEmpireAffinityCustom7Count" Type="ClassPopulationEmpire">
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityCustom7Count,ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="!ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityCustom7Count,!ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+		<Modifier TargetProperty="PopulationIsBoosted" Operation="Addition" Value="${IsBoosted}" Path="../ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulation,ClassPopulationPlanetAffinityCustom7Count" TooltipHidden="true"/>
+    </SimulationDescriptor>
+
+    <SimulationDescriptor Name="ClassPopulationEmpireAffinityCustom8Count" Type="ClassPopulationEmpire">
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityCustom8Count,ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="!ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityCustom8Count,!ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+		<Modifier TargetProperty="PopulationIsBoosted" Operation="Addition" Value="${IsBoosted}" Path="../ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulation,ClassPopulationPlanetAffinityCustom8Count" TooltipHidden="true"/>
+    </SimulationDescriptor>
+
+    <SimulationDescriptor Name="ClassPopulationEmpireAffinityCustom9Count" Type="ClassPopulationEmpire">
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityCustom9Count,ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="!ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityCustom9Count,!ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+		<Modifier TargetProperty="PopulationIsBoosted" Operation="Addition" Value="${IsBoosted}" Path="../ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulation,ClassPopulationPlanetAffinityCustom9Count" TooltipHidden="true"/>
+    </SimulationDescriptor>
+
+    <SimulationDescriptor Name="ClassPopulationEmpireAffinityCustom10Count" Type="ClassPopulationEmpire">
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityCustom10Count,ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="!ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityCustom10Count,!ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+		<Modifier TargetProperty="PopulationIsBoosted" Operation="Addition" Value="${IsBoosted}" Path="../ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulation,ClassPopulationPlanetAffinityCustom10Count" TooltipHidden="true"/>
+    </SimulationDescriptor>
+
+    <SimulationDescriptor Name="ClassPopulationEmpireAffinityCustom11Count" Type="ClassPopulationEmpire">
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityCustom11Count,ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="!ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityCustom11Count,!ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+		<Modifier TargetProperty="PopulationIsBoosted" Operation="Addition" Value="${IsBoosted}" Path="../ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulation,ClassPopulationPlanetAffinityCustom11Count" TooltipHidden="true"/>
+    </SimulationDescriptor>
+
+    <SimulationDescriptor Name="ClassPopulationEmpireAffinityVaultersCount" Type="ClassPopulationEmpire">
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityVaultersCount,ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="!ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityVaultersCount,!ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+		<Modifier TargetProperty="PopulationIsBoosted" Operation="Addition" Value="${IsBoosted}" Path="../ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulation,ClassPopulationPlanetAffinityVaultersCount" TooltipHidden="true"/>
+    </SimulationDescriptor>
+    
+    <SimulationDescriptor Name="ClassPopulationEmpireAffinityVaultersScienceCount" Type="ClassPopulationEmpire">
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityVaultersScienceCount,ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="!ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityVaultersScienceCount,!ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+		<Modifier TargetProperty="PopulationIsBoosted" Operation="Addition" Value="${IsBoosted}" Path="../ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulation,ClassPopulationPlanetAffinityVaultersScienceCount" TooltipHidden="true"/>
+    </SimulationDescriptor>
+    
+    <SimulationDescriptor Name="ClassPopulationEmpireAffinityVaultersMilitaryCount" Type="ClassPopulationEmpire">
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityVaultersMilitaryCount,ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="!ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityVaultersMilitaryCount,!ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+		<Modifier TargetProperty="PopulationIsBoosted" Operation="Addition" Value="${IsBoosted}" Path="../ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulation,ClassPopulationPlanetAffinityVaultersMilitaryCount" TooltipHidden="true"/>
+    </SimulationDescriptor>
+
+    <SimulationDescriptor Name="ClassPopulationEmpireAffinitySistersOfMercyCount" Type="ClassPopulationEmpire">
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinitySistersOfMercyCount,ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="!ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinitySistersOfMercyCount,!ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+		<Modifier TargetProperty="PopulationIsBoosted" Operation="Addition" Value="${IsBoosted}" Path="../ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulation,ClassPopulationPlanetAffinitySistersOfMercyCount" TooltipHidden="true"/>
+    </SimulationDescriptor>
+
+    <SimulationDescriptor Name="ClassPopulationEmpireAffinityMajorHisshosCount" Type="ClassPopulationEmpire">
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityMajorHisshosCount,ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="!ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityMajorHisshosCount,!ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+        <Modifier TargetProperty="PopulationIsBoosted" Operation="Addition" Value="${IsBoosted}" Path="../ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulation,ClassPopulationPlanetAffinityMajorHisshosCount" TooltipHidden="true"/>
+    </SimulationDescriptor>
+
+    <SimulationDescriptor Name="ClassPopulationEmpireAffinityIlloCount" Type="ClassPopulationEmpire">
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityIlloCount,ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="!ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityIlloCount,!ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+        <Modifier TargetProperty="PopulationIsBoosted" Operation="Addition" Value="${IsBoosted}" Path="../ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulation,ClassPopulationPlanetAffinityIlloCount" TooltipHidden="true"/>
+    </SimulationDescriptor>
+
+    <SimulationDescriptor Name="ClassPopulationEmpireAffinityUmbralChoirCount" Type="ClassPopulationEmpire">
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityUmbralChoirCount,ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="!ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityUmbralChoirCount,!ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+        <Modifier TargetProperty="PopulationIsBoosted" Operation="Addition" Value="${IsBoosted}" Path="../ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulation,ClassPopulationPlanetAffinityUmbralChoirCount" TooltipHidden="true"/>
+    </SimulationDescriptor>
+
+    <SimulationDescriptor Name="ClassPopulationEmpireAffinityMinorHackingCount" Type="ClassPopulationEmpire">
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityMinorHackingCount,ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="!ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityMinorHackingCount,!ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+        <Modifier TargetProperty="PopulationIsBoosted" Operation="Addition" Value="${IsBoosted}" Path="../ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulation,ClassPopulationPlanetAffinityMinorHackingCount" TooltipHidden="true"/>
+    </SimulationDescriptor>
+
+    <SimulationDescriptor Name="ClassPopulationEmpireAffinityTemplarsCount" Type="ClassPopulationEmpire">
+      <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityTemplarsCount,ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+      <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="!ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityTemplarsCount,!ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+      <Modifier TargetProperty="PopulationIsBoosted" Operation="Addition" Value="${IsBoosted}" Path="../ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulation,ClassPopulationPlanetAffinityTemplarsCount" TooltipHidden="true"/>
+    </SimulationDescriptor>
+
+    <SimulationDescriptor Name="ClassPopulationEmpireAffinityMinorOracularsCount" Type="ClassPopulationEmpire">
+      <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityMinorOracularsCount,ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+      <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="!ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityMinorOracularsCount,!ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+      <Modifier TargetProperty="PopulationIsBoosted" Operation="Addition" Value="${IsBoosted}" Path="../ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulation,ClassPopulationPlanetAffinityMinorOracularsCount" TooltipHidden="true"/>
+    </SimulationDescriptor>
+
+    <SimulationDescriptor Name="ClassPopulationEmpireAffinitySowersCount" Type="ClassPopulationEmpire">
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinitySowersCount,ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="!ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinitySowersCount,!ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+        <Modifier TargetProperty="PopulationIsBoosted" Operation="Addition" Value="${IsBoosted}" Path="../ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulation,ClassPopulationPlanetAffinitySowersCount" TooltipHidden="true"/>
+    </SimulationDescriptor>
+
+    <SimulationDescriptor Name="ClassPopulationEmpireAffinityKalTikMasCount" Type="ClassPopulationEmpire">
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityKalTikMasCount,ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="!ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityKalTikMasCount,!ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+        <Modifier TargetProperty="PopulationIsBoosted" Operation="Addition" Value="${IsBoosted}" Path="../ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulation,ClassPopulationPlanetAffinityKalTikMasCount" TooltipHidden="true"/>
+    </SimulationDescriptor>
+
+    <SimulationDescriptor Name="ClassPopulationEmpireAffinitySefalorosCount" Type="ClassPopulationEmpire">
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinitySefalorosCount,ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="!ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinitySefalorosCount,!ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+        <Modifier TargetProperty="PopulationIsBoosted" Operation="Addition" Value="${IsBoosted}" Path="../ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulation,ClassPopulationPlanetAffinitySefalorosCount" TooltipHidden="true"/>
+    </SimulationDescriptor>
+
+    <SimulationDescriptor Name="ClassPopulationEmpireAffinityGalvransCount" Type="ClassPopulationEmpire">
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityGalvransCount,ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="!ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityGalvransCount,!ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+        <Modifier TargetProperty="PopulationIsBoosted" Operation="Addition" Value="${IsBoosted}" Path="../ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulation,ClassPopulationPlanetAffinityGalvransCount" TooltipHidden="true"/>
+    </SimulationDescriptor>
+
+    <SimulationDescriptor Name="ClassPopulationEmpireAffinityHarmonyCount" Type="ClassPopulationEmpire">
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityHarmonyCount,ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+        <Modifier TargetProperty="NetPopulationScore" Operation="Multiplication" Value="$(PopulationGrowthScoreModifier)" Path="!ClassPopulationEmpireSuperPopulation/../ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystemAffinityHarmonyCount,!ClassPopulationPlanetSuperPopulation" Priority="100" TooltipHidden="true"/>
+        <Modifier TargetProperty="PopulationIsBoosted" Operation="Addition" Value="${IsBoosted}" Path="../ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulation,ClassPopulationPlanetAffinityHarmonyCount" TooltipHidden="true"/>
+    </SimulationDescriptor>
+
+</Datatable>

--- a/Endless Space Competitive Mod/Simulation/SimulationDescriptors[Population].xml
+++ b/Endless Space Competitive Mod/Simulation/SimulationDescriptors[Population].xml
@@ -137,6 +137,11 @@
     <Property Name="RepletionPerTurn" BaseValue="0"/>
 
     <Property Name="PlanetHasTemple" BaseValue="0" MaxValue="1"/>
+	
+	<Property Name="PopulationIsBoosted" BaseValue="0" MaxValue="1"/>
+	<Property Name="PopulationAuxValue0" BaseValue="0"/>
+	<Property Name="PopulationAuxValue1" BaseValue="0"/>
+	<Property Name="PopulationAuxValue2" BaseValue="0"/>
 
     <!-- #### ECONOMY PROCESS ##### -->
     <!-- Common trunk -->
@@ -329,6 +334,7 @@
 
   <SimulationDescriptor Name="ClassPopulationEmpire" Type="ClassPopulation">
     <Property Name="PopulationGrowthScoreModifier" BaseValue="1"/>
+	<Property Name="IsBoosted"    BaseValue="0" MinValue="0"/>
     <Property Name="CanBeBoosted" BaseValue="1"/>
     <Property Name="PopulationEmpireDepletedPlanetCount"  BaseValue="0" MinValue="0"/>
 
@@ -339,6 +345,7 @@
     <Modifier TargetProperty="NonVampirilisPopulation"  Operation="Addition" Value="$(PopulationCount)" Path="!ClassPopulationEmpireAffinityVampirilis/./ClassEmpire" TooltipHidden="true"/>
 
     <Modifier TargetProperty="PopulationTypeCount"          Operation="Addition"       Value="1"     Path="./ClassEmpire" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="IsBoosted"				Operation="Force"    Left="$(CanBeBoosted)"		BinaryOperation="Multiplication" Right="1" Path="ClassPopulationEmpire, PopulationGrowthScoreBoosted" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <!--  Parasite affinity  -->

--- a/Endless Space Competitive Mod/Simulation/Traits/PopulationModifiersTraits[0_Removed].xml
+++ b/Endless Space Competitive Mod/Simulation/Traits/PopulationModifiersTraits[0_Removed].xml
@@ -5,7 +5,7 @@
   <!-- +1 SystemManpower -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryCustomSystemManpower00" SubCategory="Primary" ShowInCustom="false" Cost="5">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomSystemManpower00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -27,7 +27,7 @@
   <!-- +2 SystemManpower -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryCustomSystemManpower01" SubCategory="Primary" ShowInCustom="false" Cost="10">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomSystemManpower01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -49,7 +49,7 @@
   <!-- +3 SystemManpower -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryCustomSystemManpower02" SubCategory="Primary" ShowInCustom="false" Cost="15">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomSystemManpower02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -73,7 +73,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomSystemManpowerOnCold00" SubCategory="Secondary" ShowInCustom="false" Cost="5">
     <Tags>PlanetGameplayTypeCold,BonusPopulationSystemManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnCold00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -96,7 +96,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomSystemManpowerOnCold01" SubCategory="Secondary" ShowInCustom="false" Cost="10">
     <Tags>PlanetGameplayTypeCold,BonusPopulationSystemManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnCold01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -119,7 +119,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomSystemManpowerOnCold02" SubCategory="Secondary" ShowInCustom="false" Cost="15">
     <Tags>PlanetGameplayTypeCold,BonusPopulationSystemManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnCold02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -143,7 +143,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomSystemManpowerOnTemperate00" SubCategory="Secondary" ShowInCustom="false" Cost="5">
     <Tags>PlanetGameplayTypeTemperate,BonusPopulationSystemManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnTemperate00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -166,7 +166,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomSystemManpowerOnTemperate01" SubCategory="Secondary" ShowInCustom="false" Cost="10">
     <Tags>PlanetGameplayTypeTemperate,BonusPopulationSystemManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnTemperate01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -189,7 +189,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomSystemManpowerOnTemperate02" SubCategory="Secondary" ShowInCustom="false" Cost="15">
     <Tags>PlanetGameplayTypeTemperate,BonusPopulationSystemManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnTemperate02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -213,7 +213,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomSystemManpowerOnHot00" SubCategory="Secondary" ShowInCustom="false" Cost="5">
     <Tags>PlanetGameplayTypeHot,BonusPopulationSystemManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnHot00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -236,7 +236,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomSystemManpowerOnHot01" SubCategory="Secondary" ShowInCustom="false" Cost="10">
     <Tags>PlanetGameplayTypeHot,BonusPopulationSystemManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnHot01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -259,7 +259,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomSystemManpowerOnHot02" SubCategory="Secondary" ShowInCustom="false" Cost="15">
     <Tags>PlanetGameplayTypeHot,BonusPopulationSystemManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnHot02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -283,7 +283,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomSystemManpowerOnTeeming00" SubCategory="Secondary" ShowInCustom="false" Cost="5">
     <Tags>PlanetGameplayTypeTeeming,BonusPopulationSystemManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnTeeming00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -306,7 +306,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomSystemManpowerOnTeeming01" SubCategory="Secondary" ShowInCustom="false" Cost="10">
     <Tags>PlanetGameplayTypeTeeming,BonusPopulationSystemManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnTeeming01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -329,7 +329,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomSystemManpowerOnTeeming02" SubCategory="Secondary" ShowInCustom="false" Cost="15">
     <Tags>PlanetGameplayTypeTeeming,BonusPopulationSystemManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnTeeming02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -353,7 +353,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomSystemManpowerOnMeager00" SubCategory="Secondary" ShowInCustom="false" Cost="5">
     <Tags>PlanetGameplayTypeMeager,BonusPopulationSystemManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnMeager00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -376,7 +376,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomSystemManpowerOnMeager01" SubCategory="Secondary" ShowInCustom="false" Cost="10">
     <Tags>PlanetGameplayTypeMeager,BonusPopulationSystemManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnMeager01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -399,7 +399,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomSystemManpowerOnMeager02" SubCategory="Secondary" ShowInCustom="false" Cost="15">
     <Tags>PlanetGameplayTypeMeager,BonusPopulationSystemManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnMeager02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -422,7 +422,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomSystemManpowerOnGas00" SubCategory="Secondary" ShowInCustom="false" Cost="5">
     <Tags>PlanetGameplayTypeGas,BonusPopulationSystemManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnGas00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -445,7 +445,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomSystemManpowerOnGas01" SubCategory="Secondary" ShowInCustom="false" Cost="10">
     <Tags>PlanetGameplayTypeGas,BonusPopulationSystemManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnGas01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -468,7 +468,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomSystemManpowerOnGas02" SubCategory="Secondary" ShowInCustom="false" Cost="15">
     <Tags>PlanetGameplayTypeGas,BonusPopulationSystemManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnGas02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -492,7 +492,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomSystemManpowerOnHappy00" SubCategory="Secondary" ShowInCustom="false" Cost="5">
     <Tags>HappinessStatusStarSystem3,BonusPopulationSystemManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnHappy00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -515,7 +515,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomSystemManpowerOnHappy01" SubCategory="Secondary" ShowInCustom="false" Cost="10">
     <Tags>HappinessStatusStarSystem3,BonusPopulationSystemManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnHappy01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -538,7 +538,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomSystemManpowerOnHappy02" SubCategory="Secondary" ShowInCustom="false" Cost="15">
     <Tags>HappinessStatusStarSystem3,BonusPopulationSystemManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnHappy02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -562,7 +562,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomSystemManpowerOnTiny00" SubCategory="Secondary" ShowInCustom="false" Cost="5">
     <Tags>PlanetSizeTiny,BonusPopulationSystemManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnTiny00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -585,7 +585,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomSystemManpowerOnTiny01" SubCategory="Secondary" ShowInCustom="false" Cost="10">
     <Tags>PlanetSizeTiny,BonusPopulationSystemManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnTiny01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -608,7 +608,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomSystemManpowerOnTiny02" SubCategory="Secondary" ShowInCustom="false" Cost="15">
     <Tags>PlanetSizeTiny,BonusPopulationSystemManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnTiny02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -632,7 +632,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomSystemManpowerOnSmall00" SubCategory="Secondary" ShowInCustom="false" Cost="5">
     <Tags>PlanetSizeSmall,BonusPopulationSystemManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnSmall00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -655,7 +655,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomSystemManpowerOnSmall01" SubCategory="Secondary" ShowInCustom="false" Cost="10">
     <Tags>PlanetSizeSmall,BonusPopulationSystemManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnSmall01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -678,7 +678,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomSystemManpowerOnSmall02" SubCategory="Secondary" ShowInCustom="false" Cost="15">
     <Tags>PlanetSizeSmall,BonusPopulationSystemManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnSmall02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -702,7 +702,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomSystemManpowerOnMedium00" SubCategory="Secondary" ShowInCustom="false" Cost="5">
     <Tags>PlanetSizeMedium,BonusPopulationSystemManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnMedium00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -725,7 +725,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomSystemManpowerOnMedium01" SubCategory="Secondary" ShowInCustom="false" Cost="10">
     <Tags>PlanetSizeMedium,BonusPopulationSystemManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnMedium01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -748,7 +748,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomSystemManpowerOnMedium02" SubCategory="Secondary" ShowInCustom="false" Cost="15">
     <Tags>PlanetSizeMedium,BonusPopulationSystemManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnMedium02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -772,7 +772,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomSystemManpowerOnLarge00" SubCategory="Secondary" ShowInCustom="false" Cost="5">
     <Tags>PlanetSizeLarge,BonusPopulationSystemManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnLarge00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -795,7 +795,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomSystemManpowerOnLarge01" SubCategory="Secondary" ShowInCustom="false" Cost="10">
     <Tags>PlanetSizeLarge,BonusPopulationSystemManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnLarge01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -818,7 +818,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomSystemManpowerOnLarge02" SubCategory="Secondary" ShowInCustom="false" Cost="15">
     <Tags>PlanetSizeLarge,BonusPopulationSystemManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnLarge02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -842,7 +842,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomSystemManpowerOnHuge00" SubCategory="Secondary" ShowInCustom="false" Cost="5">
     <Tags>PlanetSizeHuge,BonusPopulationSystemManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnHuge00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -865,7 +865,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomSystemManpowerOnHuge01" SubCategory="Secondary" ShowInCustom="false" Cost="10">
     <Tags>PlanetSizeHuge,BonusPopulationSystemManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnHuge01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -888,7 +888,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomSystemManpowerOnHuge02" SubCategory="Secondary" ShowInCustom="false" Cost="15">
     <Tags>PlanetSizeHuge,BonusPopulationSystemManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnHuge02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -912,7 +912,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomSystemManpowerOnStrategic00" SubCategory="Secondary" ShowInCustom="false" Cost="15">
     <Tags>HappinessStatusStarSystem3,BonusPopulationSystemManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnStrategic00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -936,7 +936,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomSystemManpowerOnAnomaly00" SubCategory="Secondary" ShowInCustom="false" Cost="10">
     <Tags>PlanetAnomaly,BonusPopulationSystemManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnAnomaly00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -959,7 +959,7 @@
   <!-- +5 SystemManpowerPerMinorFaction -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomSystemManpowerPerMinorFaction00" SubCategory="Secondary" ShowInCustom="false" Cost="20">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerPerMinorFaction00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -982,7 +982,7 @@
   <!-- +5 SystemManpowerPerBackdoor -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomSystemManpowerPerBackdoor00" SubCategory="Secondary" ShowInCustom="false" Cost="15">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerPerBackdoor00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1004,7 +1004,7 @@
   <!-- SystemManpower per Temple -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomSystemManpowerPerTemple00" SubCategory="Primary" ShowInCustom="false" Cost="5">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomSystemManpowerPerTemple00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1025,7 +1025,7 @@
   <!-- SystemManpower per System Level -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomSystemManpowerPerSystemLevel00" SubCategory="Secondary" ShowInCustom="false" Cost="15">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomSystemManpowerLevel00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1048,7 +1048,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomSystemManpowerOnLuxury00" SubCategory="Secondary" ShowInCustom="false" Cost="15">
     <Tags>HappinessStatusStarSystem3,BonusPopulationSystemManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnLuxury00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">

--- a/Endless Space Competitive Mod/Simulation/Traits/PopulationModifiersTraits[10_FIDSI].xml
+++ b/Endless Space Competitive Mod/Simulation/Traits/PopulationModifiersTraits[10_FIDSI].xml
@@ -3,7 +3,7 @@
   <!-- +1 FIDSI on Ecstatic -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomFIDSIEcstatic00" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomFIDSIEcstatic00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">

--- a/Endless Space Competitive Mod/Simulation/Traits/PopulationModifiersTraits[1_Food].xml
+++ b/Endless Space Competitive Mod/Simulation/Traits/PopulationModifiersTraits[1_Food].xml
@@ -5,7 +5,7 @@
   <!-- +1 Food -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryCustomFood00" SubCategory="Primary" ShowInCustom="true" Cost="3">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomFood00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -27,7 +27,7 @@
   <!-- +2 Food -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryCustomFood01" SubCategory="Primary" ShowInCustom="true" Cost="5">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomFood01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -49,7 +49,7 @@
   <!-- +3 Food -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryCustomFood02" SubCategory="Primary" ShowInCustom="true" Cost="10">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomFood02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -71,7 +71,7 @@
   <!-- +4 Food -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryCustomFood03" SubCategory="Primary" ShowInCustom="true" Cost="12">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomFood03"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -93,7 +93,7 @@
   <!-- +5 Food -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryCustomFood04" SubCategory="Primary" ShowInCustom="true" Cost="15">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomFood04"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -118,7 +118,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomFoodOnCold00" SubCategory="Secondary" ShowInCustom="true" Cost="3">
     <Tags>PlanetGameplayTypeCold,BonusPopulationFood</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnCold00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -141,7 +141,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomFoodOnCold01" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>PlanetGameplayTypeCold,BonusPopulationFood</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnCold01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -164,7 +164,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomFoodOnCold02" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetGameplayTypeCold,BonusPopulationFood</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnCold02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -187,7 +187,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomFoodOnCold03" SubCategory="Secondary" ShowInCustom="true" Cost="12">
     <Tags>PlanetGameplayTypeCold,BonusPopulationFood</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnCold03"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -210,7 +210,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomFoodOnCold04" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>PlanetGameplayTypeCold,BonusPopulationFood</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnCold04"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -234,7 +234,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomFoodOnTemperate00" SubCategory="Secondary" ShowInCustom="true" Cost="3">
     <Tags>PlanetGameplayTypeTemperate,BonusPopulationFood</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnTemperate00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -257,7 +257,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomFoodOnTemperate01" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>PlanetGameplayTypeTemperate,BonusPopulationFood</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnTemperate01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -280,7 +280,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomFoodOnTemperate02" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetGameplayTypeTemperate,BonusPopulationFood</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnTemperate02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -303,7 +303,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomFoodOnTemperate03" SubCategory="Secondary" ShowInCustom="true" Cost="12">
     <Tags>PlanetGameplayTypeTemperate,BonusPopulationFood</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnTemperate03"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -326,7 +326,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomFoodOnTemperate04" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>PlanetGameplayTypeTemperate,BonusPopulationFood</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnTemperate04"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -350,7 +350,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomFoodOnHot00" SubCategory="Secondary" ShowInCustom="true" Cost="3">
     <Tags>PlanetGameplayTypeHot,BonusPopulationFood</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnHot00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -373,7 +373,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomFoodOnHot01" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>PlanetGameplayTypeHot,BonusPopulationFood</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnHot01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -396,7 +396,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomFoodOnHot02" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetGameplayTypeHot,BonusPopulationFood</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnHot02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -419,7 +419,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomFoodOnHot03" SubCategory="Secondary" ShowInCustom="true" Cost="12">
     <Tags>PlanetGameplayTypeHot,BonusPopulationFood</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnHot03"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -442,7 +442,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomFoodOnHot04" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>PlanetGameplayTypeHot,BonusPopulationFood</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnHot04"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -466,7 +466,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomFoodOnTeeming00" SubCategory="Secondary" ShowInCustom="true" Cost="3">
     <Tags>PlanetGameplayTypeTeeming,BonusPopulationFood</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnTeeming00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -489,7 +489,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomFoodOnTeeming01" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>PlanetGameplayTypeTeeming,BonusPopulationFood</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnTeeming01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -512,7 +512,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomFoodOnTeeming02" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetGameplayTypeTeeming,BonusPopulationFood</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnTeeming02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -535,7 +535,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomFoodOnTeeming03" SubCategory="Secondary" ShowInCustom="true" Cost="12">
     <Tags>PlanetGameplayTypeTeeming,BonusPopulationFood</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnTeeming03"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -558,7 +558,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomFoodOnTeeming04" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>PlanetGameplayTypeTeeming,BonusPopulationFood</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnTeeming04"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -582,7 +582,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomFoodOnMeager00" SubCategory="Secondary" ShowInCustom="true" Cost="3">
     <Tags>PlanetGameplayTypeMeager,BonusPopulationFood</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnMeager00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -605,7 +605,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomFoodOnMeager01" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>PlanetGameplayTypeMeager,BonusPopulationFood</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnMeager01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -628,7 +628,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomFoodOnMeager02" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetGameplayTypeMeager,BonusPopulationFood</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnMeager02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -651,7 +651,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomFoodOnMeager03" SubCategory="Secondary" ShowInCustom="true" Cost="12">
     <Tags>PlanetGameplayTypeMeager,BonusPopulationFood</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnMeager03"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -674,7 +674,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomFoodOnMeager04" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>PlanetGameplayTypeMeager,BonusPopulationFood</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnMeager04"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -698,7 +698,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomFoodOnGas00" SubCategory="Secondary" ShowInCustom="true" Cost="3">
     <Tags>PlanetGameplayTypeGas,BonusPopulationFood</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnGas00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -721,7 +721,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomFoodOnGas01" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>PlanetGameplayTypeGas,BonusPopulationFood</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnGas01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -744,7 +744,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomFoodOnGas02" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetGameplayTypeGas,BonusPopulationFood</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnGas02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -767,7 +767,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomFoodOnGas03" SubCategory="Secondary" ShowInCustom="true" Cost="12">
     <Tags>PlanetGameplayTypeGas,BonusPopulationFood</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnGas03"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -790,7 +790,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomFoodOnGas04" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>PlanetGameplayTypeGas,BonusPopulationFood</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnGas04"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -814,7 +814,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomFoodOnHappy00" SubCategory="Secondary" ShowInCustom="true" Cost="3">
     <Tags>HappinessStatusStarSystem3,BonusPopulationFood</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnHappy00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -837,7 +837,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomFoodOnHappy01" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>HappinessStatusStarSystem3,BonusPopulationFood</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnHappy01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -860,7 +860,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomFoodOnHappy02" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>HappinessStatusStarSystem3,BonusPopulationFood</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnHappy02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -883,7 +883,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomFoodOnHappy03" SubCategory="Secondary" ShowInCustom="true" Cost="12">
     <Tags>HappinessStatusStarSystem3,BonusPopulationFood</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnHappy03"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -906,7 +906,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomFoodOnHappy04" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>HappinessStatusStarSystem3,BonusPopulationFood</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnHappy04"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -930,7 +930,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomFoodOnTiny00" SubCategory="Secondary" ShowInCustom="false" Cost="3">
     <Tags>PlanetSizeTiny,BonusPopulationFood</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnTiny00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -953,7 +953,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomFoodOnTiny01" SubCategory="Secondary" ShowInCustom="false" Cost="5">
     <Tags>PlanetSizeTiny,BonusPopulationFood</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnTiny01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -976,7 +976,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomFoodOnTiny02" SubCategory="Secondary" ShowInCustom="false" Cost="10">
     <Tags>PlanetSizeTiny,BonusPopulationFood</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnTiny02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -999,7 +999,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomFoodOnTiny03" SubCategory="Secondary" ShowInCustom="false" Cost="12">
     <Tags>PlanetSizeTiny,BonusPopulationFood</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnTiny03"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1022,7 +1022,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomFoodOnTiny04" SubCategory="Secondary" ShowInCustom="false" Cost="15">
     <Tags>PlanetSizeTiny,BonusPopulationFood</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnTiny04"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1046,7 +1046,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomFoodOnSmall00" SubCategory="Secondary" ShowInCustom="false" Cost="3">
     <Tags>PlanetSizeSmall,BonusPopulationFood</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnSmall00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1069,7 +1069,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomFoodOnSmall01" SubCategory="Secondary" ShowInCustom="false" Cost="5">
     <Tags>PlanetSizeSmall,BonusPopulationFood</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnSmall01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1092,7 +1092,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomFoodOnSmall02" SubCategory="Secondary" ShowInCustom="false" Cost="10">
     <Tags>PlanetSizeSmall,BonusPopulationFood</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnSmall02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1115,7 +1115,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomFoodOnSmall03" SubCategory="Secondary" ShowInCustom="false" Cost="12">
     <Tags>PlanetSizeSmall,BonusPopulationFood</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnSmall03"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1138,7 +1138,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomFoodOnSmall04" SubCategory="Secondary" ShowInCustom="false" Cost="15">
     <Tags>PlanetSizeSmall,BonusPopulationFood</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnSmall04"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1162,7 +1162,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomFoodOnMedium00" SubCategory="Secondary" ShowInCustom="false" Cost="3">
     <Tags>PlanetSizeMedium,BonusPopulationFood</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnMedium00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1185,7 +1185,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomFoodOnMedium01" SubCategory="Secondary" ShowInCustom="false" Cost="5">
     <Tags>PlanetSizeMedium,BonusPopulationFood</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnMedium01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1208,7 +1208,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomFoodOnMedium02" SubCategory="Secondary" ShowInCustom="false" Cost="10">
     <Tags>PlanetSizeMedium,BonusPopulationFood</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnMedium02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1231,7 +1231,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomFoodOnMedium03" SubCategory="Secondary" ShowInCustom="false" Cost="12">
     <Tags>PlanetSizeMedium,BonusPopulationFood</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnMedium03"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1254,7 +1254,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomFoodOnMedium04" SubCategory="Secondary" ShowInCustom="false" Cost="15">
     <Tags>PlanetSizeMedium,BonusPopulationFood</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnMedium04"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1278,7 +1278,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomFoodOnLarge00" SubCategory="Secondary" ShowInCustom="false" Cost="3">
     <Tags>PlanetSizeLarge,BonusPopulationFood</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnLarge00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1301,7 +1301,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomFoodOnLarge01" SubCategory="Secondary" ShowInCustom="false" Cost="5">
     <Tags>PlanetSizeLarge,BonusPopulationFood</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnLarge01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1324,7 +1324,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomFoodOnLarge02" SubCategory="Secondary" ShowInCustom="false" Cost="10">
     <Tags>PlanetSizeLarge,BonusPopulationFood</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnLarge02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1347,7 +1347,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomFoodOnLarge03" SubCategory="Secondary" ShowInCustom="false" Cost="12">
     <Tags>PlanetSizeLarge,BonusPopulationFood</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnLarge03"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1370,7 +1370,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomFoodOnLarge04" SubCategory="Secondary" ShowInCustom="false" Cost="15">
     <Tags>PlanetSizeLarge,BonusPopulationFood</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnLarge04"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1394,7 +1394,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomFoodOnHuge00" SubCategory="Secondary" ShowInCustom="false" Cost="3">
     <Tags>PlanetSizeHuge,BonusPopulationFood</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnHuge00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1417,7 +1417,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomFoodOnHuge01" SubCategory="Secondary" ShowInCustom="false" Cost="5">
     <Tags>PlanetSizeHuge,BonusPopulationFood</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnHuge01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1440,7 +1440,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomFoodOnHuge02" SubCategory="Secondary" ShowInCustom="false" Cost="10">
     <Tags>PlanetSizeHuge,BonusPopulationFood</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnHuge02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1463,7 +1463,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomFoodOnHuge03" SubCategory="Secondary" ShowInCustom="false" Cost="12">
     <Tags>PlanetSizeHuge,BonusPopulationFood</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnHuge03"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1486,7 +1486,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomFoodOnHuge04" SubCategory="Secondary" ShowInCustom="false" Cost="15">
     <Tags>PlanetSizeHuge,BonusPopulationFood</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnHuge04"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1510,7 +1510,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomFoodOnStrategic00" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>HappinessStatusStarSystem3,BonusPopulationFood</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnStrategic00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1534,7 +1534,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomFoodOnAnomaly00" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetAnomaly,BonusPopulationFood</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnAnomaly00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1557,7 +1557,7 @@
   <!-- +2 FoodPerMinorFaction -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomFoodPerMinorFaction00" SubCategory="Secondary" ShowInCustom="true" Cost="20">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodPerMinorFaction00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1580,7 +1580,7 @@
   <!-- +2 FoodPerBackdoor -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomFoodPerBackdoor00" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodPerBackdoor00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1602,7 +1602,7 @@
   <!-- Food per Temple -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomFoodPerTemple00" SubCategory="Primary" ShowInCustom="true" Cost="5">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomFoodPerTemple00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1623,7 +1623,7 @@
   <!-- Food per System Level -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomFoodPerSystemLevel00" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomFoodLevel00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1646,7 +1646,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomFoodOnLuxury00" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>HappinessStatusStarSystem3,BonusPopulationFood</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnLuxury00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">

--- a/Endless Space Competitive Mod/Simulation/Traits/PopulationModifiersTraits[2_Industry].xml
+++ b/Endless Space Competitive Mod/Simulation/Traits/PopulationModifiersTraits[2_Industry].xml
@@ -5,7 +5,7 @@
   <!-- +1 Industry -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryCustomIndustry00" SubCategory="Primary" ShowInCustom="true" Cost="3">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomIndustry00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -27,7 +27,7 @@
   <!-- +2 Industry -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryCustomIndustry01" SubCategory="Primary" ShowInCustom="true" Cost="5">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomIndustry01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -49,7 +49,7 @@
   <!-- +3 Industry -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryCustomIndustry02" SubCategory="Primary" ShowInCustom="true" Cost="10">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomIndustry02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -71,7 +71,7 @@
   <!-- +4 Industry -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryCustomIndustry03" SubCategory="Primary" ShowInCustom="true" Cost="12">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomIndustry03"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -93,7 +93,7 @@
   <!-- +5 Industry -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryCustomIndustry04" SubCategory="Primary" ShowInCustom="true" Cost="15">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomIndustry04"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -118,7 +118,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomIndustryOnCold00" SubCategory="Secondary" ShowInCustom="true" Cost="3">
     <Tags>PlanetGameplayTypeCold,BonusPopulationIndustry</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnCold00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -141,7 +141,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomIndustryOnCold01" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>PlanetGameplayTypeCold,BonusPopulationIndustry</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnCold01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -164,7 +164,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomIndustryOnCold02" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetGameplayTypeCold,BonusPopulationIndustry</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnCold02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -187,7 +187,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomIndustryOnCold03" SubCategory="Secondary" ShowInCustom="true" Cost="12">
     <Tags>PlanetGameplayTypeCold,BonusPopulationIndustry</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnCold03"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -210,7 +210,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomIndustryOnCold04" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>PlanetGameplayTypeCold,BonusPopulationIndustry</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnCold04"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -234,7 +234,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomIndustryOnTemperate00" SubCategory="Secondary" ShowInCustom="true" Cost="3">
     <Tags>PlanetGameplayTypeTemperate,BonusPopulationIndustry</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnTemperate00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -257,7 +257,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomIndustryOnTemperate01" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>PlanetGameplayTypeTemperate,BonusPopulationIndustry</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnTemperate01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -280,7 +280,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomIndustryOnTemperate02" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetGameplayTypeTemperate,BonusPopulationIndustry</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnTemperate02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -303,7 +303,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomIndustryOnTemperate03" SubCategory="Secondary" ShowInCustom="true" Cost="12">
     <Tags>PlanetGameplayTypeTemperate,BonusPopulationIndustry</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnTemperate03"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -326,7 +326,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomIndustryOnTemperate04" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>PlanetGameplayTypeTemperate,BonusPopulationIndustry</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnTemperate04"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -350,7 +350,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomIndustryOnHot00" SubCategory="Secondary" ShowInCustom="true" Cost="3">
     <Tags>PlanetGameplayTypeHot,BonusPopulationIndustry</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnHot00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -373,7 +373,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomIndustryOnHot01" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>PlanetGameplayTypeHot,BonusPopulationIndustry</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnHot01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -396,7 +396,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomIndustryOnHot02" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetGameplayTypeHot,BonusPopulationIndustry</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnHot02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -419,7 +419,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomIndustryOnHot03" SubCategory="Secondary" ShowInCustom="true" Cost="12">
     <Tags>PlanetGameplayTypeHot,BonusPopulationIndustry</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnHot03"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -442,7 +442,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomIndustryOnHot04" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>PlanetGameplayTypeHot,BonusPopulationIndustry</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnHot04"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -466,7 +466,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomIndustryOnTeeming00" SubCategory="Secondary" ShowInCustom="true" Cost="3">
     <Tags>PlanetGameplayTypeTeeming,BonusPopulationIndustry</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnTeeming00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -489,7 +489,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomIndustryOnTeeming01" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>PlanetGameplayTypeTeeming,BonusPopulationIndustry</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnTeeming01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -512,7 +512,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomIndustryOnTeeming02" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetGameplayTypeTeeming,BonusPopulationIndustry</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnTeeming02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -535,7 +535,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomIndustryOnTeeming03" SubCategory="Secondary" ShowInCustom="true" Cost="12">
     <Tags>PlanetGameplayTypeTeeming,BonusPopulationIndustry</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnTeeming03"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -558,7 +558,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomIndustryOnTeeming04" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>PlanetGameplayTypeTeeming,BonusPopulationIndustry</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnTeeming04"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -582,7 +582,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomIndustryOnMeager00" SubCategory="Secondary" ShowInCustom="true" Cost="3">
     <Tags>PlanetGameplayTypeMeager,BonusPopulationIndustry</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnMeager00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -605,7 +605,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomIndustryOnMeager01" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>PlanetGameplayTypeMeager,BonusPopulationIndustry</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnMeager01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -628,7 +628,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomIndustryOnMeager02" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetGameplayTypeMeager,BonusPopulationIndustry</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnMeager02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -651,7 +651,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomIndustryOnMeager03" SubCategory="Secondary" ShowInCustom="true" Cost="12">
     <Tags>PlanetGameplayTypeMeager,BonusPopulationIndustry</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnMeager03"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -674,7 +674,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomIndustryOnMeager04" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>PlanetGameplayTypeMeager,BonusPopulationIndustry</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnMeager04"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -698,7 +698,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomIndustryOnGas00" SubCategory="Secondary" ShowInCustom="true" Cost="3">
     <Tags>PlanetGameplayTypeGas,BonusPopulationIndustry</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnGas00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -721,7 +721,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomIndustryOnGas01" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>PlanetGameplayTypeGas,BonusPopulationIndustry</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnGas01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -744,7 +744,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomIndustryOnGas02" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetGameplayTypeGas,BonusPopulationIndustry</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnGas02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -767,7 +767,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomIndustryOnGas03" SubCategory="Secondary" ShowInCustom="true" Cost="12">
     <Tags>PlanetGameplayTypeGas,BonusPopulationIndustry</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnGas03"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -790,7 +790,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomIndustryOnGas04" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>PlanetGameplayTypeGas,BonusPopulationIndustry</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnGas04"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -814,7 +814,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomIndustryOnHappy00" SubCategory="Secondary" ShowInCustom="true" Cost="3">
     <Tags>HappinessStatusStarSystem3,BonusPopulationIndustry</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnHappy00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -837,7 +837,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomIndustryOnHappy01" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>HappinessStatusStarSystem3,BonusPopulationIndustry</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnHappy01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -860,7 +860,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomIndustryOnHappy02" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>HappinessStatusStarSystem3,BonusPopulationIndustry</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnHappy02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -883,7 +883,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomIndustryOnHappy03" SubCategory="Secondary" ShowInCustom="true" Cost="12">
     <Tags>HappinessStatusStarSystem3,BonusPopulationIndustry</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnHappy03"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -906,7 +906,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomIndustryOnHappy04" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>HappinessStatusStarSystem3,BonusPopulationIndustry</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnHappy04"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -930,7 +930,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomIndustryOnTiny00" SubCategory="Secondary" ShowInCustom="false" Cost="3">
     <Tags>PlanetSizeTiny,BonusPopulationIndustry</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnTiny00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -953,7 +953,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomIndustryOnTiny01" SubCategory="Secondary" ShowInCustom="false" Cost="5">
     <Tags>PlanetSizeTiny,BonusPopulationIndustry</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnTiny01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -976,7 +976,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomIndustryOnTiny02" SubCategory="Secondary" ShowInCustom="false" Cost="10">
     <Tags>PlanetSizeTiny,BonusPopulationIndustry</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnTiny02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -999,7 +999,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomIndustryOnTiny03" SubCategory="Secondary" ShowInCustom="false" Cost="12">
     <Tags>PlanetSizeTiny,BonusPopulationIndustry</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnTiny03"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1022,7 +1022,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomIndustryOnTiny04" SubCategory="Secondary" ShowInCustom="false" Cost="15">
     <Tags>PlanetSizeTiny,BonusPopulationIndustry</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnTiny04"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1046,7 +1046,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomIndustryOnSmall00" SubCategory="Secondary" ShowInCustom="false" Cost="3">
     <Tags>PlanetSizeSmall,BonusPopulationIndustry</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnSmall00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1069,7 +1069,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomIndustryOnSmall01" SubCategory="Secondary" ShowInCustom="false" Cost="5">
     <Tags>PlanetSizeSmall,BonusPopulationIndustry</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnSmall01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1092,7 +1092,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomIndustryOnSmall02" SubCategory="Secondary" ShowInCustom="false" Cost="10">
     <Tags>PlanetSizeSmall,BonusPopulationIndustry</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnSmall02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1115,7 +1115,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomIndustryOnSmall03" SubCategory="Secondary" ShowInCustom="false" Cost="12">
     <Tags>PlanetSizeSmall,BonusPopulationIndustry</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnSmall03"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1138,7 +1138,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomIndustryOnSmall04" SubCategory="Secondary" ShowInCustom="false" Cost="15">
     <Tags>PlanetSizeSmall,BonusPopulationIndustry</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnSmall04"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1162,7 +1162,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomIndustryOnMedium00" SubCategory="Secondary" ShowInCustom="false" Cost="3">
     <Tags>PlanetSizeMedium,BonusPopulationIndustry</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnMedium00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1185,7 +1185,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomIndustryOnMedium01" SubCategory="Secondary" ShowInCustom="false" Cost="5">
     <Tags>PlanetSizeMedium,BonusPopulationIndustry</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnMedium01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1208,7 +1208,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomIndustryOnMedium02" SubCategory="Secondary" ShowInCustom="false" Cost="10">
     <Tags>PlanetSizeMedium,BonusPopulationIndustry</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnMedium02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1231,7 +1231,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomIndustryOnMedium03" SubCategory="Secondary" ShowInCustom="false" Cost="12">
     <Tags>PlanetSizeMedium,BonusPopulationIndustry</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnMedium03"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1254,7 +1254,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomIndustryOnMedium04" SubCategory="Secondary" ShowInCustom="false" Cost="15">
     <Tags>PlanetSizeMedium,BonusPopulationIndustry</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnMedium04"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1278,7 +1278,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomIndustryOnLarge00" SubCategory="Secondary" ShowInCustom="false" Cost="3">
     <Tags>PlanetSizeLarge,BonusPopulationIndustry</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnLarge00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1301,7 +1301,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomIndustryOnLarge01" SubCategory="Secondary" ShowInCustom="false" Cost="5">
     <Tags>PlanetSizeLarge,BonusPopulationIndustry</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnLarge01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1324,7 +1324,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomIndustryOnLarge02" SubCategory="Secondary" ShowInCustom="false" Cost="10">
     <Tags>PlanetSizeLarge,BonusPopulationIndustry</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnLarge02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1347,7 +1347,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomIndustryOnLarge03" SubCategory="Secondary" ShowInCustom="false" Cost="12">
     <Tags>PlanetSizeLarge,BonusPopulationIndustry</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnLarge03"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1370,7 +1370,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomIndustryOnLarge04" SubCategory="Secondary" ShowInCustom="false" Cost="15">
     <Tags>PlanetSizeLarge,BonusPopulationIndustry</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnLarge04"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1394,7 +1394,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomIndustryOnHuge00" SubCategory="Secondary" ShowInCustom="false" Cost="3">
     <Tags>PlanetSizeHuge,BonusPopulationIndustry</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnHuge00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1417,7 +1417,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomIndustryOnHuge01" SubCategory="Secondary" ShowInCustom="false" Cost="5">
     <Tags>PlanetSizeHuge,BonusPopulationIndustry</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnHuge01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1440,7 +1440,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomIndustryOnHuge02" SubCategory="Secondary" ShowInCustom="false" Cost="10">
     <Tags>PlanetSizeHuge,BonusPopulationIndustry</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnHuge02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1463,7 +1463,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomIndustryOnHuge03" SubCategory="Secondary" ShowInCustom="false" Cost="12">
     <Tags>PlanetSizeHuge,BonusPopulationIndustry</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnHuge03"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1486,7 +1486,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomIndustryOnHuge04" SubCategory="Secondary" ShowInCustom="false" Cost="15">
     <Tags>PlanetSizeHuge,BonusPopulationIndustry</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnHuge04"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1510,7 +1510,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomIndustryOnStrategic00" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>HappinessStatusStarSystem3,BonusPopulationIndustry</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnStrategic00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1534,7 +1534,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomIndustryOnAnomaly00" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetAnomaly,BonusPopulationIndustry</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnAnomaly00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1557,7 +1557,7 @@
   <!-- +2 IndustryPerMinorFaction -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomIndustryPerMinorFaction00" SubCategory="Secondary" ShowInCustom="true" Cost="20">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryPerMinorFaction00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1580,7 +1580,7 @@
   <!-- +2 IndustryPerBackdoor -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomIndustryPerBackdoor00" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryPerBackdoor00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1602,7 +1602,7 @@
   <!-- Industry per Temple -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomIndustryPerTemple00" SubCategory="Primary" ShowInCustom="true" Cost="5">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomIndustryPerTemple00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1623,7 +1623,7 @@
   <!-- Industry per System Level -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomIndustryPerSystemLevel00" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomIndustryLevel00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1646,7 +1646,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomIndustryOnLuxury00" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>HappinessStatusStarSystem3,BonusPopulationIndustry</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnLuxury00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">

--- a/Endless Space Competitive Mod/Simulation/Traits/PopulationModifiersTraits[3_Dust].xml
+++ b/Endless Space Competitive Mod/Simulation/Traits/PopulationModifiersTraits[3_Dust].xml
@@ -5,7 +5,7 @@
   <!-- +1 Dust -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryCustomDust00" SubCategory="Primary" ShowInCustom="true" Cost="3">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomDust00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -27,7 +27,7 @@
   <!-- +2 Dust -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryCustomDust01" SubCategory="Primary" ShowInCustom="true" Cost="5">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomDust01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -49,7 +49,7 @@
   <!-- +3 Dust -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryCustomDust02" SubCategory="Primary" ShowInCustom="true" Cost="10">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomDust02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -71,7 +71,7 @@
   <!-- +4 Dust -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryCustomDust03" SubCategory="Primary" ShowInCustom="true" Cost="12">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomDust03"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -93,7 +93,7 @@
   <!-- +5 Dust -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryCustomDust04" SubCategory="Primary" ShowInCustom="true" Cost="15">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomDust04"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -118,7 +118,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDustOnCold00" SubCategory="Secondary" ShowInCustom="true" Cost="3">
     <Tags>PlanetGameplayTypeCold,BonusPopulationDust</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnCold00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -141,7 +141,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDustOnCold01" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>PlanetGameplayTypeCold,BonusPopulationDust</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnCold01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -164,7 +164,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDustOnCold02" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetGameplayTypeCold,BonusPopulationDust</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnCold02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -187,7 +187,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDustOnCold03" SubCategory="Secondary" ShowInCustom="true" Cost="12">
     <Tags>PlanetGameplayTypeCold,BonusPopulationDust</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnCold03"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -210,7 +210,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDustOnCold04" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>PlanetGameplayTypeCold,BonusPopulationDust</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnCold04"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -234,7 +234,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDustOnTemperate00" SubCategory="Secondary" ShowInCustom="true" Cost="3">
     <Tags>PlanetGameplayTypeTemperate,BonusPopulationDust</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnTemperate00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -257,7 +257,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDustOnTemperate01" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>PlanetGameplayTypeTemperate,BonusPopulationDust</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnTemperate01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -280,7 +280,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDustOnTemperate02" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetGameplayTypeTemperate,BonusPopulationDust</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnTemperate02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -303,7 +303,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDustOnTemperate03" SubCategory="Secondary" ShowInCustom="true" Cost="12">
     <Tags>PlanetGameplayTypeTemperate,BonusPopulationDust</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnTemperate03"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -326,7 +326,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDustOnTemperate04" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>PlanetGameplayTypeTemperate,BonusPopulationDust</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnTemperate04"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -350,7 +350,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDustOnHot00" SubCategory="Secondary" ShowInCustom="true" Cost="3">
     <Tags>PlanetGameplayTypeHot,BonusPopulationDust</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnHot00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -373,7 +373,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDustOnHot01" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>PlanetGameplayTypeHot,BonusPopulationDust</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnHot01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -396,7 +396,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDustOnHot02" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetGameplayTypeHot,BonusPopulationDust</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnHot02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -419,7 +419,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDustOnHot03" SubCategory="Secondary" ShowInCustom="true" Cost="12">
     <Tags>PlanetGameplayTypeHot,BonusPopulationDust</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnHot03"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -442,7 +442,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDustOnHot04" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>PlanetGameplayTypeHot,BonusPopulationDust</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnHot04"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -466,7 +466,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDustOnTeeming00" SubCategory="Secondary" ShowInCustom="true" Cost="3">
     <Tags>PlanetGameplayTypeTeeming,BonusPopulationDust</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnTeeming00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -489,7 +489,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDustOnTeeming01" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>PlanetGameplayTypeTeeming,BonusPopulationDust</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnTeeming01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -512,7 +512,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDustOnTeeming02" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetGameplayTypeTeeming,BonusPopulationDust</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnTeeming02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -535,7 +535,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDustOnTeeming03" SubCategory="Secondary" ShowInCustom="true" Cost="12">
     <Tags>PlanetGameplayTypeTeeming,BonusPopulationDust</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnTeeming03"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -558,7 +558,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDustOnTeeming04" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>PlanetGameplayTypeTeeming,BonusPopulationDust</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnTeeming04"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -582,7 +582,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDustOnMeager00" SubCategory="Secondary" ShowInCustom="true" Cost="3">
     <Tags>PlanetGameplayTypeMeager,BonusPopulationDust</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnMeager00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -605,7 +605,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDustOnMeager01" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>PlanetGameplayTypeMeager,BonusPopulationDust</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnMeager01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -628,7 +628,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDustOnMeager02" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetGameplayTypeMeager,BonusPopulationDust</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnMeager02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -651,7 +651,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDustOnMeager03" SubCategory="Secondary" ShowInCustom="true" Cost="12">
     <Tags>PlanetGameplayTypeMeager,BonusPopulationDust</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnMeager03"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -674,7 +674,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDustOnMeager04" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>PlanetGameplayTypeMeager,BonusPopulationDust</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnMeager04"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -698,7 +698,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDustOnGas00" SubCategory="Secondary" ShowInCustom="true" Cost="3">
     <Tags>PlanetGameplayTypeGas,BonusPopulationDust</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnGas00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -721,7 +721,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDustOnGas01" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>PlanetGameplayTypeGas,BonusPopulationDust</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnGas01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -744,7 +744,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDustOnGas02" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetGameplayTypeGas,BonusPopulationDust</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnGas02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -767,7 +767,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDustOnGas03" SubCategory="Secondary" ShowInCustom="true" Cost="12">
     <Tags>PlanetGameplayTypeGas,BonusPopulationDust</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnGas03"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -790,7 +790,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDustOnGas04" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>PlanetGameplayTypeGas,BonusPopulationDust</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnGas04"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -814,7 +814,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDustOnHappy00" SubCategory="Secondary" ShowInCustom="true" Cost="3">
     <Tags>HappinessStatusStarSystem3,BonusPopulationDust</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnHappy00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -837,7 +837,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDustOnHappy01" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>HappinessStatusStarSystem3,BonusPopulationDust</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnHappy01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -860,7 +860,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDustOnHappy02" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>HappinessStatusStarSystem3,BonusPopulationDust</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnHappy02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -883,7 +883,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDustOnHappy03" SubCategory="Secondary" ShowInCustom="true" Cost="12">
     <Tags>HappinessStatusStarSystem3,BonusPopulationDust</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnHappy03"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -906,7 +906,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDustOnHappy04" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>HappinessStatusStarSystem3,BonusPopulationDust</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnHappy04"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -930,7 +930,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDustOnTiny00" SubCategory="Secondary" ShowInCustom="false" Cost="3">
     <Tags>PlanetSizeTiny,BonusPopulationDust</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnTiny00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -953,7 +953,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDustOnTiny01" SubCategory="Secondary" ShowInCustom="false" Cost="5">
     <Tags>PlanetSizeTiny,BonusPopulationDust</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnTiny01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -976,7 +976,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDustOnTiny02" SubCategory="Secondary" ShowInCustom="false" Cost="10">
     <Tags>PlanetSizeTiny,BonusPopulationDust</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnTiny02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -999,7 +999,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDustOnTiny03" SubCategory="Secondary" ShowInCustom="false" Cost="12">
     <Tags>PlanetSizeTiny,BonusPopulationDust</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnTiny03"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1022,7 +1022,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDustOnTiny04" SubCategory="Secondary" ShowInCustom="false" Cost="15">
     <Tags>PlanetSizeTiny,BonusPopulationDust</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnTiny04"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1046,7 +1046,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDustOnSmall00" SubCategory="Secondary" ShowInCustom="false" Cost="3">
     <Tags>PlanetSizeSmall,BonusPopulationDust</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnSmall00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1069,7 +1069,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDustOnSmall01" SubCategory="Secondary" ShowInCustom="false" Cost="5">
     <Tags>PlanetSizeSmall,BonusPopulationDust</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnSmall01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1092,7 +1092,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDustOnSmall02" SubCategory="Secondary" ShowInCustom="false" Cost="10">
     <Tags>PlanetSizeSmall,BonusPopulationDust</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnSmall02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1115,7 +1115,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDustOnSmall03" SubCategory="Secondary" ShowInCustom="false" Cost="12">
     <Tags>PlanetSizeSmall,BonusPopulationDust</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnSmall03"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1138,7 +1138,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDustOnSmall04" SubCategory="Secondary" ShowInCustom="false" Cost="15">
     <Tags>PlanetSizeSmall,BonusPopulationDust</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnSmall04"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1162,7 +1162,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDustOnMedium00" SubCategory="Secondary" ShowInCustom="false" Cost="3">
     <Tags>PlanetSizeMedium,BonusPopulationDust</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnMedium00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1185,7 +1185,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDustOnMedium01" SubCategory="Secondary" ShowInCustom="false" Cost="5">
     <Tags>PlanetSizeMedium,BonusPopulationDust</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnMedium01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1208,7 +1208,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDustOnMedium02" SubCategory="Secondary" ShowInCustom="false" Cost="10">
     <Tags>PlanetSizeMedium,BonusPopulationDust</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnMedium02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1231,7 +1231,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDustOnMedium03" SubCategory="Secondary" ShowInCustom="false" Cost="12">
     <Tags>PlanetSizeMedium,BonusPopulationDust</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnMedium03"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1254,7 +1254,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDustOnMedium04" SubCategory="Secondary" ShowInCustom="false" Cost="15">
     <Tags>PlanetSizeMedium,BonusPopulationDust</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnMedium04"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1278,7 +1278,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDustOnLarge00" SubCategory="Secondary" ShowInCustom="false" Cost="3">
     <Tags>PlanetSizeLarge,BonusPopulationDust</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnLarge00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1301,7 +1301,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDustOnLarge01" SubCategory="Secondary" ShowInCustom="false" Cost="5">
     <Tags>PlanetSizeLarge,BonusPopulationDust</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnLarge01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1324,7 +1324,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDustOnLarge02" SubCategory="Secondary" ShowInCustom="false" Cost="10">
     <Tags>PlanetSizeLarge,BonusPopulationDust</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnLarge02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1347,7 +1347,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDustOnLarge03" SubCategory="Secondary" ShowInCustom="false" Cost="12">
     <Tags>PlanetSizeLarge,BonusPopulationDust</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnLarge03"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1370,7 +1370,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDustOnLarge04" SubCategory="Secondary" ShowInCustom="false" Cost="15">
     <Tags>PlanetSizeLarge,BonusPopulationDust</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnLarge04"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1394,7 +1394,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDustOnHuge00" SubCategory="Secondary" ShowInCustom="false" Cost="3">
     <Tags>PlanetSizeHuge,BonusPopulationDust</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnHuge00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1417,7 +1417,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDustOnHuge01" SubCategory="Secondary" ShowInCustom="false" Cost="5">
     <Tags>PlanetSizeHuge,BonusPopulationDust</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnHuge01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1440,7 +1440,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDustOnHuge02" SubCategory="Secondary" ShowInCustom="false" Cost="10">
     <Tags>PlanetSizeHuge,BonusPopulationDust</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnHuge02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1463,7 +1463,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDustOnHuge03" SubCategory="Secondary" ShowInCustom="false" Cost="12">
     <Tags>PlanetSizeHuge,BonusPopulationDust</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnHuge03"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1486,7 +1486,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDustOnHuge04" SubCategory="Secondary" ShowInCustom="false" Cost="15">
     <Tags>PlanetSizeHuge,BonusPopulationDust</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnHuge04"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1510,7 +1510,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDustOnStrategic00" SubCategory="Secondary" ShowInCustom="false" Cost="5">
     <Tags>HappinessStatusStarSystem3,BonusPopulationDust</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnStrategic00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1534,7 +1534,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDustOnAnomaly00" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetAnomaly,BonusPopulationDust</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnAnomaly00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1557,7 +1557,7 @@
   <!-- +2 DustPerMinorFaction -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDustPerMinorFaction00" SubCategory="Secondary" ShowInCustom="true" Cost="20">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustPerMinorFaction00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1580,7 +1580,7 @@
   <!-- +2 DustPerBackdoor -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDustPerBackdoor00" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustPerBackdoor00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1602,7 +1602,7 @@
   <!-- Dust per Temple -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDustPerTemple00" SubCategory="Primary" ShowInCustom="true" Cost="5">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomDustPerTemple00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1623,7 +1623,7 @@
   <!-- Dust per System Level -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDustPerSystemLevel00" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomDustLevel00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1646,7 +1646,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDustOnLuxury00" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>HappinessStatusStarSystem3,BonusPopulationDust</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnLuxury00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">

--- a/Endless Space Competitive Mod/Simulation/Traits/PopulationModifiersTraits[4_Science].xml
+++ b/Endless Space Competitive Mod/Simulation/Traits/PopulationModifiersTraits[4_Science].xml
@@ -5,7 +5,7 @@
   <!-- +1 Science -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryCustomScience00" SubCategory="Primary" ShowInCustom="true" Cost="3">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomScience00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -27,7 +27,7 @@
   <!-- +2 Science -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryCustomScience01" SubCategory="Primary" ShowInCustom="true" Cost="5">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomScience01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -49,7 +49,7 @@
   <!-- +3 Science -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryCustomScience02" SubCategory="Primary" ShowInCustom="true" Cost="10">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomScience02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -71,7 +71,7 @@
   <!-- +4 Science -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryCustomScience03" SubCategory="Primary" ShowInCustom="true" Cost="12">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomScience03"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -93,7 +93,7 @@
   <!-- +5 Science -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryCustomScience04" SubCategory="Primary" ShowInCustom="true" Cost="15">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomScience04"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -118,7 +118,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomScienceOnCold00" SubCategory="Secondary" ShowInCustom="true" Cost="3">
     <Tags>PlanetGameplayTypeCold,BonusPopulationScience</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnCold00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -141,7 +141,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomScienceOnCold01" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>PlanetGameplayTypeCold,BonusPopulationScience</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnCold01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -164,7 +164,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomScienceOnCold02" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetGameplayTypeCold,BonusPopulationScience</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnCold02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -187,7 +187,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomScienceOnCold03" SubCategory="Secondary" ShowInCustom="true" Cost="12">
     <Tags>PlanetGameplayTypeCold,BonusPopulationScience</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnCold03"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -210,7 +210,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomScienceOnCold04" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>PlanetGameplayTypeCold,BonusPopulationScience</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnCold04"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -234,7 +234,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomScienceOnTemperate00" SubCategory="Secondary" ShowInCustom="true" Cost="3">
     <Tags>PlanetGameplayTypeTemperate,BonusPopulationScience</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnTemperate00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -257,7 +257,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomScienceOnTemperate01" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>PlanetGameplayTypeTemperate,BonusPopulationScience</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnTemperate01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -280,7 +280,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomScienceOnTemperate02" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetGameplayTypeTemperate,BonusPopulationScience</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnTemperate02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -303,7 +303,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomScienceOnTemperate03" SubCategory="Secondary" ShowInCustom="true" Cost="12">
     <Tags>PlanetGameplayTypeTemperate,BonusPopulationScience</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnTemperate03"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -326,7 +326,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomScienceOnTemperate04" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>PlanetGameplayTypeTemperate,BonusPopulationScience</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnTemperate04"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -350,7 +350,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomScienceOnHot00" SubCategory="Secondary" ShowInCustom="true" Cost="3">
     <Tags>PlanetGameplayTypeHot,BonusPopulationScience</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnHot00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -373,7 +373,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomScienceOnHot01" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>PlanetGameplayTypeHot,BonusPopulationScience</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnHot01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -396,7 +396,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomScienceOnHot02" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetGameplayTypeHot,BonusPopulationScience</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnHot02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -419,7 +419,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomScienceOnHot03" SubCategory="Secondary" ShowInCustom="true" Cost="12">
     <Tags>PlanetGameplayTypeHot,BonusPopulationScience</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnHot03"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -442,7 +442,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomScienceOnHot04" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>PlanetGameplayTypeHot,BonusPopulationScience</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnHot04"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -466,7 +466,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomScienceOnTeeming00" SubCategory="Secondary" ShowInCustom="true" Cost="3">
     <Tags>PlanetGameplayTypeTeeming,BonusPopulationScience</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnTeeming00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -489,7 +489,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomScienceOnTeeming01" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>PlanetGameplayTypeTeeming,BonusPopulationScience</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnTeeming01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -512,7 +512,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomScienceOnTeeming02" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetGameplayTypeTeeming,BonusPopulationScience</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnTeeming02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -535,7 +535,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomScienceOnTeeming03" SubCategory="Secondary" ShowInCustom="true" Cost="12">
     <Tags>PlanetGameplayTypeTeeming,BonusPopulationScience</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnTeeming03"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -558,7 +558,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomScienceOnTeeming04" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>PlanetGameplayTypeTeeming,BonusPopulationScience</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnTeeming04"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -582,7 +582,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomScienceOnMeager00" SubCategory="Secondary" ShowInCustom="true" Cost="3">
     <Tags>PlanetGameplayTypeMeager,BonusPopulationScience</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnMeager00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -605,7 +605,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomScienceOnMeager01" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>PlanetGameplayTypeMeager,BonusPopulationScience</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnMeager01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -628,7 +628,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomScienceOnMeager02" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetGameplayTypeMeager,BonusPopulationScience</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnMeager02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -651,7 +651,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomScienceOnMeager03" SubCategory="Secondary" ShowInCustom="true" Cost="12">
     <Tags>PlanetGameplayTypeMeager,BonusPopulationScience</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnMeager03"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -674,7 +674,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomScienceOnMeager04" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>PlanetGameplayTypeMeager,BonusPopulationScience</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnMeager04"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -698,7 +698,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomScienceOnGas00" SubCategory="Secondary" ShowInCustom="true" Cost="3">
     <Tags>PlanetGameplayTypeGas,BonusPopulationScience</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnGas00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -721,7 +721,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomScienceOnGas01" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>PlanetGameplayTypeGas,BonusPopulationScience</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnGas01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -744,7 +744,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomScienceOnGas02" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetGameplayTypeGas,BonusPopulationScience</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnGas02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -767,7 +767,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomScienceOnGas03" SubCategory="Secondary" ShowInCustom="true" Cost="12">
     <Tags>PlanetGameplayTypeGas,BonusPopulationScience</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnGas03"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -790,7 +790,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomScienceOnGas04" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>PlanetGameplayTypeGas,BonusPopulationScience</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnGas04"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -814,7 +814,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomScienceOnHappy00" SubCategory="Secondary" ShowInCustom="true" Cost="3">
     <Tags>HappinessStatusStarSystem3,BonusPopulationScience</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnHappy00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -837,7 +837,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomScienceOnHappy01" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>HappinessStatusStarSystem3,BonusPopulationScience</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnHappy01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -860,7 +860,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomScienceOnHappy02" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>HappinessStatusStarSystem3,BonusPopulationScience</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnHappy02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -883,7 +883,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomScienceOnHappy03" SubCategory="Secondary" ShowInCustom="true" Cost="12">
     <Tags>HappinessStatusStarSystem3,BonusPopulationScience</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnHappy03"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -906,7 +906,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomScienceOnHappy04" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>HappinessStatusStarSystem3,BonusPopulationScience</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnHappy04"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -930,7 +930,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomScienceOnTiny00" SubCategory="Secondary" ShowInCustom="false" Cost="3">
     <Tags>PlanetSizeTiny,BonusPopulationScience</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnTiny00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -953,7 +953,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomScienceOnTiny01" SubCategory="Secondary" ShowInCustom="false" Cost="5">
     <Tags>PlanetSizeTiny,BonusPopulationScience</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnTiny01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -976,7 +976,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomScienceOnTiny02" SubCategory="Secondary" ShowInCustom="false" Cost="10">
     <Tags>PlanetSizeTiny,BonusPopulationScience</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnTiny02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -999,7 +999,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomScienceOnTiny03" SubCategory="Secondary" ShowInCustom="false" Cost="12">
     <Tags>PlanetSizeTiny,BonusPopulationScience</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnTiny03"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1022,7 +1022,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomScienceOnTiny04" SubCategory="Secondary" ShowInCustom="false" Cost="15">
     <Tags>PlanetSizeTiny,BonusPopulationScience</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnTiny04"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1046,7 +1046,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomScienceOnSmall00" SubCategory="Secondary" ShowInCustom="false" Cost="3">
     <Tags>PlanetSizeSmall,BonusPopulationScience</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnSmall00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1069,7 +1069,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomScienceOnSmall01" SubCategory="Secondary" ShowInCustom="false" Cost="5">
     <Tags>PlanetSizeSmall,BonusPopulationScience</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnSmall01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1092,7 +1092,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomScienceOnSmall02" SubCategory="Secondary" ShowInCustom="false" Cost="10">
     <Tags>PlanetSizeSmall,BonusPopulationScience</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnSmall02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1115,7 +1115,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomScienceOnSmall03" SubCategory="Secondary" ShowInCustom="false" Cost="12">
     <Tags>PlanetSizeSmall,BonusPopulationScience</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnSmall03"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1138,7 +1138,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomScienceOnSmall04" SubCategory="Secondary" ShowInCustom="false" Cost="15">
     <Tags>PlanetSizeSmall,BonusPopulationScience</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnSmall04"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1162,7 +1162,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomScienceOnMedium00" SubCategory="Secondary" ShowInCustom="false" Cost="3">
     <Tags>PlanetSizeMedium,BonusPopulationScience</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnMedium00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1185,7 +1185,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomScienceOnMedium01" SubCategory="Secondary" ShowInCustom="false" Cost="5">
     <Tags>PlanetSizeMedium,BonusPopulationScience</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnMedium01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1208,7 +1208,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomScienceOnMedium02" SubCategory="Secondary" ShowInCustom="false" Cost="10">
     <Tags>PlanetSizeMedium,BonusPopulationScience</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnMedium02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1231,7 +1231,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomScienceOnMedium03" SubCategory="Secondary" ShowInCustom="false" Cost="12">
     <Tags>PlanetSizeMedium,BonusPopulationScience</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnMedium03"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1254,7 +1254,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomScienceOnMedium04" SubCategory="Secondary" ShowInCustom="false" Cost="15">
     <Tags>PlanetSizeMedium,BonusPopulationScience</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnMedium04"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1278,7 +1278,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomScienceOnLarge00" SubCategory="Secondary" ShowInCustom="false" Cost="3">
     <Tags>PlanetSizeLarge,BonusPopulationScience</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnLarge00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1301,7 +1301,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomScienceOnLarge01" SubCategory="Secondary" ShowInCustom="false" Cost="5">
     <Tags>PlanetSizeLarge,BonusPopulationScience</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnLarge01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1324,7 +1324,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomScienceOnLarge02" SubCategory="Secondary" ShowInCustom="false" Cost="10">
     <Tags>PlanetSizeLarge,BonusPopulationScience</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnLarge02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1347,7 +1347,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomScienceOnLarge03" SubCategory="Secondary" ShowInCustom="false" Cost="12">
     <Tags>PlanetSizeLarge,BonusPopulationScience</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnLarge03"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1370,7 +1370,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomScienceOnLarge04" SubCategory="Secondary" ShowInCustom="false" Cost="15">
     <Tags>PlanetSizeLarge,BonusPopulationScience</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnLarge04"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1394,7 +1394,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomScienceOnHuge00" SubCategory="Secondary" ShowInCustom="false" Cost="3">
     <Tags>PlanetSizeHuge,BonusPopulationScience</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnHuge00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1417,7 +1417,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomScienceOnHuge01" SubCategory="Secondary" ShowInCustom="false" Cost="5">
     <Tags>PlanetSizeHuge,BonusPopulationScience</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnHuge01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1440,7 +1440,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomScienceOnHuge02" SubCategory="Secondary" ShowInCustom="false" Cost="10">
     <Tags>PlanetSizeHuge,BonusPopulationScience</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnHuge02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1463,7 +1463,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomScienceOnHuge03" SubCategory="Secondary" ShowInCustom="false" Cost="12">
     <Tags>PlanetSizeHuge,BonusPopulationScience</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnHuge03"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1486,7 +1486,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomScienceOnHuge04" SubCategory="Secondary" ShowInCustom="false" Cost="15">
     <Tags>PlanetSizeHuge,BonusPopulationScience</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnHuge04"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1510,7 +1510,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomScienceOnStrategic00" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>HappinessStatusStarSystem3,BonusPopulationScience</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnStrategic00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1534,7 +1534,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomScienceOnAnomaly000" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetAnomaly,BonusPopulationScience</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnAnomaly000"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1557,7 +1557,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomScienceOnAnomaly00" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetAnomaly,BonusPopulationScience</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnAnomaly00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1580,7 +1580,7 @@
   <!-- +2 SciencePerMinorFaction -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomSciencePerMinorFaction00" SubCategory="Secondary" ShowInCustom="true" Cost="20">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSciencePerMinorFaction00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1603,7 +1603,7 @@
   <!-- +2 SciencePerBackdoor -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomSciencePerBackdoor00" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSciencePerBackdoor00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1625,7 +1625,7 @@
   <!-- Science per Temple -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomSciencePerTemple00" SubCategory="Primary" ShowInCustom="true" Cost="5">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomSciencePerTemple00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1646,7 +1646,7 @@
   <!-- Science per System Level -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomSciencePerSystemLevel00" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomScienceLevel00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1669,7 +1669,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomScienceOnLuxury00" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>HappinessStatusStarSystem3,BonusPopulationScience</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnLuxury00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">

--- a/Endless Space Competitive Mod/Simulation/Traits/PopulationModifiersTraits[5_Influence].xml
+++ b/Endless Space Competitive Mod/Simulation/Traits/PopulationModifiersTraits[5_Influence].xml
@@ -5,7 +5,7 @@
   <!-- +1 Prestige -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryCustomPrestige00" SubCategory="Primary" ShowInCustom="true" Cost="5">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomPrestige00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -27,7 +27,7 @@
   <!-- +2 Prestige -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryCustomPrestige01" SubCategory="Primary" ShowInCustom="true" Cost="10">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomPrestige01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -49,7 +49,7 @@
   <!-- +3 Prestige -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryCustomPrestige02" SubCategory="Primary" ShowInCustom="true" Cost="15">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomPrestige02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -74,7 +74,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomPrestigeOnCold00" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>PlanetGameplayTypeCold,BonusPopulationPrestige</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnCold00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -97,7 +97,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomPrestigeOnCold01" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetGameplayTypeCold,BonusPopulationPrestige</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnCold01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -120,7 +120,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomPrestigeOnCold02" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>PlanetGameplayTypeCold,BonusPopulationPrestige</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnCold02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -144,7 +144,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomPrestigeOnTemperate00" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>PlanetGameplayTypeTemperate,BonusPopulationPrestige</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnTemperate00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -167,7 +167,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomPrestigeOnTemperate01" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetGameplayTypeTemperate,BonusPopulationPrestige</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnTemperate01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -190,7 +190,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomPrestigeOnTemperate02" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>PlanetGameplayTypeTemperate,BonusPopulationPrestige</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnTemperate02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -214,7 +214,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomPrestigeOnHot00" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>PlanetGameplayTypeHot,BonusPopulationPrestige</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnHot00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -237,7 +237,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomPrestigeOnHot01" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetGameplayTypeHot,BonusPopulationPrestige</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnHot01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -260,7 +260,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomPrestigeOnHot02" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>PlanetGameplayTypeHot,BonusPopulationPrestige</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnHot02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -284,7 +284,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomPrestigeOnTeeming00" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>PlanetGameplayTypeTeeming,BonusPopulationPrestige</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnTeeming00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -307,7 +307,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomPrestigeOnTeeming01" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetGameplayTypeTeeming,BonusPopulationPrestige</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnTeeming01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -330,7 +330,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomPrestigeOnTeeming02" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>PlanetGameplayTypeTeeming,BonusPopulationPrestige</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnTeeming02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -354,7 +354,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomPrestigeOnMeager00" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>PlanetGameplayTypeMeager,BonusPopulationPrestige</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnMeager00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -377,7 +377,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomPrestigeOnMeager01" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetGameplayTypeMeager,BonusPopulationPrestige</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnMeager01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -400,7 +400,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomPrestigeOnMeager02" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>PlanetGameplayTypeMeager,BonusPopulationPrestige</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnMeager02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -423,7 +423,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomPrestigeOnGas00" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>PlanetGameplayTypeGas,BonusPopulationPrestige</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnGas00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -446,7 +446,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomPrestigeOnGas01" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetGameplayTypeGas,BonusPopulationPrestige</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnGas01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -469,7 +469,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomPrestigeOnGas02" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>PlanetGameplayTypeGas,BonusPopulationPrestige</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnGas02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -493,7 +493,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomPrestigeOnHappy00" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>HappinessStatusStarSystem3,BonusPopulationPrestige</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnHappy00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -516,7 +516,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomPrestigeOnHappy01" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>HappinessStatusStarSystem3,BonusPopulationPrestige</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnHappy01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -539,7 +539,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomPrestigeOnHappy02" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>HappinessStatusStarSystem3,BonusPopulationPrestige</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnHappy02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -563,7 +563,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomPrestigeOnTiny00" SubCategory="Secondary" ShowInCustom="false" Cost="5">
     <Tags>PlanetSizeTiny,BonusPopulationPrestige</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnTiny00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -586,7 +586,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomPrestigeOnTiny01" SubCategory="Secondary" ShowInCustom="false" Cost="10">
     <Tags>PlanetSizeTiny,BonusPopulationPrestige</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnTiny01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -609,7 +609,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomPrestigeOnTiny02" SubCategory="Secondary" ShowInCustom="false" Cost="15">
     <Tags>PlanetSizeTiny,BonusPopulationPrestige</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnTiny02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -633,7 +633,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomPrestigeOnSmall00" SubCategory="Secondary" ShowInCustom="false" Cost="5">
     <Tags>PlanetSizeSmall,BonusPopulationPrestige</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnSmall00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -656,7 +656,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomPrestigeOnSmall01" SubCategory="Secondary" ShowInCustom="false" Cost="10">
     <Tags>PlanetSizeSmall,BonusPopulationPrestige</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnSmall01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -679,7 +679,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomPrestigeOnSmall02" SubCategory="Secondary" ShowInCustom="false" Cost="15">
     <Tags>PlanetSizeSmall,BonusPopulationPrestige</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnSmall02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -703,7 +703,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomPrestigeOnMedium00" SubCategory="Secondary" ShowInCustom="false" Cost="5">
     <Tags>PlanetSizeMedium,BonusPopulationPrestige</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnMedium00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -726,7 +726,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomPrestigeOnMedium01" SubCategory="Secondary" ShowInCustom="false" Cost="10">
     <Tags>PlanetSizeMedium,BonusPopulationPrestige</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnMedium01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -749,7 +749,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomPrestigeOnMedium02" SubCategory="Secondary" ShowInCustom="false" Cost="15">
     <Tags>PlanetSizeMedium,BonusPopulationPrestige</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnMedium02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -773,7 +773,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomPrestigeOnLarge00" SubCategory="Secondary" ShowInCustom="false" Cost="5">
     <Tags>PlanetSizeLarge,BonusPopulationPrestige</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnLarge00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -796,7 +796,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomPrestigeOnLarge01" SubCategory="Secondary" ShowInCustom="false" Cost="10">
     <Tags>PlanetSizeLarge,BonusPopulationPrestige</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnLarge01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -819,7 +819,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomPrestigeOnLarge02" SubCategory="Secondary" ShowInCustom="false" Cost="15">
     <Tags>PlanetSizeLarge,BonusPopulationPrestige</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnLarge02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -843,7 +843,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomPrestigeOnStrategic00" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>HappinessStatusStarSystem3,BonusPopulationPrestige</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnStrategic00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -867,7 +867,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomPrestigeOnAnomaly00" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetAnomaly,BonusPopulationPrestige</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnAnomaly00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -890,7 +890,7 @@
   <!-- +1 PrestigePerMinorFaction -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomPrestigePerMinorFaction00" SubCategory="Secondary" ShowInCustom="true" Cost="20">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigePerMinorFaction00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -913,7 +913,7 @@
   <!-- +1 PrestigePerBackdoor -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomPrestigePerBackdoor00" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigePerBackdoor00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -935,7 +935,7 @@
   <!-- Prestige per Temple -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomPrestigePerTemple00" SubCategory="Primary" ShowInCustom="true" Cost="5">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomPrestigePerTemple00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -956,7 +956,7 @@
   <!-- Prestige per System Level -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomPrestigePerSystemLevel00" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomPrestigeLevel00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -979,7 +979,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomPrestigeOnLuxury00" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>HappinessStatusStarSystem3,BonusPopulationPrestige</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnLuxury00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">

--- a/Endless Space Competitive Mod/Simulation/Traits/PopulationModifiersTraits[6_Happiness].xml
+++ b/Endless Space Competitive Mod/Simulation/Traits/PopulationModifiersTraits[6_Happiness].xml
@@ -5,7 +5,7 @@
   <!-- +2 Happiness / +30 System manpower capacity-->
   <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryCustomHappiness00" SubCategory="Primary" ShowInCustom="true" Cost="5">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomHappiness00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -27,7 +27,7 @@
   <!-- +2 Happiness / +1 Influence-->
   <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryCustomHappinessPrestige00" SubCategory="Primary" Cost="5">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomHappinessPrestige00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -49,7 +49,7 @@
 <!-- +3 Happiness / +3 Science-->
   <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryCustomHappinessPrestige005" SubCategory="Primary" Cost="5">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomHappinessPrestige005"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -71,7 +71,7 @@
   <!-- +4 Happiness -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryCustomHappiness01" SubCategory="Primary" ShowInCustom="true" Cost="10">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomHappiness01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -93,7 +93,7 @@
   <!-- +6 Happiness -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryCustomHappiness02" SubCategory="Primary" ShowInCustom="true" Cost="15">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomHappiness02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -118,7 +118,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomHappinessOnCold00" SubCategory="Secondary" ShowInCustom="true" Cost="3">
     <Tags>PlanetGameplayTypeCold,BonusPopulationHappiness</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnCold00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -141,7 +141,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomHappinessOnCold01" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>PlanetGameplayTypeCold,BonusPopulationHappiness</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnCold01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -164,7 +164,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomHappinessOnCold02" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetGameplayTypeCold,BonusPopulationHappiness</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnCold02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -187,7 +187,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomHappinessOnCold03" SubCategory="Secondary" ShowInCustom="true" Cost="12">
     <Tags>PlanetGameplayTypeCold,BonusPopulationHappiness</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnCold03"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -210,7 +210,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomHappinessOnCold04" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>PlanetGameplayTypeCold,BonusPopulationHappiness</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnCold04"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -234,7 +234,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomHappinessOnTemperate00" SubCategory="Secondary" ShowInCustom="true" Cost="3">
     <Tags>PlanetGameplayTypeTemperate,BonusPopulationHappiness</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTemperate00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -257,7 +257,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomHappinessOnTemperate01" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>PlanetGameplayTypeTemperate,BonusPopulationHappiness</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTemperate01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -280,7 +280,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomHappinessOnTemperate02" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetGameplayTypeTemperate,BonusPopulationHappiness</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTemperate02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -303,7 +303,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomHappinessOnTemperate03" SubCategory="Secondary" ShowInCustom="true" Cost="12">
     <Tags>PlanetGameplayTypeTemperate,BonusPopulationHappiness</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTemperate03"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -326,7 +326,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomHappinessOnTemperate04" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>PlanetGameplayTypeTemperate,BonusPopulationHappiness</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTemperate04"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -350,7 +350,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomHappinessOnHot00" SubCategory="Secondary" ShowInCustom="true" Cost="3">
     <Tags>PlanetGameplayTypeHot,BonusPopulationHappiness</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHot00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -373,7 +373,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomHappinessOnHot01" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>PlanetGameplayTypeHot,BonusPopulationHappiness</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHot01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -396,7 +396,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomHappinessOnHot02" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetGameplayTypeHot,BonusPopulationHappiness</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHot02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -419,7 +419,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomHappinessOnHot03" SubCategory="Secondary" ShowInCustom="true" Cost="12">
     <Tags>PlanetGameplayTypeHot,BonusPopulationHappiness</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHot03"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -442,7 +442,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomHappinessOnHot04" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>PlanetGameplayTypeHot,BonusPopulationHappiness</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHot04"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -466,7 +466,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomHappinessOnTeeming00" SubCategory="Secondary" ShowInCustom="true" Cost="3">
     <Tags>PlanetGameplayTypeTeeming,BonusPopulationHappiness</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTeeming00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -489,7 +489,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomHappinessOnTeeming01" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>PlanetGameplayTypeTeeming,BonusPopulationHappiness</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTeeming01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -512,7 +512,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomHappinessOnTeeming02" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetGameplayTypeTeeming,BonusPopulationHappiness</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTeeming02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -535,7 +535,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomHappinessOnTeeming03" SubCategory="Secondary" ShowInCustom="true" Cost="12">
     <Tags>PlanetGameplayTypeTeeming,BonusPopulationHappiness</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTeeming03"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -558,7 +558,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomHappinessOnTeeming04" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>PlanetGameplayTypeTeeming,BonusPopulationHappiness</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTeeming04"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -582,7 +582,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomHappinessOnMeager00" SubCategory="Secondary" ShowInCustom="true" Cost="3">
     <Tags>PlanetGameplayTypeMeager,BonusPopulationHappiness</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnMeager00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -605,7 +605,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomHappinessOnMeager01" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>PlanetGameplayTypeMeager,BonusPopulationHappiness</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnMeager01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -628,7 +628,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomHappinessFoodOnMeager01" SubCategory="Secondary" Cost="5">
     <Tags>PlanetGameplayTypeMeager,BonusPopulationHappiness</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessFoodOnMeager01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -651,7 +651,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomHappinessOnMeager02" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetGameplayTypeMeager,BonusPopulationHappiness</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnMeager02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -674,7 +674,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomHappinessOnMeager03" SubCategory="Secondary" ShowInCustom="true" Cost="12">
     <Tags>PlanetGameplayTypeMeager,BonusPopulationHappiness</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnMeager03"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -697,7 +697,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomHappinessOnMeager04" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>PlanetGameplayTypeMeager,BonusPopulationHappiness</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnMeager04"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -721,7 +721,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomHappinessOnGas00" SubCategory="Secondary" ShowInCustom="true" Cost="3">
     <Tags>PlanetGameplayTypeGas,BonusPopulationHappiness</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnGas00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -744,7 +744,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomHappinessOnGas01" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>PlanetGameplayTypeGas,BonusPopulationHappiness</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnGas01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -767,7 +767,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomHappinessOnGas02" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetGameplayTypeGas,BonusPopulationHappiness</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnGas02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -790,7 +790,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomHappinessOnGas03" SubCategory="Secondary" ShowInCustom="true" Cost="12">
     <Tags>PlanetGameplayTypeGas,BonusPopulationHappiness</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnGas03"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -813,7 +813,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomHappinessOnGas04" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>PlanetGameplayTypeGas,BonusPopulationHappiness</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnGas04"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -837,7 +837,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomHappinessOnHappy00" SubCategory="Secondary" ShowInCustom="true" Cost="3">
     <Tags>HappinessStatusStarSystem3,BonusPopulationHappiness</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHappy00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -860,7 +860,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomHappinessOnHappy01" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>HappinessStatusStarSystem3,BonusPopulationHappiness</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHappy01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -883,7 +883,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomHappinessOnHappy02" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>HappinessStatusStarSystem3,BonusPopulationHappiness</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHappy02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -906,7 +906,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomHappinessOnHappy03" SubCategory="Secondary" ShowInCustom="true" Cost="12">
     <Tags>HappinessStatusStarSystem3,BonusPopulationHappiness</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHappy03"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -929,7 +929,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomHappinessOnHappy04" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>HappinessStatusStarSystem3,BonusPopulationHappiness</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHappy04"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -953,7 +953,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomHappinessOnTiny00" SubCategory="Secondary" ShowInCustom="false" Cost="3">
     <Tags>PlanetSizeTiny,BonusPopulationHappiness</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTiny00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -976,7 +976,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomHappinessOnTiny01" SubCategory="Secondary" ShowInCustom="false" Cost="5">
     <Tags>PlanetSizeTiny,BonusPopulationHappiness</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTiny01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -999,7 +999,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomHappinessOnTiny02" SubCategory="Secondary" ShowInCustom="false" Cost="10">
     <Tags>PlanetSizeTiny,BonusPopulationHappiness</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTiny02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1022,7 +1022,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomHappinessOnTiny03" SubCategory="Secondary" ShowInCustom="false" Cost="12">
     <Tags>PlanetSizeTiny,BonusPopulationHappiness</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTiny03"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1045,7 +1045,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomHappinessOnTiny04" SubCategory="Secondary" ShowInCustom="false" Cost="15">
     <Tags>PlanetSizeTiny,BonusPopulationHappiness</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTiny04"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1069,7 +1069,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomHappinessOnSmall00" SubCategory="Secondary" ShowInCustom="false" Cost="3">
     <Tags>PlanetSizeSmall,BonusPopulationHappiness</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnSmall00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1092,7 +1092,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomHappinessOnSmall01" SubCategory="Secondary" ShowInCustom="false" Cost="5">
     <Tags>PlanetSizeSmall,BonusPopulationHappiness</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnSmall01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1115,7 +1115,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomHappinessOnSmall02" SubCategory="Secondary" ShowInCustom="false" Cost="10">
     <Tags>PlanetSizeSmall,BonusPopulationHappiness</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnSmall02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1138,7 +1138,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomHappinessOnSmall03" SubCategory="Secondary" ShowInCustom="false" Cost="12">
     <Tags>PlanetSizeSmall,BonusPopulationHappiness</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnSmall03"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1161,7 +1161,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomHappinessOnSmall04" SubCategory="Secondary" ShowInCustom="false" Cost="15">
     <Tags>PlanetSizeSmall,BonusPopulationHappiness</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnSmall04"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1185,7 +1185,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomHappinessOnMedium00" SubCategory="Secondary" ShowInCustom="false" Cost="3">
     <Tags>PlanetSizeMedium,BonusPopulationHappiness</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnMedium00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1208,7 +1208,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomHappinessOnMedium01" SubCategory="Secondary" ShowInCustom="false" Cost="5">
     <Tags>PlanetSizeMedium,BonusPopulationHappiness</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnMedium01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1231,7 +1231,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomHappinessOnMedium02" SubCategory="Secondary" ShowInCustom="false" Cost="10">
     <Tags>PlanetSizeMedium,BonusPopulationHappiness</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnMedium02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1254,7 +1254,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomHappinessOnMedium03" SubCategory="Secondary" ShowInCustom="false" Cost="12">
     <Tags>PlanetSizeMedium,BonusPopulationHappiness</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnMedium03"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1277,7 +1277,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomHappinessOnMedium04" SubCategory="Secondary" ShowInCustom="false" Cost="15">
     <Tags>PlanetSizeMedium,BonusPopulationHappiness</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnMedium04"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1301,7 +1301,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomHappinessOnLarge00" SubCategory="Secondary" ShowInCustom="false" Cost="3">
     <Tags>PlanetSizeLarge,BonusPopulationHappiness</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnLarge00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1324,7 +1324,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomHappinessOnLarge01" SubCategory="Secondary" ShowInCustom="false" Cost="5">
     <Tags>PlanetSizeLarge,BonusPopulationHappiness</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnLarge01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1347,7 +1347,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomHappinessOnLarge02" SubCategory="Secondary" ShowInCustom="false" Cost="10">
     <Tags>PlanetSizeLarge,BonusPopulationHappiness</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnLarge02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1370,7 +1370,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomHappinessOnLarge03" SubCategory="Secondary" ShowInCustom="false" Cost="12">
     <Tags>PlanetSizeLarge,BonusPopulationHappiness</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnLarge03"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1393,7 +1393,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomHappinessOnLarge04" SubCategory="Secondary" ShowInCustom="false" Cost="15">
     <Tags>PlanetSizeLarge,BonusPopulationHappiness</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnLarge04"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1417,7 +1417,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomHappinessOnHuge00" SubCategory="Secondary" ShowInCustom="false" Cost="3">
     <Tags>PlanetSizeHuge,BonusPopulationHappiness</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHuge00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1440,7 +1440,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomHappinessOnHuge01" SubCategory="Secondary" ShowInCustom="false" Cost="5">
     <Tags>PlanetSizeHuge,BonusPopulationHappiness</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHuge01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1463,7 +1463,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomHappinessOnHuge02" SubCategory="Secondary" ShowInCustom="false" Cost="10">
     <Tags>PlanetSizeHuge,BonusPopulationHappiness</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHuge02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1486,7 +1486,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomHappinessOnHuge03" SubCategory="Secondary" ShowInCustom="false" Cost="12">
     <Tags>PlanetSizeHuge,BonusPopulationHappiness</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHuge03"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1509,7 +1509,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomHappinessOnHuge04" SubCategory="Secondary" ShowInCustom="false" Cost="15">
     <Tags>PlanetSizeHuge,BonusPopulationHappiness</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHuge04"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1533,7 +1533,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomHappinessOnStrategic00" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>HappinessStatusStarSystem3,BonusPopulationHappiness</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnStrategic00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1557,7 +1557,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomHappinessOnAnomaly00" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetAnomaly,BonusPopulationHappiness</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnAnomaly00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1580,7 +1580,7 @@
   <!-- +2 HappinessPerMinorFaction -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomHappinessPerMinorFaction00" SubCategory="Secondary" ShowInCustom="true" Cost="20">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessPerMinorFaction00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1603,7 +1603,7 @@
   <!-- +2 HappinessPerBackdoor -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomHappinessPerBackdoor00" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessPerBackdoor00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1625,7 +1625,7 @@
   <!-- Happiness per Temple -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomHappinessPerTemple00" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomHappinessPerTemple00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1646,7 +1646,7 @@
   <!-- Happiness per System Level -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomHappinessPerSystemLevel00" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomHappinessLevel00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1669,7 +1669,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomHappinessOnLuxury00" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>HappinessStatusStarSystem3,BonusPopulationHappiness</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnLuxury00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">

--- a/Endless Space Competitive Mod/Simulation/Traits/PopulationModifiersTraits[7_Military].xml
+++ b/Endless Space Competitive Mod/Simulation/Traits/PopulationModifiersTraits[7_Military].xml
@@ -5,7 +5,7 @@
   <!-- +1 EmpireManpower -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryCustomEmpireManpower00" SubCategory="Primary" ShowInCustom="true" Cost="5">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomEmpireManpower00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -27,7 +27,7 @@
   <!-- +2 EmpireManpower -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryCustomEmpireManpower01" SubCategory="Primary" ShowInCustom="true" Cost="10">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomEmpireManpower01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -49,7 +49,7 @@
   <!-- +3 EmpireManpower -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryCustomEmpireManpower02" SubCategory="Primary" ShowInCustom="true" Cost="15">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomEmpireManpower02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -72,7 +72,7 @@
   <!-- +25 GroundBattleBombardmentAttackerDamages -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryCustomGroundBattleBombardmentAttackerDamages00" SubCategory="Primary" ShowInCustom="true" Cost="5">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomGroundBattleBombardmentAttackerDamages00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -94,7 +94,7 @@
   <!-- +50 GroundBattleBombardmentAttackerDamages -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryCustomGroundBattleBombardmentAttackerDamages01" SubCategory="Primary" ShowInCustom="true" Cost="10">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomGroundBattleBombardmentAttackerDamages01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -116,7 +116,7 @@
   <!-- +75 GroundBattleBombardmentAttackerDamages -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryCustomGroundBattleBombardmentAttackerDamages02" SubCategory="Primary" ShowInCustom="true" Cost="15">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomGroundBattleBombardmentAttackerDamages02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -139,7 +139,7 @@
   <!-- +25 Defense -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryCustomDefense00" SubCategory="Primary" ShowInCustom="true" Cost="5">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomSystemManpower00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -161,7 +161,7 @@
   <!-- +50 Defense -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryCustomDefense01" SubCategory="Primary" ShowInCustom="true" Cost="10">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomSystemManpower01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -183,7 +183,7 @@
   <!-- +75 Defense -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryCustomDefense02" SubCategory="Primary" ShowInCustom="true" Cost="15">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomSystemManpower02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -206,7 +206,7 @@
   <!-- +1 EmpireManpower -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpower00" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomEmpireManpower00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -231,7 +231,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnCold00" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>PlanetGameplayTypeCold,BonusPopulationEmpireManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnCold00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -254,7 +254,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnCold01" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetGameplayTypeCold,BonusPopulationEmpireManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnCold01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -277,7 +277,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnCold02" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>PlanetGameplayTypeCold,BonusPopulationEmpireManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnCold02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -301,7 +301,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnTemperate00" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>PlanetGameplayTypeTemperate,BonusPopulationEmpireManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnTemperate00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -324,7 +324,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnTemperate01" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetGameplayTypeTemperate,BonusPopulationEmpireManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnTemperate01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -347,7 +347,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnTemperate02" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>PlanetGameplayTypeTemperate,BonusPopulationEmpireManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnTemperate02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -371,7 +371,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnHot00" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>PlanetGameplayTypeHot,BonusPopulationEmpireManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnHot00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -394,7 +394,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnHot01" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetGameplayTypeHot,BonusPopulationEmpireManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnHot01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -417,7 +417,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnHot02" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>PlanetGameplayTypeHot,BonusPopulationEmpireManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnHot02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -441,7 +441,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnTeeming00" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>PlanetGameplayTypeTeeming,BonusPopulationEmpireManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnTeeming00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -464,7 +464,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnTeeming01" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetGameplayTypeTeeming,BonusPopulationEmpireManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnTeeming01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -487,7 +487,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnTeeming02" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>PlanetGameplayTypeTeeming,BonusPopulationEmpireManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnTeeming02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -511,7 +511,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnMeager00" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>PlanetGameplayTypeMeager,BonusPopulationEmpireManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnMeager00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -534,7 +534,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnMeager01" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetGameplayTypeMeager,BonusPopulationEmpireManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnMeager01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -557,7 +557,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnMeager02" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>PlanetGameplayTypeMeager,BonusPopulationEmpireManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnMeager02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -580,7 +580,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnGas00" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>PlanetGameplayTypeGas,BonusPopulationEmpireManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnGas00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -603,7 +603,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnGas01" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetGameplayTypeGas,BonusPopulationEmpireManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnGas01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -626,7 +626,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnGas02" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>PlanetGameplayTypeGas,BonusPopulationEmpireManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnGas02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -650,7 +650,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnHappy00" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>HappinessStatusStarSystem3,BonusPopulationEmpireManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnHappy00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -673,7 +673,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnHappy01" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>HappinessStatusStarSystem3,BonusPopulationEmpireManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnHappy01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -696,7 +696,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnHappy02" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>HappinessStatusStarSystem3,BonusPopulationEmpireManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnHappy02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -720,7 +720,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnTiny00" SubCategory="Secondary" ShowInCustom="false" Cost="5">
     <Tags>PlanetSizeTiny,BonusPopulationEmpireManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnTiny00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -743,7 +743,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnTiny01" SubCategory="Secondary" ShowInCustom="false" Cost="10">
     <Tags>PlanetSizeTiny,BonusPopulationEmpireManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnTiny01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -766,7 +766,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnTiny02" SubCategory="Secondary" ShowInCustom="false" Cost="15">
     <Tags>PlanetSizeTiny,BonusPopulationEmpireManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnTiny02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -790,7 +790,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnSmall00" SubCategory="Secondary" ShowInCustom="false" Cost="5">
     <Tags>PlanetSizeSmall,BonusPopulationEmpireManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnSmall00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -813,7 +813,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnSmall01" SubCategory="Secondary" ShowInCustom="false" Cost="10">
     <Tags>PlanetSizeSmall,BonusPopulationEmpireManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnSmall01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -836,7 +836,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnSmall02" SubCategory="Secondary" ShowInCustom="false" Cost="15">
     <Tags>PlanetSizeSmall,BonusPopulationEmpireManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnSmall02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -860,7 +860,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnMedium00" SubCategory="Secondary" ShowInCustom="false" Cost="5">
     <Tags>PlanetSizeMedium,BonusPopulationEmpireManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnMedium00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -883,7 +883,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnMedium01" SubCategory="Secondary" ShowInCustom="false" Cost="10">
     <Tags>PlanetSizeMedium,BonusPopulationEmpireManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnMedium01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -906,7 +906,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnMedium02" SubCategory="Secondary" ShowInCustom="false" Cost="15">
     <Tags>PlanetSizeMedium,BonusPopulationEmpireManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnMedium02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -930,7 +930,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnLarge00" SubCategory="Secondary" ShowInCustom="false" Cost="5">
     <Tags>PlanetSizeLarge,BonusPopulationEmpireManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnLarge00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -953,7 +953,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnLarge01" SubCategory="Secondary" ShowInCustom="false" Cost="10">
     <Tags>PlanetSizeLarge,BonusPopulationEmpireManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnLarge01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -976,7 +976,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnLarge02" SubCategory="Secondary" ShowInCustom="false" Cost="15">
     <Tags>PlanetSizeLarge,BonusPopulationEmpireManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnLarge02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1000,7 +1000,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnHuge00" SubCategory="Secondary" ShowInCustom="false" Cost="5">
     <Tags>PlanetSizeHuge,BonusPopulationEmpireManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnHuge00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1023,7 +1023,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnHuge01" SubCategory="Secondary" ShowInCustom="false" Cost="10">
     <Tags>PlanetSizeHuge,BonusPopulationEmpireManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnHuge01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1046,7 +1046,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnHuge02" SubCategory="Secondary" ShowInCustom="false" Cost="15">
     <Tags>PlanetSizeHuge,BonusPopulationEmpireManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnHuge02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1070,7 +1070,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnStrategic00" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>HappinessStatusStarSystem3,BonusPopulationEmpireManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnStrategic00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1094,7 +1094,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnAnomaly00" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetAnomaly,BonusPopulationEmpireManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnAnomaly00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1117,7 +1117,7 @@
   <!-- +2 EmpireManpowerPerMinorFaction -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerPerMinorFaction00" SubCategory="Secondary" ShowInCustom="true" Cost="20">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerPerMinorFaction00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1140,7 +1140,7 @@
   <!-- +2 EmpireManpowerPerBackdoor -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerPerBackdoor00" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerPerBackdoor00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1162,7 +1162,7 @@
   <!-- EmpireManpower per Temple -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerPerTemple00" SubCategory="Primary" ShowInCustom="true" Cost="5">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomEmpireManpowerPerTemple00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1183,7 +1183,7 @@
   <!-- EmpireManpower per System Level -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerPerSystemLevel00" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomEmpireManpowerLevel00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1206,7 +1206,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnLuxury00" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>HappinessStatusStarSystem3,BonusPopulationEmpireManpower</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnLuxury00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1230,7 +1230,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnCold00" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>PlanetGameplayTypeCold,BonusPopulationGroundBattleBombardmentAttackerDamages</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnCold00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1253,7 +1253,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnCold01" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetGameplayTypeCold,BonusPopulationGroundBattleBombardmentAttackerDamages</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnCold01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1276,7 +1276,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnCold02" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>PlanetGameplayTypeCold,BonusPopulationGroundBattleBombardmentAttackerDamages</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnCold02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1300,7 +1300,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnTemperate00" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>PlanetGameplayTypeTemperate,BonusPopulationGroundBattleBombardmentAttackerDamages</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnTemperate00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1323,7 +1323,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnTemperate01" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetGameplayTypeTemperate,BonusPopulationGroundBattleBombardmentAttackerDamages</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnTemperate01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1346,7 +1346,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnTemperate02" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>PlanetGameplayTypeTemperate,BonusPopulationGroundBattleBombardmentAttackerDamages</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnTemperate02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1370,7 +1370,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnHot00" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>PlanetGameplayTypeHot,BonusPopulationGroundBattleBombardmentAttackerDamages</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnHot00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1393,7 +1393,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnHot01" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetGameplayTypeHot,BonusPopulationGroundBattleBombardmentAttackerDamages</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnHot01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1416,7 +1416,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnHot02" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>PlanetGameplayTypeHot,BonusPopulationGroundBattleBombardmentAttackerDamages</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnHot02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1440,7 +1440,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnTeeming00" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>PlanetGameplayTypeTeeming,BonusPopulationGroundBattleBombardmentAttackerDamages</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnTeeming00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1463,7 +1463,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnTeeming01" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetGameplayTypeTeeming,BonusPopulationGroundBattleBombardmentAttackerDamages</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnTeeming01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1486,7 +1486,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnTeeming02" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>PlanetGameplayTypeTeeming,BonusPopulationGroundBattleBombardmentAttackerDamages</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnTeeming02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1510,7 +1510,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnMeager00" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>PlanetGameplayTypeMeager,BonusPopulationGroundBattleBombardmentAttackerDamages</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnMeager00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1533,7 +1533,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnMeager01" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetGameplayTypeMeager,BonusPopulationGroundBattleBombardmentAttackerDamages</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnMeager01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1556,7 +1556,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnMeager02" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>PlanetGameplayTypeMeager,BonusPopulationGroundBattleBombardmentAttackerDamages</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnMeager02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1579,7 +1579,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnGas00" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>PlanetGameplayTypeGas,BonusPopulationGroundBattleBombardmentAttackerDamages</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnGas00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1602,7 +1602,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnGas01" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetGameplayTypeGas,BonusPopulationGroundBattleBombardmentAttackerDamages</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnGas01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1625,7 +1625,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnGas02" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>PlanetGameplayTypeGas,BonusPopulationGroundBattleBombardmentAttackerDamages</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnGas02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1649,7 +1649,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnHappy00" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>HappinessStatusStarSystem3,BonusPopulationGroundBattleBombardmentAttackerDamages</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnHappy00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1672,7 +1672,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnHappy01" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>HappinessStatusStarSystem3,BonusPopulationGroundBattleBombardmentAttackerDamages</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnHappy01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1695,7 +1695,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnHappy02" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>HappinessStatusStarSystem3,BonusPopulationGroundBattleBombardmentAttackerDamages</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnHappy02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1719,7 +1719,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnTiny00" SubCategory="Secondary" ShowInCustom="false" Cost="5">
     <Tags>PlanetSizeTiny,BonusPopulationGroundBattleBombardmentAttackerDamages</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnTiny00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1742,7 +1742,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnTiny01" SubCategory="Secondary" ShowInCustom="false" Cost="10">
     <Tags>PlanetSizeTiny,BonusPopulationGroundBattleBombardmentAttackerDamages</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnTiny01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1765,7 +1765,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnTiny02" SubCategory="Secondary" ShowInCustom="false" Cost="15">
     <Tags>PlanetSizeTiny,BonusPopulationGroundBattleBombardmentAttackerDamages</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnTiny02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1789,7 +1789,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnSmall00" SubCategory="Secondary" ShowInCustom="false" Cost="5">
     <Tags>PlanetSizeSmall,BonusPopulationGroundBattleBombardmentAttackerDamages</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnSmall00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1812,7 +1812,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnSmall01" SubCategory="Secondary" ShowInCustom="false" Cost="10">
     <Tags>PlanetSizeSmall,BonusPopulationGroundBattleBombardmentAttackerDamages</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnSmall01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1835,7 +1835,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnSmall02" SubCategory="Secondary" ShowInCustom="false" Cost="15">
     <Tags>PlanetSizeSmall,BonusPopulationGroundBattleBombardmentAttackerDamages</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnSmall02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1859,7 +1859,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnMedium00" SubCategory="Secondary" ShowInCustom="false" Cost="5">
     <Tags>PlanetSizeMedium,BonusPopulationGroundBattleBombardmentAttackerDamages</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnMedium00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1882,7 +1882,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnMedium01" SubCategory="Secondary" ShowInCustom="false" Cost="10">
     <Tags>PlanetSizeMedium,BonusPopulationGroundBattleBombardmentAttackerDamages</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnMedium01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1905,7 +1905,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnMedium02" SubCategory="Secondary" ShowInCustom="false" Cost="15">
     <Tags>PlanetSizeMedium,BonusPopulationGroundBattleBombardmentAttackerDamages</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnMedium02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1929,7 +1929,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnLarge00" SubCategory="Secondary" ShowInCustom="false" Cost="5">
     <Tags>PlanetSizeLarge,BonusPopulationGroundBattleBombardmentAttackerDamages</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnLarge00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1952,7 +1952,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnLarge01" SubCategory="Secondary" ShowInCustom="false" Cost="10">
     <Tags>PlanetSizeLarge,BonusPopulationGroundBattleBombardmentAttackerDamages</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnLarge01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1975,7 +1975,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnLarge02" SubCategory="Secondary" ShowInCustom="false" Cost="15">
     <Tags>PlanetSizeLarge,BonusPopulationGroundBattleBombardmentAttackerDamages</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnLarge02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1999,7 +1999,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnHuge00" SubCategory="Secondary" ShowInCustom="false" Cost="5">
     <Tags>PlanetSizeHuge,BonusPopulationGroundBattleBombardmentAttackerDamages</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnHuge00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -2022,7 +2022,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnHuge01" SubCategory="Secondary" ShowInCustom="false" Cost="10">
     <Tags>PlanetSizeHuge,BonusPopulationGroundBattleBombardmentAttackerDamages</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnHuge01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -2045,7 +2045,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnHuge02" SubCategory="Secondary" ShowInCustom="false" Cost="15">
     <Tags>PlanetSizeHuge,BonusPopulationGroundBattleBombardmentAttackerDamages</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnHuge02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -2069,7 +2069,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnStrategic00" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>HappinessStatusStarSystem3,BonusPopulationGroundBattleBombardmentAttackerDamages</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnStrategic00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -2093,7 +2093,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnAnomaly00" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetAnomaly,BonusPopulationGroundBattleBombardmentAttackerDamages</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnAnomaly00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -2116,7 +2116,7 @@
   <!-- +25 GroundBattleBombardmentAttackerDamagesPerMinorFaction -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesPerMinorFaction00" SubCategory="Secondary" ShowInCustom="true" Cost="20">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesPerMinorFaction00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -2139,7 +2139,7 @@
   <!-- +25 GroundBattleBombardmentAttackerDamagesPerBackdoor -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesPerBackdoor00" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesPerBackdoor00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -2161,7 +2161,7 @@
   <!-- GroundBattleBombardmentAttackerDamages per Temple -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesPerTemple00" SubCategory="Primary" ShowInCustom="true" Cost="5">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomGroundBattleBombardmentAttackerDamagesPerTemple00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -2182,7 +2182,7 @@
   <!-- GroundBattleBombardmentAttackerDamages per System Level -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesPerSystemLevel00" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomGroundBattleBombardmentAttackerDamagesLevel00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -2205,7 +2205,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnLuxury00" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>HappinessStatusStarSystem3,BonusPopulationGroundBattleBombardmentAttackerDamages</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnLuxury00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -2229,7 +2229,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnCold00" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>PlanetGameplayTypeCold,BonusPopulationDefense</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnCold00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -2252,7 +2252,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnCold01" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetGameplayTypeCold,BonusPopulationDefense</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnCold01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -2275,7 +2275,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnCold02" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>PlanetGameplayTypeCold,BonusPopulationDefense</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnCold02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -2299,7 +2299,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnTemperate00" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>PlanetGameplayTypeTemperate,BonusPopulationDefense</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnTemperate00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -2322,7 +2322,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnTemperate01" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetGameplayTypeTemperate,BonusPopulationDefense</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnTemperate01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -2345,7 +2345,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnTemperate02" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>PlanetGameplayTypeTemperate,BonusPopulationDefense</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnTemperate02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -2369,7 +2369,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnHot00" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>PlanetGameplayTypeHot,BonusPopulationDefense</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnHot00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -2392,7 +2392,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnHot01" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetGameplayTypeHot,BonusPopulationDefense</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnHot01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -2415,7 +2415,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnHot02" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>PlanetGameplayTypeHot,BonusPopulationDefense</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnHot02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -2439,7 +2439,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnTeeming00" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>PlanetGameplayTypeTeeming,BonusPopulationDefense</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnTeeming00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -2462,7 +2462,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnTeeming01" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetGameplayTypeTeeming,BonusPopulationDefense</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnTeeming01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -2485,7 +2485,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnTeeming02" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>PlanetGameplayTypeTeeming,BonusPopulationDefense</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnTeeming02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -2509,7 +2509,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnMeager00" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>PlanetGameplayTypeMeager,BonusPopulationDefense</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnMeager00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -2532,7 +2532,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnMeager01" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetGameplayTypeMeager,BonusPopulationDefense</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnMeager01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -2555,7 +2555,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnMeager02" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>PlanetGameplayTypeMeager,BonusPopulationDefense</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnMeager02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -2578,7 +2578,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnGas00" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>PlanetGameplayTypeGas,BonusPopulationDefense</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnGas00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -2601,7 +2601,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnGas01" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetGameplayTypeGas,BonusPopulationDefense</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnGas01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -2624,7 +2624,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnGas02" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>PlanetGameplayTypeGas,BonusPopulationDefense</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnGas02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -2648,7 +2648,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnHappy00" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>HappinessStatusStarSystem3,BonusPopulationDefense</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnHappy00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -2671,7 +2671,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnHappy01" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>HappinessStatusStarSystem3,BonusPopulationDefense</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnHappy01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -2694,7 +2694,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnHappy02" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>HappinessStatusStarSystem3,BonusPopulationDefense</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnHappy02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -2718,7 +2718,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnTiny00" SubCategory="Secondary" ShowInCustom="false" Cost="5">
     <Tags>PlanetSizeTiny,BonusPopulationDefense</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnTiny00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -2741,7 +2741,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnTiny01" SubCategory="Secondary" ShowInCustom="false" Cost="10">
     <Tags>PlanetSizeTiny,BonusPopulationDefense</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnTiny01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -2764,7 +2764,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnTiny02" SubCategory="Secondary" ShowInCustom="false" Cost="15">
     <Tags>PlanetSizeTiny,BonusPopulationDefense</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnTiny02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -2788,7 +2788,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnSmall00" SubCategory="Secondary" ShowInCustom="false" Cost="5">
     <Tags>PlanetSizeSmall,BonusPopulationDefense</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnSmall00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -2811,7 +2811,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnSmall01" SubCategory="Secondary" ShowInCustom="false" Cost="10">
     <Tags>PlanetSizeSmall,BonusPopulationDefense</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnSmall01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -2834,7 +2834,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnSmall02" SubCategory="Secondary" ShowInCustom="false" Cost="15">
     <Tags>PlanetSizeSmall,BonusPopulationDefense</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnSmall02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -2858,7 +2858,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnMedium00" SubCategory="Secondary" ShowInCustom="false" Cost="5">
     <Tags>PlanetSizeMedium,BonusPopulationDefense</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnMedium00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -2881,7 +2881,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnMedium01" SubCategory="Secondary" ShowInCustom="false" Cost="10">
     <Tags>PlanetSizeMedium,BonusPopulationDefense</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnMedium01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -2904,7 +2904,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnMedium02" SubCategory="Secondary" ShowInCustom="false" Cost="15">
     <Tags>PlanetSizeMedium,BonusPopulationDefense</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnMedium02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -2928,7 +2928,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnLarge00" SubCategory="Secondary" ShowInCustom="false" Cost="5">
     <Tags>PlanetSizeLarge,BonusPopulationDefense</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnLarge00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -2951,7 +2951,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnLarge01" SubCategory="Secondary" ShowInCustom="false" Cost="10">
     <Tags>PlanetSizeLarge,BonusPopulationDefense</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnLarge01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -2974,7 +2974,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnLarge02" SubCategory="Secondary" ShowInCustom="false" Cost="15">
     <Tags>PlanetSizeLarge,BonusPopulationDefense</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnLarge02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -2998,7 +2998,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnHuge00" SubCategory="Secondary" ShowInCustom="false" Cost="5">
     <Tags>PlanetSizeHuge,BonusPopulationDefense</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnHuge00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -3021,7 +3021,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnHuge01" SubCategory="Secondary" ShowInCustom="false" Cost="10">
     <Tags>PlanetSizeHuge,BonusPopulationDefense</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnHuge01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -3044,7 +3044,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnHuge02" SubCategory="Secondary" ShowInCustom="false" Cost="15">
     <Tags>PlanetSizeHuge,BonusPopulationDefense</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnHuge02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -3068,7 +3068,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnStrategic00" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>HappinessStatusStarSystem3,BonusPopulationDefense</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnStrategic00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -3092,7 +3092,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnAnomaly00" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetAnomaly,BonusPopulationDefense</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnAnomaly00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -3115,7 +3115,7 @@
   <!-- +25 DefensePerMinorFaction -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefensePerMinorFaction00" SubCategory="Secondary" ShowInCustom="true" Cost="20">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerPerMinorFaction00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -3138,7 +3138,7 @@
   <!-- +25 DefensePerBackdoor -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefensePerBackdoor00" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerPerBackdoor00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -3160,7 +3160,7 @@
   <!-- Defense per Temple -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefensePerTemple00" SubCategory="Primary" ShowInCustom="true" Cost="5">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomSystemManpowerPerTemple00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -3181,7 +3181,7 @@
   <!-- Defense per System Level -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefensePerSystemLevel00" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomSystemManpowerLevel00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -3204,7 +3204,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnLuxury00" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>HappinessStatusStarSystem3,BonusPopulationDefense</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnLuxury00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">

--- a/Endless Space Competitive Mod/Simulation/Traits/PopulationModifiersTraits[8_Other].xml
+++ b/Endless Space Competitive Mod/Simulation/Traits/PopulationModifiersTraits[8_Other].xml
@@ -5,7 +5,7 @@
   <!-- +1 FIDSI -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryCustomFIDSI00" SubCategory="Primary" ShowInCustom="true" Cost="15">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomFIDSI00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -27,7 +27,7 @@
   <!-- +2 FIDSI -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryCustomFIDSI01" SubCategory="Primary" ShowInCustom="true" Cost="20">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomFIDSI01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -49,7 +49,7 @@
   <!-- +3 FIDSI -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryCustomFIDSI02" SubCategory="Primary" ShowInCustom="true" Cost="25">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomFIDSI02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -72,7 +72,7 @@
   <!-- +1 FIDSILevel -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryCustomFIDSILevel00" SubCategory="Primary" ShowInCustom="true" Cost="25">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomFIDSILevel00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -94,7 +94,7 @@
   <!-- +2 FIDSILevel -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryCustomFIDSILevel01" SubCategory="Primary" ShowInCustom="true" Cost="30">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomFIDSILevel01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -116,7 +116,7 @@
   <!-- +3 FIDSILevel -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryCustomFIDSILevel02" SubCategory="Primary" ShowInCustom="true" Cost="35">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomFIDSILevel02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -138,7 +138,7 @@
   <!-- +1 FIDS -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryCustomFIDS00" SubCategory="Primary" ShowInCustom="true" Cost="10">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomFIDS00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -160,7 +160,7 @@
   <!-- +1 FIDS and +2 Happiness per Temple -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomFIDSPerTemple00" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomFIDSPerTemple00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -183,7 +183,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryLuxuryValue" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>ResourceTypeLuxury</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryLuxuryValue"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -205,7 +205,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryStrategicValue" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>ResourceTypeStrategic</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryStrategicValue"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">

--- a/Endless Space Competitive Mod/Simulation/Traits/PopulationModifiersTraits[9_Vanilla].xml
+++ b/Endless Space Competitive Mod/Simulation/Traits/PopulationModifiersTraits[9_Vanilla].xml
@@ -3,7 +3,7 @@
   <!--Local Bonus: Analysts-->
     <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryScience01" SubCategory="Primary" ShowInCustom="false" Cost="5">
         <Modifiers>
-            <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+            <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
                 <!-- Allows tracking by Traits rather than Affinities for CustomFactions -->
                 <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryScience01"/>
             </Modifier>
@@ -29,7 +29,7 @@
     <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryScienceCold" SubCategory="Secondary" ShowInCustom="false" Cost="5">
         <Tags>PlanetGameplayTypeCold,BonusPopulationScience</Tags>
         <Modifiers>
-            <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+            <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
                 <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryScienceCold"/>
             </Modifier>
             <Modifier Class="ClassPopulationPlanet">
@@ -53,7 +53,7 @@
         <Tags>PlanetDepletionPerTurn,BonusPopulationFIDSPercent</Tags>
         <Command Name="SetHomePlanetDepletion"          Arguments="0.25"/>
         <Modifiers>
-            <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+            <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
                 <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryDepletionFIDS"/>
             </Modifier>
             <Modifier Class="ClassPopulationPlanet">
@@ -77,7 +77,7 @@
     <Tags>PlanetDepletionPerTurn,BonusPopulationFIDSPercent</Tags>
     <Command Name="SetHomePlanetDepletion"          Arguments="0.25"/>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryDepletionFIDS"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -99,7 +99,7 @@
   <!--Local Bonus: Bankers-->
     <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryDust" SubCategory="Primary" ShowInCustom="false" Cost="5">
         <Modifiers>
-            <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+            <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
                 <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryDust"/>
             </Modifier>
             <Modifier Class="ClassPopulationPlanet">
@@ -122,7 +122,7 @@
     <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryDustFertile" SubCategory="Secondary" ShowInCustom="false" Cost="5">
         <Tags>PlanetGameplayTypeTeeming,BonusPopulationDust</Tags>
         <Modifiers>
-            <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+            <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
                 <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryDustFertile"/>
             </Modifier>
             <Modifier Class="ClassPopulationPlanet">
@@ -144,7 +144,7 @@
     <!--Local Bonus: Gargantuan Populations-->
     <PopulationModifiersTrait Name="PopulationModifiersTraitPrimarySlowGrowthFIDS" SubCategory="Primary" ShowInCustom="true" Cost="15">
         <Modifiers>
-            <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+            <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
                 <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimarySlowGrowthFIDS"/>
             </Modifier>
             <Modifier Class="ClassPopulationStarSystem">
@@ -170,7 +170,7 @@
     <!--Local Bonus: Loyal Citizens-->
     <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryInfluence" SubCategory="Primary" ShowInCustom="false" Cost="5">
         <Modifiers>
-            <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+            <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
                 <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryInfluence"/>
             </Modifier>
             <Modifier Class="ClassPopulationPlanet">
@@ -193,7 +193,7 @@
     <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryInfluenceTemperate" SubCategory="Secondary" ShowInCustom="false" Cost="5">
         <Tags>PlanetGameplayTypeTemperate,BonusPopulationPrestige</Tags>
         <Modifiers>
-            <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+            <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
                 <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryInfluenceTemperate"/>
             </Modifier>
             <Modifier Class="ClassPopulationPlanet">
@@ -215,7 +215,7 @@
     <!--Local Bonus: Martial Traditions-->
     <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryDefense" SubCategory="Primary" ShowInCustom="false" Cost="5">
         <Modifiers>
-            <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+            <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
                 <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryDefense"/>
             </Modifier>
             <Modifier Class="ClassPopulationPlanet">
@@ -237,7 +237,7 @@
     <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryDefenseSterile" SubCategory="Secondary" ShowInCustom="false" Cost="5">
         <Tags>PlanetGameplayTypeMeager,BonusPopulationDefense</Tags>
         <Modifiers>
-            <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+            <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
                 <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryDefenseSterile"/>
             </Modifier>
             <Modifier Class="ClassPopulationPlanet">
@@ -258,7 +258,7 @@
     <!--Local Bonus: Hedonists-->
     <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryHappiness" SubCategory="Primary" ShowInCustom="false" Cost="5">
         <Modifiers>
-            <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+            <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
                 <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryHappiness"/>
             </Modifier>
             <Modifier Class="ClassPopulationPlanet">
@@ -280,7 +280,7 @@
     <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryHappinessHot" SubCategory="Secondary" ShowInCustom="false" Cost="5">
         <Tags>PlanetGameplayTypeHot,BonusPopulationHappiness</Tags>
         <Modifiers>
-            <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+            <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
                 <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryHappinessHot"/>
             </Modifier>
             <Modifier Class="ClassPopulationPlanet">
@@ -302,7 +302,7 @@
     <!--Local Bonus: Adept Workers-->
     <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryIDS" SubCategory="Primary" ShowInCustom="true" Cost="25">
         <Modifiers>
-            <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+            <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
                 <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryIDS"/>
             </Modifier>
             <Modifier Class="ClassPopulationPlanet">
@@ -324,7 +324,7 @@
     <!--Local Bonus: Epicureans-->
     <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryFood03" SubCategory="Primary" ShowInCustom="false" Cost="15">
         <Modifiers>
-            <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+            <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
                 <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryFood03"/>
             </Modifier>
             <Modifier Class="ClassPopulationPlanet">
@@ -346,7 +346,7 @@
     <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryFoodFertile02" SubCategory="Secondary" ShowInCustom="false" Cost="15">
         <Tags>PlanetGameplayTypeTeeming,BonusPopulationFood</Tags>
         <Modifiers>
-            <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+            <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
                 <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryFoodFertile02"/>
             </Modifier>
             <Modifier Class="ClassPopulationPlanet">
@@ -368,7 +368,7 @@
     <!--Local Bonus: Agriculturalists-->
     <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryFood01" SubCategory="Primary" ShowInCustom="false" Cost="5">
         <Modifiers>
-            <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+            <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
                 <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryFood01"/>
             </Modifier>
             <Modifier Class="ClassPopulationPlanet">
@@ -391,7 +391,7 @@
     <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryFoodSterile" SubCategory="Secondary" ShowInCustom="false" Cost="10">
         <Tags>PlanetGameplayTypeMeager,BonusPopulationFood</Tags>
         <Modifiers>
-            <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+            <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
                 <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryFoodSterile"/>
             </Modifier>
             <Modifier Class="ClassPopulationPlanet">
@@ -414,7 +414,7 @@
     <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryHappinessFertile" SubCategory="Secondary" ShowInCustom="false" Cost="10">
         <Tags>PlanetGameplayTypeTeeming,BonusPopulationHappiness</Tags>
         <Modifiers>
-            <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+            <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
                 <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryHappinessFertile"/>
             </Modifier>
             <Modifier Class="ClassPopulationPlanet">
@@ -436,7 +436,7 @@
     <!--Local Bonus: Craftsmen-->
     <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryIndustry" SubCategory="Primary" ShowInCustom="false" Cost="5">
         <Modifiers>
-            <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+            <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
                 <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryIndustry"/>
             </Modifier>
             <Modifier Class="ClassPopulationPlanet">
@@ -458,7 +458,7 @@
     <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryIndustryHot" SubCategory="Secondary" ShowInCustom="false" Cost="5">
         <Tags>PlanetGameplayTypeHot,BonusPopulationIndustry</Tags>
         <Modifiers>
-            <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+            <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
                 <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryIndustryHot"/>
             </Modifier>
             <Modifier Class="ClassPopulationPlanet">
@@ -480,7 +480,7 @@
     <!--Local Bonus: Methodists-->
     <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryScience02" SubCategory="Primary" ShowInCustom="false" Cost="10">
         <Modifiers>
-            <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+            <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
                 <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryScience02"/>
             </Modifier>
             <Modifier Class="ClassPopulationPlanet">
@@ -503,7 +503,7 @@
     <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryFoodGas" SubCategory="Secondary" ShowInCustom="false" Cost="5">
         <Tags>PlanetGameplayTypeGas,BonusPopulationFood</Tags>
         <Modifiers>
-            <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+            <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
                 <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryFoodGas"/>
             </Modifier>
             <Modifier Class="ClassPopulationPlanet">
@@ -525,7 +525,7 @@
     <!--Local Bonus: Nurturers-->
     <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryFood02" SubCategory="Primary" ShowInCustom="false" Cost="10">
         <Modifiers>
-            <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+            <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
                 <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryFood02"/>
             </Modifier>
             <Modifier Class="ClassPopulationPlanet">
@@ -548,7 +548,7 @@
     <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryScienceAnomaly01" SubCategory="Secondary" ShowInCustom="false" Cost="5">
         <Tags>PlanetAnomaly,BonusPopulationScience</Tags>
         <Modifiers>
-            <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+            <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
                 <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryScienceAnomaly01"/>
             </Modifier>
             <Modifier Class="ClassPopulationPlanet">
@@ -571,7 +571,7 @@
     <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryScienceHappy" SubCategory="Secondary" ShowInCustom="false" Cost="10">
         <Tags>HappinessStatusStarSystem3,BonusPopulationScience</Tags>
         <Modifiers>
-            <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+            <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
                 <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryScienceHappy"/>
             </Modifier>
             <Modifier Class="ClassPopulationPlanet">
@@ -593,7 +593,7 @@
     <!--Local Bonus: Eager Volunteers-->
     <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryManpower" SubCategory="Primary" ShowInCustom="false" Cost="10">
         <Modifiers>
-            <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+            <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
                 <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryManpower"/>
             </Modifier>
             <Modifier Class="ClassPopulationPlanet">
@@ -616,7 +616,7 @@
     <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryManpowerFertile" SubCategory="Secondary" ShowInCustom="false" Cost="5">
         <Tags>PlanetGameplayTypeTeeming,BonusPopulationEmpireManpower</Tags>
         <Modifiers>
-            <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+            <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
                 <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryManpowerFertile"/>
             </Modifier>
             <Modifier Class="ClassPopulationPlanet">
@@ -638,7 +638,7 @@
     <!--Local Bonus: [Tough Defenders] -->
     <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryGroundBattleAttackerDamage" SubCategory="Primary" ShowInCustom="false" Cost="5">
         <Modifiers>
-            <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+            <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
                 <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryGroundBattleAttackerDamage"/>
             </Modifier>
             <Modifier Class="ClassPopulationPlanet">
@@ -660,7 +660,7 @@
     <!--Contextual Bonus: Ruthless Defenders-->
     <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryGroundBattleAttackerDamageFertile" SubCategory="Secondary" ShowInCustom="false" Cost="10">
         <Modifiers>
-            <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+            <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
                 <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryGroundBattleAttackerDamageFertile"/>
             </Modifier>
             <Modifier Class="ClassPopulationPlanet">
@@ -683,7 +683,7 @@
     <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryDustGas" SubCategory="Secondary" ShowInCustom="false" Cost="5">
         <Tags>PlanetGameplayTypeGas,BonusPopulationDust</Tags>
         <Modifiers>
-            <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+            <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
                 <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryDustGas"/>
             </Modifier>
             <Modifier Class="ClassPopulationPlanet">
@@ -706,7 +706,7 @@
     <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryFoodFertile01" SubCategory="Secondary" ShowInCustom="false" Cost="5">
         <Tags>PlanetGameplayTypeTeeming,BonusPopulationFood</Tags>
         <Modifiers>
-            <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+            <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
                 <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryFoodFertile01"/>
             </Modifier>
             <Modifier Class="ClassPopulationPlanet">
@@ -729,7 +729,7 @@
     <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryDustHappy" SubCategory="Secondary" ShowInCustom="false" Cost="5">
         <Tags>HappinessStatusStarSystem3,BonusPopulationDust</Tags>
         <Modifiers>
-            <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+            <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
                 <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryDustHappy"/>
             </Modifier>
             <Modifier Class="ClassPopulationPlanet">
@@ -752,7 +752,7 @@
     <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryScienceAnomaly02" SubCategory="Secondary" ShowInCustom="false" Cost="10">
         <Tags>PlanetAnomaly,BonusPopulationScience</Tags>
         <Modifiers>
-            <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+            <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
                 <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryScienceAnomaly02"/>
             </Modifier>
             <Modifier Class="ClassPopulationPlanet">
@@ -775,7 +775,7 @@
     <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryIndustrySterile" SubCategory="Secondary" ShowInCustom="false" Cost="5">
         <Tags>PlanetGameplayTypeMeager,BonusPopulationIndustry</Tags>
         <Modifiers>
-            <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+            <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
                 <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryIndustrySterile"/>
             </Modifier>
             <Modifier Class="ClassPopulationPlanet">
@@ -798,7 +798,7 @@
     <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryDustSterile" SubCategory="Secondary" ShowInCustom="false" Cost="10">
         <Tags>PlanetGameplayTypeMeager,BonusPopulationDust</Tags>
         <Modifiers>
-            <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+            <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
                 <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryDustSterile"/>
             </Modifier>
             <Modifier Class="ClassPopulationPlanet">
@@ -821,7 +821,7 @@
     <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryHappinessTemperate" SubCategory="Secondary" ShowInCustom="false" Cost="5">
         <Tags>PlanetGameplayTypeTemperate,BonusPopulationHappiness</Tags>
         <Modifiers>
-            <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+            <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
                 <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryHappinessTemperate"/>
             </Modifier>
             <Modifier Class="ClassPopulationPlanet">
@@ -844,7 +844,7 @@
     <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryIndustryCold" SubCategory="Secondary" ShowInCustom="false" Cost="5">
         <Tags>PlanetGameplayTypeCold,BonusPopulationIndustry</Tags>
         <Modifiers>
-            <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+            <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
                 <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryIndustryCold"/>
             </Modifier>
             <Modifier Class="ClassPopulationPlanet">
@@ -867,7 +867,7 @@
     <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryScienceHot" SubCategory="Secondary" ShowInCustom="false" Cost="5">
         <Tags>PlanetGameplayTypeHot,BonusPopulationScience</Tags>
         <Modifiers>
-            <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+            <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
                 <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryScienceHot"/>
             </Modifier>
             <Modifier Class="ClassPopulationPlanet">
@@ -890,7 +890,7 @@
     <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryDefenseFertile" SubCategory="Secondary" ShowInCustom="false" Cost="5">
         <Tags>PlanetGameplayTypeTeeming,BonusPopulationDefense</Tags>
         <Modifiers>
-            <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+            <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
                 <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryDefenseFertile"/>
             </Modifier>
             <Modifier Class="ClassPopulationPlanet">
@@ -912,7 +912,7 @@
     <!--Contextual Bonus: Meritocratic Cosmopolites-->
     <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryFIDSI" SubCategory="Primary" ShowInCustom="false" Cost="15">
         <Modifiers>
-            <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+            <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
                 <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryFIDSI"/>
             </Modifier>
             <Modifier Class="ClassPopulationPlanet">
@@ -935,7 +935,7 @@
   <!--First trait is the same as sophons-->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryGroundBattleAttackerDamage01" SubCategory="Secondary" ShowInCustom="false" Cost="5">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <!--+20 Ground battle damage to attacker -->
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryGroundBattleAttackerDamage01"/>
       </Modifier>
@@ -957,7 +957,7 @@
 
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryManpower" SubCategory="Secondary" ShowInCustom="false" Cost="5">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryManpower"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -978,7 +978,7 @@
 
   <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryInfluenceOnHot01" SubCategory="Secondary" ShowInCustom="false" Cost="5">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <!-- +1 influence on Hot -->
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryInfluenceOnHot01"/>
       </Modifier>
@@ -1002,7 +1002,7 @@
     <!--Contextual Bonus: Hardened Dwellers-->
     <Tags>PlanetGameplayTypeMeager,BonusPopulationHappiness</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryHappinessSterile"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1026,7 +1026,7 @@
     <!--Contextual Bonus: Biomimetic Builders-->
     <Tags>PlanetGameplayTypeTeeming,BonusPopulationIndustry</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryIndustryFertile"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1050,7 +1050,7 @@
     <!--Contextual Bonus: Planet Menders I-->
     <Tags>PlanetDepletion</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryAntiDepletion00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1073,7 +1073,7 @@
   <!--Contextual Bonus: Planet Menders II-->
     <Tags>PlanetDepletion</Tags>
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryAntiDepletion01"/> 
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1122,7 +1122,7 @@
 
   <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryStrategicToFood01" SubCategory="Primary" ShowInCustom="false" Cost="5">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryStrategicToFood01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1143,7 +1143,7 @@
 
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryStrategicToScience01" SubCategory="Secondary" ShowInCustom="false" Cost="15">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryStrategicToScience01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1165,7 +1165,7 @@
   <!-- +1 Bandwidth -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryProcessingPower01" SubCategory="Primary" ShowInCustom="true" Cost="5">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryProcessingPower01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
@@ -1186,7 +1186,7 @@
 
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryProcessingPower01" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Modifiers>
-      <Modifier Class="ClassPopulationEmpire" DisplayWhenBoostedOnly="true">
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryProcessingPower01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">

--- a/Endless Space Competitive Mod/Simulation/Traits/SimulationDescriptors[10_FIDS].xml
+++ b/Endless Space Competitive Mod/Simulation/Traits/SimulationDescriptors[10_FIDS].xml
@@ -9,8 +9,9 @@
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomFIDSIEcstatic00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationFIDSI" Operation="Addition" Value="1" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
-    <Modifier TargetProperty="BonusPopulationFIDSI" Operation="Addition" Value="1" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
-    <BinaryModifier TargetProperty="BonusPopulationFIDSI" Operation="Addition" Left="1" BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)"  Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPopulationPlanetModifiersTraitSecondaryCustomFIDSIEcstatic00" TooltipHidden="true" SearchValueFromPath="true"/>
+    <Modifier		TargetProperty="BonusPopulationFIDSI"	Operation="Addition" Value="1" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
+    <Modifier		TargetProperty="BonusPopulationFIDSI"	Operation="Addition" Value="1" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition" Left="1"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFIDSI"   Operation="Addition" Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" TooltipHidden="true"/>
   </SimulationDescriptor>
 </Datatable>

--- a/Endless Space Competitive Mod/Simulation/Traits/SimulationDescriptors[1_Food].xml
+++ b/Endless Space Competitive Mod/Simulation/Traits/SimulationDescriptors[1_Food].xml
@@ -1,96 +1,83 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Datatable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xsi:noNamespaceSchemaLocation="../../Schemas/Amplitude.Unity.Simulation.SimulationDescriptor.xsd">
-  <!-- Primary -->
-  <!-- Food -->
-  <!-- +1 Food -->
-  <!-- Primary -->
+<!-- Primary -->
+<!-- Food -->
 
+<!-- +1 Food -->
+<!-- Primary -->
 
 <!-- Food -->
 
+  <!-- +1 Food -->
+  <SimulationDescriptor Type="WithPopulationPlanet" Name="WithPopulationPlanetModifiersTraitPrimaryCustomFood00">
+	<Modifier       TargetProperty="BonusPopulationFood"    Operation="Addition"    Value="1"   Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationFood"    Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+  </SimulationDescriptor>
 
-<!-- +1 Food -->
+  <SimulationDescriptor Type="ClassPopulationPlanet" Name="ClassPopulationPlanetModifiersTraitPrimaryCustomFood00">
+	<Modifier Path="ClassPopulation" Value="1" Operation="Addition" TargetProperty="BonusPopulationFood"/>
+  </SimulationDescriptor>
 
-
-
--<SimulationDescriptor Type="WithPopulationPlanet" Name="WithPopulationPlanetModifiersTraitPrimaryCustomFood00">
-<Modifier Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimaryCustomFood00, ClassPopulation" Value="1" Operation="Addition" TargetProperty="BonusPopulationFood"/>
-</SimulationDescriptor>
-
-
--<SimulationDescriptor Type="ClassPopulationPlanet" Name="ClassPopulationPlanetModifiersTraitPrimaryCustomFood00">
-<Modifier Path="ClassPopulation" Value="1" Operation="Addition" TargetProperty="BonusPopulationFood"/>
-</SimulationDescriptor>
-
-
--<SimulationDescriptor Type="ClassPopulationAssimilated" Name="ClassPopulationAssimilatedPrimaryCustomFood00">
-<Modifier Path="ClassPopulation" Value="2" Operation="Addition" TargetProperty="BonusPopulationFood"/>
-</SimulationDescriptor>
+  <SimulationDescriptor Type="ClassPopulationAssimilated" Name="ClassPopulationAssimilatedPrimaryCustomFood00">
+	<Modifier Path="ClassPopulation" Value="2" Operation="Addition" TargetProperty="BonusPopulationFood"/>
+  </SimulationDescriptor>
 
   <!-- +2 Food -->
+  <SimulationDescriptor Type="WithPopulationPlanet" Name="WithPopulationPlanetModifiersTraitPrimaryCustomFood01">
+	<Modifier       TargetProperty="BonusPopulationFood"    Operation="Addition"    Value="2"   Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationFood"    Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+  </SimulationDescriptor>
 
--<SimulationDescriptor Type="WithPopulationPlanet" Name="WithPopulationPlanetModifiersTraitPrimaryCustomFood01">
-<Modifier Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimaryCustomFood01, ClassPopulation" Value="2" Operation="Addition" TargetProperty="BonusPopulationFood"/>
-</SimulationDescriptor>
-
-
--<SimulationDescriptor Type="ClassPopulationPlanet" Name="ClassPopulationPlanetModifiersTraitPrimaryCustomFood01">
-<Modifier Path="ClassPopulation" Value="2" Operation="Addition" TargetProperty="BonusPopulationFood"/>
-</SimulationDescriptor>
+  <SimulationDescriptor Type="ClassPopulationPlanet" Name="ClassPopulationPlanetModifiersTraitPrimaryCustomFood01">
+	<Modifier Path="ClassPopulation" Value="2" Operation="Addition" TargetProperty="BonusPopulationFood"/>
+  </SimulationDescriptor>
 
   <!-- +3 Food -->
+  <SimulationDescriptor Type="WithPopulationPlanet" Name="WithPopulationPlanetModifiersTraitPrimaryCustomFood02">
+	<Modifier       TargetProperty="BonusPopulationFood"    Operation="Addition"    Value="3"   Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationFood"    Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+  </SimulationDescriptor>
 
--<SimulationDescriptor Type="WithPopulationPlanet" Name="WithPopulationPlanetModifiersTraitPrimaryCustomFood02">
-<Modifier Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimaryCustomFood02, ClassPopulation" Value="3" Operation="Addition" TargetProperty="BonusPopulationFood"/>
-</SimulationDescriptor>
+  <SimulationDescriptor Type="ClassPopulationPlanet" Name="ClassPopulationPlanetModifiersTraitPrimaryCustomFood02">
+	<Modifier Path="ClassPopulation" Value="3" Operation="Addition" TargetProperty="BonusPopulationFood"/>
+  </SimulationDescriptor>
 
-
--<SimulationDescriptor Type="ClassPopulationPlanet" Name="ClassPopulationPlanetModifiersTraitPrimaryCustomFood02">
-<Modifier Path="ClassPopulation" Value="3" Operation="Addition" TargetProperty="BonusPopulationFood"/>
-</SimulationDescriptor>
-
-
--<SimulationDescriptor Type="ClassPopulationAssimilated" Name="ClassPopulationAssimilatedPrimaryCustomFood02">
-<Modifier Path="ClassPopulation" Value="3" Operation="Addition" TargetProperty="BonusPopulationFood"/>
-</SimulationDescriptor>
+  <SimulationDescriptor Type="ClassPopulationAssimilated" Name="ClassPopulationAssimilatedPrimaryCustomFood02">
+	<Modifier Path="ClassPopulation" Value="3" Operation="Addition" TargetProperty="BonusPopulationFood"/>
+  </SimulationDescriptor>
 
   <!-- +4 Food -->
+  <SimulationDescriptor Type="WithPopulationPlanet" Name="WithPopulationPlanetModifiersTraitPrimaryCustomFood03">
+	<Modifier       TargetProperty="BonusPopulationFood"    Operation="Addition"    Value="4"   Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationFood"    Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+  </SimulationDescriptor>
 
-
-
--<SimulationDescriptor Type="WithPopulationPlanet" Name="WithPopulationPlanetModifiersTraitPrimaryCustomFood03">
-<Modifier Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimaryCustomFood03, ClassPopulation" Value="4" Operation="Addition" TargetProperty="BonusPopulationFood"/>
-</SimulationDescriptor>
-
-
--<SimulationDescriptor Type="ClassPopulationPlanet" Name="ClassPopulationPlanetModifiersTraitPrimaryCustomFood03">
-<Modifier Path="ClassPopulation" Value="4" Operation="Addition" TargetProperty="BonusPopulationFood"/>
-</SimulationDescriptor>
+  <SimulationDescriptor Type="ClassPopulationPlanet" Name="ClassPopulationPlanetModifiersTraitPrimaryCustomFood03">
+	<Modifier Path="ClassPopulation" Value="4" Operation="Addition" TargetProperty="BonusPopulationFood"/>
+  </SimulationDescriptor>
 
   <!-- +5 Food -->
+  <SimulationDescriptor Type="WithPopulationPlanet" Name="WithPopulationPlanetModifiersTraitPrimaryCustomFood04">
+	<Modifier       TargetProperty="BonusPopulationFood"    Operation="Addition"    Value="5"   Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationFood"    Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+  </SimulationDescriptor>
 
+  <SimulationDescriptor Type="ClassPopulationPlanet" Name="ClassPopulationPlanetModifiersTraitPrimaryCustomFood04">
+	<Modifier Path="ClassPopulation" Value="5" Operation="Addition" TargetProperty="BonusPopulationFood"/>
+  </SimulationDescriptor>
 
+  <SimulationDescriptor Type="ClassPopulationAssimilated" Name="ClassPopulationAssimilatedPrimaryCustomFood04">
+    <Modifier Path="ClassPopulation" Value="4" Operation="Addition" TargetProperty="BonusPopulationFood"/>
+  </SimulationDescriptor>
 
--<SimulationDescriptor Type="WithPopulationPlanet" Name="WithPopulationPlanetModifiersTraitPrimaryCustomFood04">
-<Modifier Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimaryCustomFood04, ClassPopulation" Value="5" Operation="Addition" TargetProperty="BonusPopulationFood"/>
-</SimulationDescriptor>
+<!-- Secondary -->
+<!-- Food on Cold -->
 
-
--<SimulationDescriptor Type="ClassPopulationPlanet" Name="ClassPopulationPlanetModifiersTraitPrimaryCustomFood04">
-<Modifier Path="ClassPopulation" Value="5" Operation="Addition" TargetProperty="BonusPopulationFood"/>
-</SimulationDescriptor>
-
-
--<SimulationDescriptor Type="ClassPopulationAssimilated" Name="ClassPopulationAssimilatedPrimaryCustomFood04">
-<Modifier Path="ClassPopulation" Value="4" Operation="Addition" TargetProperty="BonusPopulationFood"/>
-</SimulationDescriptor>
-
-  <!-- Secondary -->
-  <!-- Food on Cold -->
   <!-- +1 FoodOnCold -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnCold00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeCold/ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnCold00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationFood"    Operation="Addition"    Value="1"   Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFood"    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsCold)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnCold00" Type="ClassPopulationPlanet">
@@ -104,8 +91,9 @@
 
   <!-- +2 FoodOnCold -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnCold01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeCold/ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnCold01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationFood"    Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFood"    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsCold)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnCold01" Type="ClassPopulationPlanet">
@@ -115,8 +103,9 @@
 
   <!-- +3 FoodOnCold -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnCold02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeCold/ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnCold02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationFood"    Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFood"    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsCold)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnCold02" Type="ClassPopulationPlanet">
@@ -130,8 +119,9 @@
 
   <!-- +4 FoodOnCold -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnCold03" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="4" Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="4" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeCold/ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnCold03" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationFood"    Operation="Addition"    Value="4"   Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFood"    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsCold)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnCold03" Type="ClassPopulationPlanet">
@@ -141,8 +131,9 @@
 
   <!-- +5 FoodOnCold -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnCold04" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeCold/ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnCold04" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationFood"    Operation="Addition"    Value="5"   Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFood"    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsCold)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnCold04" Type="ClassPopulationPlanet">
@@ -157,8 +148,9 @@
   <!-- Food on Temperate -->
   <!-- +1 FoodOnTemperate -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnTemperate00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTemperate/ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnTemperate00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationFood"	    Operation="Addition"    Value="1"   Path="FAKEFORGUI./PlanetGameplayTypeTemperate"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFood"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTemperate)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnTemperate00" Type="ClassPopulationPlanet">
@@ -172,8 +164,9 @@
 
   <!-- +2 FoodOnTemperate -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnTemperate01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTemperate/ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnTemperate01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationFood"	    Operation="Addition"    Value="2"   Path="FAKEFORGUI./PlanetGameplayTypeTemperate"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFood"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTemperate)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnTemperate01" Type="ClassPopulationPlanet">
@@ -183,8 +176,9 @@
 
   <!-- +3 FoodOnTemperate -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnTemperate02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTemperate/ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnTemperate02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationFood"	    Operation="Addition"    Value="3"   Path="FAKEFORGUI./PlanetGameplayTypeTemperate"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFood"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTemperate)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnTemperate02" Type="ClassPopulationPlanet">
@@ -198,8 +192,9 @@
 
   <!-- +4 FoodOnTemperate -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnTemperate03" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="4" Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="4" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTemperate/ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnTemperate03" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationFood"	    Operation="Addition"    Value="4"   Path="FAKEFORGUI./PlanetGameplayTypeTemperate"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFood"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTemperate)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnTemperate03" Type="ClassPopulationPlanet">
@@ -209,8 +204,9 @@
 
   <!-- +5 FoodOnTemperate -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnTemperate04" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTemperate/ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnTemperate04" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationFood"	    Operation="Addition"    Value="5"   Path="FAKEFORGUI./PlanetGameplayTypeTemperate"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFood"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTemperate)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnTemperate04" Type="ClassPopulationPlanet">
@@ -225,8 +221,9 @@
   <!-- Food on Hot -->
   <!-- +1 FoodOnHot -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnHot00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeHot/ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnHot00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationFood"	    Operation="Addition"    Value="1"   Path="FAKEFORGUI./PlanetGameplayTypeHot"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFood"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHot)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnHot00" Type="ClassPopulationPlanet">
@@ -240,8 +237,9 @@
 
   <!-- +2 FoodOnHot -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnHot01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeHot/ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnHot01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationFood"	    Operation="Addition"    Value="2"   Path="FAKEFORGUI./PlanetGameplayTypeHot"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFood"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHot)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnHot01" Type="ClassPopulationPlanet">
@@ -251,8 +249,9 @@
 
   <!-- +3 FoodOnHot -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnHot02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeHot/ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnHot02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationFood"	    Operation="Addition"    Value="3"   Path="FAKEFORGUI./PlanetGameplayTypeHot"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFood"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHot)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnHot02" Type="ClassPopulationPlanet">
@@ -266,8 +265,9 @@
 
   <!-- +4 FoodOnHot -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnHot03" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="4" Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="4" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeHot/ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnHot03" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationFood"	    Operation="Addition"    Value="4"   Path="FAKEFORGUI./PlanetGameplayTypeHot"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFood"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHot)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnHot03" Type="ClassPopulationPlanet">
@@ -277,8 +277,9 @@
 
   <!-- +5 FoodOnHot -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnHot04" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeHot/ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnHot04" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationFood"	    Operation="Addition"    Value="5"   Path="FAKEFORGUI./PlanetGameplayTypeHot"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFood"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHot)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnHot04" Type="ClassPopulationPlanet">
@@ -293,8 +294,9 @@
   <!-- Food on Teeming -->
   <!-- +1 FoodOnTeeming -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnTeeming00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTeeming/ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnTeeming00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationFood"	    Operation="Addition"    Value="1"   Path="FAKEFORGUI./PlanetGameplayTypeTeeming"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFood"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnTeeming00" Type="ClassPopulationPlanet">
@@ -308,8 +310,9 @@
 
   <!-- +2 FoodOnTeeming -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnTeeming01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTeeming/ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnTeeming01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationFood"	    Operation="Addition"    Value="2"   Path="FAKEFORGUI./PlanetGameplayTypeTeeming"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFood"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnTeeming01" Type="ClassPopulationPlanet">
@@ -319,8 +322,9 @@
 
   <!-- +3 FoodOnTeeming -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnTeeming02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTeeming/ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnTeeming02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationFood"	    Operation="Addition"    Value="3"   Path="FAKEFORGUI./PlanetGameplayTypeTeeming"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFood"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnTeeming02" Type="ClassPopulationPlanet">
@@ -334,8 +338,9 @@
 
   <!-- +4 FoodOnTeeming -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnTeeming03" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="4" Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="4" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTeeming/ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnTeeming03" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationFood"	    Operation="Addition"    Value="4"   Path="FAKEFORGUI./PlanetGameplayTypeTeeming"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFood"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnTeeming03" Type="ClassPopulationPlanet">
@@ -345,8 +350,9 @@
 
   <!-- +5 FoodOnTeeming -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnTeeming04" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTeeming/ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnTeeming04" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationFood"	    Operation="Addition"    Value="5"   Path="FAKEFORGUI./PlanetGameplayTypeTeeming"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFood"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnTeeming04" Type="ClassPopulationPlanet">
@@ -361,8 +367,9 @@
   <!-- Food on Meager -->
   <!-- +1 FoodOnMeager -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnMeager00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeMeager/ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnMeager00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationFood"	    Operation="Addition"    Value="1"   Path="FAKEFORGUI./PlanetGameplayTypeMeager"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFood"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMeager)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnMeager00" Type="ClassPopulationPlanet">
@@ -376,8 +383,9 @@
 
   <!-- +2 FoodOnMeager -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnMeager01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeMeager/ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnMeager01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationFood"	    Operation="Addition"    Value="2"   Path="FAKEFORGUI./PlanetGameplayTypeMeager"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFood"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMeager)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnMeager01" Type="ClassPopulationPlanet">
@@ -387,8 +395,9 @@
 
   <!-- +3 FoodOnMeager -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnMeager02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeMeager/ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnMeager02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationFood"	    Operation="Addition"    Value="3"   Path="FAKEFORGUI./PlanetGameplayTypeMeager"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFood"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMeager)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnMeager02" Type="ClassPopulationPlanet">
@@ -402,8 +411,9 @@
 
   <!-- +4 FoodOnMeager -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnMeager03" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="4" Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="4" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeMeager/ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnMeager03" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationFood"	    Operation="Addition"    Value="4"   Path="FAKEFORGUI./PlanetGameplayTypeMeager"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFood"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMeager)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnMeager03" Type="ClassPopulationPlanet">
@@ -413,8 +423,9 @@
 
   <!-- +5 FoodOnMeager -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnMeager04" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeMeager/ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnMeager04" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationFood"	    Operation="Addition"    Value="5"   Path="FAKEFORGUI./PlanetGameplayTypeMeager"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFood"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMeager)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnMeager04" Type="ClassPopulationPlanet">
@@ -427,10 +438,11 @@
   </SimulationDescriptor>
 
   <!-- Food on Gas -->
-  <!-- +1 FoodOnGas -->
+  <!-- +3 FoodOnGas -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnGas00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeGas/ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnGas00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationFood"	    Operation="Addition"    Value="3"   Path="FAKEFORGUI./PlanetGameplayTypeGas"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFood"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsGas)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnGas00" Type="ClassPopulationPlanet">
@@ -442,10 +454,11 @@
     <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="3" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +2 FoodOnGas -->
+  <!-- +5 FoodOnGas -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnGas01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeGas/ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnGas01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationFood"	    Operation="Addition"    Value="5"   Path="FAKEFORGUI./PlanetGameplayTypeGas"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFood"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsGas)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnGas01" Type="ClassPopulationPlanet">
@@ -453,10 +466,11 @@
     <BinaryModifier TargetProperty="BonusPopulationFood" Operation="Addition" Left="5" BinaryOperation="Multiplication" Right="$(PlanetIsGas)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +3 FoodOnGas -->
+  <!-- +10 FoodOnGas -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnGas02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="10" Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="10" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeGas/ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnGas02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationFood"	    Operation="Addition"    Value="10"  Path="FAKEFORGUI./PlanetGameplayTypeGas"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="10"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFood"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsGas)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnGas02" Type="ClassPopulationPlanet">
@@ -468,10 +482,11 @@
     <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="3" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +4 FoodOnGas -->
+  <!-- +12 FoodOnGas -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnGas03" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="12" Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="12" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeGas/ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnGas03" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationFood"	    Operation="Addition"    Value="12"  Path="FAKEFORGUI./PlanetGameplayTypeGas"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="12"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFood"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsGas)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnGas03" Type="ClassPopulationPlanet">
@@ -479,10 +494,11 @@
     <BinaryModifier TargetProperty="BonusPopulationFood" Operation="Addition" Left="12" BinaryOperation="Multiplication" Right="$(PlanetIsGas)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +5 FoodOnGas -->
+  <!-- +15 FoodOnGas -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnGas04" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="15" Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="15" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeGas/ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnGas04" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationFood"	    Operation="Addition"    Value="15"  Path="FAKEFORGUI./PlanetGameplayTypeGas"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="15"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFood"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsGas)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnGas04" Type="ClassPopulationPlanet">
@@ -497,9 +513,10 @@
   <!-- Food on Happy -->
   <!-- +1 FoodOnHappy -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnHappy00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="1" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="1" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
-    <BinaryModifier TargetProperty="BonusPopulationFood" Operation="Addition" Left="1" BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)"  Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnHappy00" TooltipHidden="true" SearchValueFromPath="true"/>
+    <Modifier		TargetProperty="BonusPopulationFood"			Operation="Addition" Value="1" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
+    <Modifier		TargetProperty="BonusPopulationFood"			Operation="Addition" Value="1" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"			Operation="Addition" Left="1"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFood"			Operation="Addition" Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnHappy00" Type="ClassPopulationPlanet">
@@ -514,9 +531,10 @@
 
   <!-- +2 FoodOnHappy -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnHappy01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="2" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="2" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
-    <BinaryModifier TargetProperty="BonusPopulationFood" Operation="Addition" Left="2" BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnHappy01" TooltipHidden="true" SearchValueFromPath="true"/>
+    <Modifier		TargetProperty="BonusPopulationFood"			Operation="Addition" Value="2" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
+    <Modifier		TargetProperty="BonusPopulationFood"			Operation="Addition" Value="2" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"			Operation="Addition" Left="2"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFood"			Operation="Addition" Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnHappy01" Type="ClassPopulationPlanet">
@@ -527,9 +545,10 @@
 
   <!-- +3 FoodOnHappy -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnHappy02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="3" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="3" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
-    <BinaryModifier TargetProperty="BonusPopulationFood" Operation="Addition" Left="3" BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnHappy02" TooltipHidden="true" SearchValueFromPath="true"/>
+    <Modifier		TargetProperty="BonusPopulationFood"			Operation="Addition" Value="3" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
+    <Modifier		TargetProperty="BonusPopulationFood"			Operation="Addition" Value="3" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"			Operation="Addition" Left="3"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFood"			Operation="Addition" Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnHappy02" Type="ClassPopulationPlanet">
@@ -544,9 +563,10 @@
 
   <!-- +4 FoodOnHappy -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnHappy03" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="4" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="4" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
-    <BinaryModifier TargetProperty="BonusPopulationFood" Operation="Addition" Left="4" BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnHappy03" TooltipHidden="true" SearchValueFromPath="true"/>
+    <Modifier		TargetProperty="BonusPopulationFood"			Operation="Addition" Value="4" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
+    <Modifier		TargetProperty="BonusPopulationFood"			Operation="Addition" Value="4" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"			Operation="Addition" Left="4"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFood"			Operation="Addition" Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnHappy03" Type="ClassPopulationPlanet">
@@ -557,9 +577,10 @@
 
   <!-- +5 FoodOnHappy -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnHappy04" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="5" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="5" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
-    <BinaryModifier TargetProperty="BonusPopulationFood" Operation="Addition" Left="5" BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnHappy04" TooltipHidden="true" SearchValueFromPath="true"/>
+    <Modifier		TargetProperty="BonusPopulationFood"			Operation="Addition" Value="5" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
+    <Modifier		TargetProperty="BonusPopulationFood"			Operation="Addition" Value="5" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"			Operation="Addition" Left="5"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFood"			Operation="Addition" Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnHappy04" Type="ClassPopulationPlanet">
@@ -575,8 +596,9 @@
   <!-- Food on Tiny -->
   <!-- +1 FoodOnTiny -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnTiny00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetSizeTiny"/>
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeTiny/ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnTiny00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationFood"	    Operation="Addition"    Value="1"   Path="FAKEFORGUI./PlanetSizeTiny"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFood"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTiny)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnTiny00" Type="ClassPopulationPlanet">
@@ -590,8 +612,9 @@
 
   <!-- +2 FoodOnTiny -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnTiny01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetSizeTiny"/>
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeTiny/ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnTiny01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationFood"	    Operation="Addition"    Value="2"   Path="FAKEFORGUI./PlanetSizeTiny"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFood"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTiny)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnTiny01" Type="ClassPopulationPlanet">
@@ -601,8 +624,9 @@
 
   <!-- +3 FoodOnTiny -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnTiny02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetSizeTiny"/>
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeTiny/ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnTiny02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationFood"	    Operation="Addition"    Value="3"   Path="FAKEFORGUI./PlanetSizeTiny"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFood"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTiny)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnTiny02" Type="ClassPopulationPlanet">
@@ -616,8 +640,9 @@
 
   <!-- +4 FoodOnTiny -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnTiny03" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="4" Path="FAKEFORGUI/./PlanetSizeTiny"/>
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="4" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeTiny/ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnTiny03" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationFood"	    Operation="Addition"    Value="4"   Path="FAKEFORGUI./PlanetSizeTiny"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFood"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTiny)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnTiny03" Type="ClassPopulationPlanet">
@@ -627,8 +652,9 @@
 
   <!-- +5 FoodOnTiny -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnTiny04" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetSizeTiny"/>
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeTiny/ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnTiny04" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationFood"	    Operation="Addition"    Value="5"   Path="FAKEFORGUI./PlanetSizeTiny"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFood"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTiny)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnTiny04" Type="ClassPopulationPlanet">
@@ -643,8 +669,9 @@
   <!-- Food on Small -->
   <!-- +1 FoodOnSmall -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnSmall00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetSizeSmall"/>
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeSmall/ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnSmall00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationFood"	    Operation="Addition"    Value="1"   Path="FAKEFORGUI./PlanetSizeSmall"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFood"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsSmall)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnSmall00" Type="ClassPopulationPlanet">
@@ -658,8 +685,9 @@
 
   <!-- +2 FoodOnSmall -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnSmall01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetSizeSmall"/>
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeSmall/ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnSmall01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationFood"	    Operation="Addition"    Value="2"   Path="FAKEFORGUI./PlanetSizeSmall"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFood"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsSmall)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnSmall01" Type="ClassPopulationPlanet">
@@ -669,8 +697,9 @@
 
   <!-- +3 FoodOnSmall -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnSmall02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetSizeSmall"/>
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeSmall/ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnSmall02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationFood"	    Operation="Addition"    Value="3"   Path="FAKEFORGUI./PlanetSizeSmall"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFood"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsSmall)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnSmall02" Type="ClassPopulationPlanet">
@@ -684,8 +713,9 @@
 
   <!-- +4 FoodOnSmall -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnSmall03" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="4" Path="FAKEFORGUI/./PlanetSizeSmall"/>
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="4" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeSmall/ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnSmall03" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationFood"	    Operation="Addition"    Value="4"   Path="FAKEFORGUI./PlanetSizeSmall"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFood"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsSmall)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnSmall03" Type="ClassPopulationPlanet">
@@ -695,8 +725,9 @@
 
   <!-- +5 FoodOnSmall -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnSmall04" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetSizeSmall"/>
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeSmall/ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnSmall04" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationFood"	    Operation="Addition"    Value="5"   Path="FAKEFORGUI./PlanetSizeSmall"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFood"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsSmall)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnSmall04" Type="ClassPopulationPlanet">
@@ -711,8 +742,9 @@
   <!-- Food on Medium -->
   <!-- +1 FoodOnMedium -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnMedium00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetSizeMedium"/>
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeMedium/ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnMedium00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationFood"	    Operation="Addition"    Value="1"   Path="FAKEFORGUI./PlanetSizeMedium"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFood"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMedium)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnMedium00" Type="ClassPopulationPlanet">
@@ -726,8 +758,9 @@
 
   <!-- +2 FoodOnMedium -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnMedium01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetSizeMedium"/>
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeMedium/ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnMedium01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationFood"	    Operation="Addition"    Value="2"   Path="FAKEFORGUI./PlanetSizeMedium"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFood"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMedium)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnMedium01" Type="ClassPopulationPlanet">
@@ -737,8 +770,9 @@
 
   <!-- +3 FoodOnMedium -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnMedium02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetSizeMedium"/>
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeMedium/ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnMedium02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationFood"	    Operation="Addition"    Value="3"   Path="FAKEFORGUI./PlanetSizeMedium"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFood"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMedium)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnMedium02" Type="ClassPopulationPlanet">
@@ -752,8 +786,9 @@
 
   <!-- +4 FoodOnMedium -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnMedium03" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="4" Path="FAKEFORGUI/./PlanetSizeMedium"/>
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="4" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeMedium/ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnMedium03" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationFood"	    Operation="Addition"    Value="4"   Path="FAKEFORGUI./PlanetSizeMedium"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFood"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMedium)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnMedium03" Type="ClassPopulationPlanet">
@@ -763,8 +798,9 @@
 
   <!-- +5 FoodOnMedium -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnMedium04" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetSizeMedium"/>
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeMedium/ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnMedium04" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationFood"	    Operation="Addition"    Value="5"   Path="FAKEFORGUI./PlanetSizeMedium"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFood"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMedium)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnMedium04" Type="ClassPopulationPlanet">
@@ -779,8 +815,9 @@
   <!-- Food on Large -->
   <!-- +1 FoodOnLarge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnLarge00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetSizeLarge"/>
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeLarge/ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnLarge00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationFood"	    Operation="Addition"    Value="1"   Path="FAKEFORGUI./PlanetSizeLarge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFood"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsLarge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnLarge00" Type="ClassPopulationPlanet">
@@ -794,8 +831,9 @@
 
   <!-- +2 FoodOnLarge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnLarge01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetSizeLarge"/>
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeLarge/ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnLarge01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationFood"	    Operation="Addition"    Value="2"   Path="FAKEFORGUI./PlanetSizeLarge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFood"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsLarge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnLarge01" Type="ClassPopulationPlanet">
@@ -805,8 +843,9 @@
 
   <!-- +3 FoodOnLarge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnLarge02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetSizeLarge"/>
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeLarge/ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnLarge02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationFood"	    Operation="Addition"    Value="3"   Path="FAKEFORGUI./PlanetSizeLarge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFood"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsLarge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnLarge02" Type="ClassPopulationPlanet">
@@ -820,8 +859,9 @@
 
   <!-- +4 FoodOnLarge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnLarge03" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="4" Path="FAKEFORGUI/./PlanetSizeLarge"/>
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="4" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeLarge/ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnLarge03" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationFood"	    Operation="Addition"    Value="4"   Path="FAKEFORGUI./PlanetSizeLarge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFood"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsLarge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnLarge03" Type="ClassPopulationPlanet">
@@ -831,8 +871,9 @@
 
   <!-- +5 FoodOnLarge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnLarge04" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetSizeLarge"/>
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeLarge/ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnLarge04" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationFood"	    Operation="Addition"    Value="5"   Path="FAKEFORGUI./PlanetSizeLarge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFood"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsLarge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnLarge04" Type="ClassPopulationPlanet">
@@ -847,8 +888,9 @@
   <!-- Food on Huge -->
   <!-- +1 FoodOnHuge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnHuge00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetSizeHuge"/>
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeHuge/ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnHuge00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationFood"	    Operation="Addition"    Value="1"   Path="FAKEFORGUI./PlanetSizeHuge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFood"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHuge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnHuge00" Type="ClassPopulationPlanet">
@@ -862,8 +904,9 @@
 
   <!-- +2 FoodOnHuge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnHuge01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetSizeHuge"/>
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeHuge/ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnHuge01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationFood"	    Operation="Addition"    Value="2"   Path="FAKEFORGUI./PlanetSizeHuge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFood"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHuge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnHuge01" Type="ClassPopulationPlanet">
@@ -873,8 +916,9 @@
 
   <!-- +3 FoodOnHuge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnHuge02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetSizeHuge"/>
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeHuge/ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnHuge02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationFood"	    Operation="Addition"    Value="3"   Path="FAKEFORGUI./PlanetSizeHuge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFood"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHuge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnHuge02" Type="ClassPopulationPlanet">
@@ -888,8 +932,9 @@
 
   <!-- +4 FoodOnHuge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnHuge03" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="4" Path="FAKEFORGUI/./PlanetSizeHuge"/>
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="4" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeHuge/ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnHuge03" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationFood"	    Operation="Addition"    Value="4"   Path="FAKEFORGUI./PlanetSizeHuge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFood"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHuge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnHuge03" Type="ClassPopulationPlanet">
@@ -899,8 +944,9 @@
 
   <!-- +5 FoodOnHuge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnHuge04" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetSizeHuge"/>
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeHuge/ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnHuge04" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationFood"	    Operation="Addition"    Value="5"   Path="FAKEFORGUI./PlanetSizeHuge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFood"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHuge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnHuge04" Type="ClassPopulationPlanet">
@@ -915,8 +961,9 @@
   <!-- Food on Strategic -->
   <!-- +2 FoodOnStrategic -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnStrategic00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetHasDepositStrategic"/>
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet,PlanetHasDepositStrategic/ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnStrategic00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationFood"	    Operation="Addition"    Value="2"   Path="FAKEFORGUI./PlanetHasDepositStrategic"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFood"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetHasStrategicDeposit)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnStrategic00" Type="ClassPopulationPlanet">
@@ -931,8 +978,9 @@
   <!-- Food on Luxury -->
   <!-- +2 FoodOnLuxury -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnLuxury00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetHasDepositLuxury"/>
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet,PlanetHasDepositLuxury/ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnLuxury00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationFood"	    Operation="Addition"    Value="2"   Path="FAKEFORGUI./PlanetHasDepositLuxury"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFood"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetHasLuxuryDeposit)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnLuxury00" Type="ClassPopulationPlanet">
@@ -947,8 +995,9 @@
   <!-- Food on Anomaly -->
   <!-- +5 FoodOnAnomaly -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodOnAnomaly00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetAnomaly"/>
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetAnomaly/ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnAnomaly00,ClassPopulation" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationFood"	    Operation="Addition"    Value="5"   Path="FAKEFORGUI./PlanetAnomaly"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFood"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetHasAnomaly)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomFoodOnAnomaly00" Type="ClassPopulationPlanet">
@@ -963,7 +1012,8 @@
   <!-- Food per Minor Faction -->
   <!-- +1 FoodPerMinorFaction -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodPerMinorFaction00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitSecondaryCustomFoodPerMinorFaction00,ClassPopulation"/>
+	<Modifier       TargetProperty="BonusPopulationFood"    Operation="Addition"    Value="3"   Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationFood"    Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomFoodPerMinorFaction00" Type="ClassPopulationPlanet">
@@ -976,7 +1026,8 @@
   <!-- Food per Backdoor -->
   <!-- +1 FoodPerBackdoor -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomFoodPerBackdoor00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationFood" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitSecondaryCustomFoodPerBackdoor00,ClassPopulation"/>
+	<Modifier       TargetProperty="BonusPopulationFood"    Operation="Addition"    Value="2"   Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationFood"    Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomFoodPerBackdoor00" Type="ClassPopulationPlanet">
@@ -989,8 +1040,9 @@
 
   <!-- Food per Temple -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitPrimaryCustomFoodPerTemple00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationFood"          Operation="Addition"    Value="2"       Path="FAKEFORGUI/./PlanetWithTemple"/>
-    <Modifier TargetProperty="BonusPopulationFood"          Operation="Addition"    Value="2"       Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimaryCustomFoodPerTemple00,ClassPopulation" TooltipHidden="true" />
+    <Modifier       TargetProperty="BonusPopulationFood"	    Operation="Addition"    Value="2"   Path="FAKEFORGUI./PlanetWithTemple"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue0"	    Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFood"	    Operation="Addition"    Left="$(PopulationAuxValue0)"    BinaryOperation="Multiplication" Right="$(PlanetHasTemple)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitPrimaryCustomFoodPerTemple00" Type="ClassPopulationPlanet">
@@ -998,9 +1050,11 @@
     <BinaryModifier     TargetProperty="BonusPopulationFood"    Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PlanetHasTemple)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +1 FoodLevel-->
+  <!-- +2 Food per System Level -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitPrimaryCustomFoodLevel00" Type="WithPopulationPlanet">
-    <BinaryModifier TargetProperty="BonusPopulationFood" Operation="Addition" Left="2" BinaryOperation="Multiplication" Right="$(PopulationSystemLevel)"  Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimaryCustomFoodLevel00,ClassPopulation" TooltipHidden="true" SearchValueFromPath="true"/>
+    <Modifier       TargetProperty="BonusPopulationFood"	    Operation="Addition"    Value="2"   Path="FAKEFORGUI./SystemLevel"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFood"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PopulationSystemLevel)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitPrimaryCustomFoodLevel00" Type="ClassPopulationPlanet">

--- a/Endless Space Competitive Mod/Simulation/Traits/SimulationDescriptors[2_Industry].xml
+++ b/Endless Space Competitive Mod/Simulation/Traits/SimulationDescriptors[2_Industry].xml
@@ -2,89 +2,69 @@
 <Datatable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xsi:noNamespaceSchemaLocation="../../Schemas/Amplitude.Unity.Simulation.SimulationDescriptor.xsd">
   <!-- Primary -->
 
-
 <!-- Industry -->
 
+  <!-- +1 Industry -->
+  <SimulationDescriptor Type="WithPopulationPlanet" Name="WithPopulationPlanetModifiersTraitPrimaryCustomIndustry00">
+	<Modifier       TargetProperty="BonusPopulationIndustry" Operation="Addition"    Value="1"   Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationIndustry" Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+  </SimulationDescriptor>
 
-<!-- +1 Industry -->
+  <SimulationDescriptor Type="ClassPopulationPlanet" Name="ClassPopulationPlanetModifiersTraitPrimaryCustomIndustry00">
+    <Modifier Path="ClassPopulation" Value="1" Operation="Addition" TargetProperty="BonusPopulationIndustry"/>
+  </SimulationDescriptor>
 
-
-
--<SimulationDescriptor Type="WithPopulationPlanet" Name="WithPopulationPlanetModifiersTraitPrimaryCustomIndustry00">
-<Modifier Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimaryCustomIndustry00, ClassPopulation" Value="1" Operation="Addition" TargetProperty="BonusPopulationIndustry"/>
-</SimulationDescriptor>
-
-
--<SimulationDescriptor Type="ClassPopulationPlanet" Name="ClassPopulationPlanetModifiersTraitPrimaryCustomIndustry00">
-<Modifier Path="ClassPopulation" Value="1" Operation="Addition" TargetProperty="BonusPopulationIndustry"/>
-</SimulationDescriptor>
-
-
--<SimulationDescriptor Type="ClassPopulationAssimilated" Name="ClassPopulationAssimilatedPrimaryCustomIndustry00">
-<Modifier Path="ClassPopulation" Value="2" Operation="Addition" TargetProperty="BonusPopulationIndustry"/>
-</SimulationDescriptor>
+  <SimulationDescriptor Type="ClassPopulationAssimilated" Name="ClassPopulationAssimilatedPrimaryCustomIndustry00">
+    <Modifier Path="ClassPopulation" Value="2" Operation="Addition" TargetProperty="BonusPopulationIndustry"/>
+  </SimulationDescriptor>
 
   <!-- +2 Industry -->
+  <SimulationDescriptor Type="WithPopulationPlanet" Name="WithPopulationPlanetModifiersTraitPrimaryCustomIndustry01">
+	<Modifier       TargetProperty="BonusPopulationIndustry" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationIndustry" Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+  </SimulationDescriptor>
 
-
-
--<SimulationDescriptor Type="WithPopulationPlanet" Name="WithPopulationPlanetModifiersTraitPrimaryCustomIndustry01">
-<Modifier Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimaryCustomIndustry01, ClassPopulation" Value="2" Operation="Addition" TargetProperty="BonusPopulationIndustry"/>
-</SimulationDescriptor>
-
-
--<SimulationDescriptor Type="ClassPopulationPlanet" Name="ClassPopulationPlanetModifiersTraitPrimaryCustomIndustry01">
-<Modifier Path="ClassPopulation" Value="2" Operation="Addition" TargetProperty="BonusPopulationIndustry"/>
-</SimulationDescriptor>
+  <SimulationDescriptor Type="ClassPopulationPlanet" Name="ClassPopulationPlanetModifiersTraitPrimaryCustomIndustry01">
+    <Modifier Path="ClassPopulation" Value="2" Operation="Addition" TargetProperty="BonusPopulationIndustry"/>
+  </SimulationDescriptor>
 
   <!-- +3 Industry -->
+  <SimulationDescriptor Type="WithPopulationPlanet" Name="WithPopulationPlanetModifiersTraitPrimaryCustomIndustry02">
+	<Modifier       TargetProperty="BonusPopulationIndustry" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationIndustry" Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+  </SimulationDescriptor>
 
+  <SimulationDescriptor Type="ClassPopulationPlanet" Name="ClassPopulationPlanetModifiersTraitPrimaryCustomIndustry02">
+    <Modifier Path="ClassPopulation" Value="3" Operation="Addition" TargetProperty="BonusPopulationIndustry"/>
+  </SimulationDescriptor>
 
-
--<SimulationDescriptor Type="WithPopulationPlanet" Name="WithPopulationPlanetModifiersTraitPrimaryCustomIndustry02">
-<Modifier Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimaryCustomIndustry02, ClassPopulation" Value="3" Operation="Addition" TargetProperty="BonusPopulationIndustry"/>
-</SimulationDescriptor>
-
-
--<SimulationDescriptor Type="ClassPopulationPlanet" Name="ClassPopulationPlanetModifiersTraitPrimaryCustomIndustry02">
-<Modifier Path="ClassPopulation" Value="3" Operation="Addition" TargetProperty="BonusPopulationIndustry"/>
-</SimulationDescriptor>
-
-
--<SimulationDescriptor Type="ClassPopulationAssimilated" Name="ClassPopulationAssimilatedPrimaryCustomIndustry02">
-<Modifier Path="ClassPopulation" Value="3" Operation="Addition" TargetProperty="BonusPopulationIndustry"/>
-</SimulationDescriptor>
+  <SimulationDescriptor Type="ClassPopulationAssimilated" Name="ClassPopulationAssimilatedPrimaryCustomIndustry02">
+    <Modifier Path="ClassPopulation" Value="3" Operation="Addition" TargetProperty="BonusPopulationIndustry"/>
+  </SimulationDescriptor>
   
   <!-- +4 Industry -->
+  <SimulationDescriptor Type="WithPopulationPlanet" Name="WithPopulationPlanetModifiersTraitPrimaryCustomIndustry03">
+	<Modifier       TargetProperty="BonusPopulationIndustry" Operation="Addition"    Value="4"   Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationIndustry" Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+  </SimulationDescriptor>
 
-
-
--<SimulationDescriptor Type="WithPopulationPlanet" Name="WithPopulationPlanetModifiersTraitPrimaryCustomIndustry03">
-<Modifier Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimaryCustomIndustry03, ClassPopulation" Value="4" Operation="Addition" TargetProperty="BonusPopulationIndustry"/>
-</SimulationDescriptor>
-
-
--<SimulationDescriptor Type="ClassPopulationPlanet" Name="ClassPopulationPlanetModifiersTraitPrimaryCustomIndustry03">
-<Modifier Path="ClassPopulation" Value="4" Operation="Addition" TargetProperty="BonusPopulationIndustry"/>
-</SimulationDescriptor>
+  <SimulationDescriptor Type="ClassPopulationPlanet" Name="ClassPopulationPlanetModifiersTraitPrimaryCustomIndustry03">
+    <Modifier Path="ClassPopulation" Value="4" Operation="Addition" TargetProperty="BonusPopulationIndustry"/>
+  </SimulationDescriptor>
 
   <!-- +5 Industry -->
+  <SimulationDescriptor Type="WithPopulationPlanet" Name="WithPopulationPlanetModifiersTraitPrimaryCustomIndustry04">
+	<Modifier       TargetProperty="BonusPopulationIndustry" Operation="Addition"    Value="5"   Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationIndustry" Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+  </SimulationDescriptor>
 
+  <SimulationDescriptor Type="ClassPopulationPlanet" Name="ClassPopulationPlanetModifiersTraitPrimaryCustomIndustry04">
+    <Modifier Path="ClassPopulation" Value="5" Operation="Addition" TargetProperty="BonusPopulationIndustry"/>
+  </SimulationDescriptor>
 
-
--<SimulationDescriptor Type="WithPopulationPlanet" Name="WithPopulationPlanetModifiersTraitPrimaryCustomIndustry04">
-<Modifier Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimaryCustomIndustry04, ClassPopulation" Value="5" Operation="Addition" TargetProperty="BonusPopulationIndustry"/>
-</SimulationDescriptor>
-
-
--<SimulationDescriptor Type="ClassPopulationPlanet" Name="ClassPopulationPlanetModifiersTraitPrimaryCustomIndustry04">
-<Modifier Path="ClassPopulation" Value="5" Operation="Addition" TargetProperty="BonusPopulationIndustry"/>
-</SimulationDescriptor>
-
-
--<SimulationDescriptor Type="ClassPopulationAssimilated" Name="ClassPopulationAssimilatedPrimaryCustomIndustry04">
-<Modifier Path="ClassPopulation" Value="4" Operation="Addition" TargetProperty="BonusPopulationIndustry"/>
-</SimulationDescriptor>
+  <SimulationDescriptor Type="ClassPopulationAssimilated" Name="ClassPopulationAssimilatedPrimaryCustomIndustry04">
+    <Modifier Path="ClassPopulation" Value="4" Operation="Addition" TargetProperty="BonusPopulationIndustry"/>
+  </SimulationDescriptor>
 
 <!-- Secondary -->
 
@@ -92,8 +72,9 @@
   <!-- Industry on Cold -->
   <!-- +1 IndustryOnCold -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnCold00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeCold/ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnCold00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationIndustry" Operation="Addition"    Value="1"   Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationIndustry" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsCold)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnCold00" Type="ClassPopulationPlanet">
@@ -107,8 +88,9 @@
 
   <!-- +2 IndustryOnCold -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnCold01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeCold/ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnCold01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationIndustry" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationIndustry" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsCold)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnCold01" Type="ClassPopulationPlanet">
@@ -118,8 +100,9 @@
 
   <!-- +3 IndustryOnCold -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnCold02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeCold/ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnCold02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationIndustry" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationIndustry" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsCold)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnCold02" Type="ClassPopulationPlanet">
@@ -133,8 +116,9 @@
 
   <!-- +4 IndustryOnCold -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnCold03" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="4" Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="4" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeCold/ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnCold03" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationIndustry" Operation="Addition"    Value="4"   Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationIndustry" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsCold)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnCold03" Type="ClassPopulationPlanet">
@@ -144,8 +128,9 @@
 
   <!-- +5 IndustryOnCold -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnCold04" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeCold/ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnCold04" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationIndustry" Operation="Addition"    Value="5"   Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationIndustry" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsCold)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnCold04" Type="ClassPopulationPlanet">
@@ -160,8 +145,9 @@
   <!-- Industry on Temperate -->
   <!-- +1 IndustryOnTemperate -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnTemperate00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTemperate/ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnTemperate00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationIndustry" Operation="Addition"    Value="1"   Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationIndustry" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTemperate)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnTemperate00" Type="ClassPopulationPlanet">
@@ -175,8 +161,9 @@
 
   <!-- +2 IndustryOnTemperate -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnTemperate01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTemperate/ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnTemperate01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationIndustry" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationIndustry" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTemperate)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnTemperate01" Type="ClassPopulationPlanet">
@@ -186,8 +173,9 @@
 
   <!-- +3 IndustryOnTemperate -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnTemperate02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTemperate/ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnTemperate02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationIndustry" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationIndustry" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTemperate)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnTemperate02" Type="ClassPopulationPlanet">
@@ -201,8 +189,9 @@
 
   <!-- +4 IndustryOnTemperate -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnTemperate03" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="4" Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="4" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTemperate/ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnTemperate03" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationIndustry" Operation="Addition"    Value="4"   Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationIndustry" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTemperate)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnTemperate03" Type="ClassPopulationPlanet">
@@ -212,8 +201,9 @@
 
   <!-- +5 IndustryOnTemperate -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnTemperate04" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTemperate/ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnTemperate04" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationIndustry" Operation="Addition"    Value="5"   Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationIndustry" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTemperate)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnTemperate04" Type="ClassPopulationPlanet">
@@ -228,8 +218,9 @@
   <!-- Industry on Hot -->
   <!-- +1 IndustryOnHot -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnHot00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeHot/ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnHot00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationIndustry" Operation="Addition"    Value="1"   Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationIndustry" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHot)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnHot00" Type="ClassPopulationPlanet">
@@ -243,8 +234,9 @@
 
   <!-- +2 IndustryOnHot -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnHot01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeHot/ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnHot01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationIndustry" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationIndustry" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHot)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnHot01" Type="ClassPopulationPlanet">
@@ -254,8 +246,9 @@
 
   <!-- +3 IndustryOnHot -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnHot02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeHot/ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnHot02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationIndustry" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationIndustry" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHot)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnHot02" Type="ClassPopulationPlanet">
@@ -269,8 +262,9 @@
 
   <!-- +4 IndustryOnHot -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnHot03" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="4" Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="4" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeHot/ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnHot03" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationIndustry" Operation="Addition"    Value="4"   Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationIndustry" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHot)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnHot03" Type="ClassPopulationPlanet">
@@ -280,8 +274,9 @@
 
   <!-- +5 IndustryOnHot -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnHot04" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeHot/ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnHot04" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationIndustry" Operation="Addition"    Value="5"   Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationIndustry" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHot)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnHot04" Type="ClassPopulationPlanet">
@@ -296,8 +291,9 @@
   <!-- Industry on Teeming -->
   <!-- +1 IndustryOnTeeming -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnTeeming00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTeeming/ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnTeeming00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationIndustry" Operation="Addition"    Value="1"   Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationIndustry" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnTeeming00" Type="ClassPopulationPlanet">
@@ -311,8 +307,9 @@
 
   <!-- +2 IndustryOnTeeming -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnTeeming01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTeeming/ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnTeeming01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationIndustry" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationIndustry" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnTeeming01" Type="ClassPopulationPlanet">
@@ -322,8 +319,9 @@
 
   <!-- +3 IndustryOnTeeming -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnTeeming02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTeeming/ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnTeeming02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationIndustry" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationIndustry" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnTeeming02" Type="ClassPopulationPlanet">
@@ -337,8 +335,9 @@
 
   <!-- +4 IndustryOnTeeming -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnTeeming03" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="4" Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="4" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTeeming/ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnTeeming03" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationIndustry" Operation="Addition"    Value="4"   Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationIndustry" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnTeeming03" Type="ClassPopulationPlanet">
@@ -348,8 +347,9 @@
 
   <!-- +5 IndustryOnTeeming -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnTeeming04" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTeeming/ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnTeeming04" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationIndustry" Operation="Addition"    Value="5"   Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationIndustry" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnTeeming04" Type="ClassPopulationPlanet">
@@ -364,8 +364,9 @@
   <!-- Industry on Meager -->
   <!-- +1 IndustryOnMeager -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnMeager00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeMeager/ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnMeager00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationIndustry" Operation="Addition"    Value="1"   Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationIndustry" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMeager)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnMeager00" Type="ClassPopulationPlanet">
@@ -379,8 +380,9 @@
 
   <!-- +2 IndustryOnMeager -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnMeager01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeMeager/ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnMeager01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationIndustry" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationIndustry" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMeager)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnMeager01" Type="ClassPopulationPlanet">
@@ -390,8 +392,9 @@
 
   <!-- +3 IndustryOnMeager -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnMeager02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeMeager/ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnMeager02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationIndustry" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationIndustry" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMeager)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnMeager02" Type="ClassPopulationPlanet">
@@ -405,8 +408,9 @@
 
   <!-- +4 IndustryOnMeager -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnMeager03" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="4" Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="4" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeMeager/ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnMeager03" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationIndustry" Operation="Addition"    Value="4"   Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationIndustry" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMeager)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnMeager03" Type="ClassPopulationPlanet">
@@ -416,8 +420,9 @@
 
   <!-- +5 IndustryOnMeager -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnMeager04" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeMeager/ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnMeager04" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationIndustry" Operation="Addition"    Value="5"   Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationIndustry" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMeager)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnMeager04" Type="ClassPopulationPlanet">
@@ -430,10 +435,11 @@
   </SimulationDescriptor>
 
   <!-- Industry on Gas -->
-  <!-- +1 IndustryOnGas -->
+  <!-- +3 IndustryOnGas -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnGas00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeGas/ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnGas00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationIndustry" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationIndustry" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsGas)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnGas00" Type="ClassPopulationPlanet">
@@ -445,10 +451,11 @@
     <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="2" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +2 IndustryOnGas -->
+  <!-- +5 IndustryOnGas -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnGas01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeGas/ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnGas01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationIndustry" Operation="Addition"    Value="5"   Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationIndustry" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsGas)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnGas01" Type="ClassPopulationPlanet">
@@ -456,10 +463,11 @@
     <BinaryModifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Left="5" BinaryOperation="Multiplication" Right="$(PlanetIsGas)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +3 IndustryOnGas -->
+  <!-- +10 IndustryOnGas -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnGas02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="10" Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="10" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeGas/ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnGas02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationIndustry" Operation="Addition"    Value="10"  Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="10"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationIndustry" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsGas)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnGas02" Type="ClassPopulationPlanet">
@@ -471,10 +479,11 @@
     <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="4" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +4 IndustryOnGas -->
+  <!-- +12 IndustryOnGas -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnGas03" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="12" Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="12" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeGas/ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnGas03" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationIndustry" Operation="Addition"    Value="12"  Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="12"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationIndustry" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsGas)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnGas03" Type="ClassPopulationPlanet">
@@ -482,10 +491,11 @@
     <BinaryModifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Left="12" BinaryOperation="Multiplication" Right="$(PlanetIsGas)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +5 IndustryOnGas -->
+  <!-- +15 IndustryOnGas -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnGas04" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="15" Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="15" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeGas/ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnGas04" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationIndustry" Operation="Addition"    Value="15"  Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="15"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationIndustry" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsGas)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnGas04" Type="ClassPopulationPlanet">
@@ -500,9 +510,10 @@
   <!-- Industry on Happy -->
   <!-- +1 IndustryOnHappy -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnHappy00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="1" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="1" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
-    <BinaryModifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Left="1" BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)"  Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnHappy00" TooltipHidden="true" SearchValueFromPath="true"/>
+    <Modifier		TargetProperty="BonusPopulationIndustry"		Operation="Addition" Value="1" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
+    <Modifier		TargetProperty="BonusPopulationIndustry"		Operation="Addition" Value="1" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"			Operation="Addition" Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationIndustry"		Operation="Addition" Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnHappy00" Type="ClassPopulationPlanet">
@@ -517,9 +528,10 @@
 
   <!-- +2 IndustryOnHappy -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnHappy01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="2" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="2" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
-    <BinaryModifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Left="2" BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnHappy01" TooltipHidden="true" SearchValueFromPath="true"/>
+    <Modifier		TargetProperty="BonusPopulationIndustry"		Operation="Addition" Value="2" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
+    <Modifier		TargetProperty="BonusPopulationIndustry"		Operation="Addition" Value="2" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"			Operation="Addition" Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationIndustry"		Operation="Addition" Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnHappy01" Type="ClassPopulationPlanet">
@@ -530,9 +542,10 @@
 
   <!-- +3 IndustryOnHappy -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnHappy02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="3" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="3" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
-    <BinaryModifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Left="3" BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnHappy02" TooltipHidden="true" SearchValueFromPath="true"/>
+    <Modifier		TargetProperty="BonusPopulationIndustry"		Operation="Addition" Value="3" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
+    <Modifier		TargetProperty="BonusPopulationIndustry"		Operation="Addition" Value="3" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"			Operation="Addition" Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationIndustry"		Operation="Addition" Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnHappy02" Type="ClassPopulationPlanet">
@@ -547,9 +560,10 @@
 
   <!-- +4 IndustryOnHappy -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnHappy03" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="4" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="4" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
-    <BinaryModifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Left="4" BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnHappy03" TooltipHidden="true" SearchValueFromPath="true"/>
+    <Modifier		TargetProperty="BonusPopulationIndustry"		Operation="Addition" Value="4" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
+    <Modifier		TargetProperty="BonusPopulationIndustry"		Operation="Addition" Value="4" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"			Operation="Addition" Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationIndustry"		Operation="Addition" Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnHappy03" Type="ClassPopulationPlanet">
@@ -560,9 +574,10 @@
 
   <!-- +5 IndustryOnHappy -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnHappy04" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="5" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="5" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
-    <BinaryModifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Left="5" BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnHappy04" TooltipHidden="true" SearchValueFromPath="true"/>
+    <Modifier		TargetProperty="BonusPopulationIndustry"		Operation="Addition" Value="5" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
+    <Modifier		TargetProperty="BonusPopulationIndustry"		Operation="Addition" Value="5" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"			Operation="Addition" Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationIndustry"		Operation="Addition" Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnHappy04" Type="ClassPopulationPlanet">
@@ -578,8 +593,9 @@
   <!-- Industry on Tiny -->
   <!-- +1 IndustryOnTiny -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnTiny00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetSizeTiny"/>
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeTiny/ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnTiny00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationIndustry" Operation="Addition"    Value="1"   Path="FAKEFORGUI/./PlanetSizeTiny"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationIndustry" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTiny)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnTiny00" Type="ClassPopulationPlanet">
@@ -593,8 +609,9 @@
 
   <!-- +2 IndustryOnTiny -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnTiny01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetSizeTiny"/>
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeTiny/ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnTiny01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationIndustry" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetSizeTiny"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationIndustry" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTiny)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnTiny01" Type="ClassPopulationPlanet">
@@ -604,8 +621,9 @@
 
   <!-- +3 IndustryOnTiny -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnTiny02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetSizeTiny"/>
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeTiny/ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnTiny02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationIndustry" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetSizeTiny"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationIndustry" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTiny)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnTiny02" Type="ClassPopulationPlanet">
@@ -619,8 +637,9 @@
 
   <!-- +4 IndustryOnTiny -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnTiny03" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="4" Path="FAKEFORGUI/./PlanetSizeTiny"/>
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="4" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeTiny/ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnTiny03" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationIndustry" Operation="Addition"    Value="4"   Path="FAKEFORGUI/./PlanetSizeTiny"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationIndustry" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTiny)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnTiny03" Type="ClassPopulationPlanet">
@@ -630,8 +649,9 @@
 
   <!-- +5 IndustryOnTiny -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnTiny04" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetSizeTiny"/>
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeTiny/ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnTiny04" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationIndustry" Operation="Addition"    Value="5"   Path="FAKEFORGUI/./PlanetSizeTiny"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationIndustry" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTiny)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnTiny04" Type="ClassPopulationPlanet">
@@ -646,8 +666,9 @@
   <!-- Industry on Small -->
   <!-- +1 IndustryOnSmall -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnSmall00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetSizeSmall"/>
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeSmall/ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnSmall00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationIndustry" Operation="Addition"    Value="1"   Path="FAKEFORGUI/./PlanetSizeSmall"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationIndustry" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsSmall)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnSmall00" Type="ClassPopulationPlanet">
@@ -661,8 +682,9 @@
 
   <!-- +2 IndustryOnSmall -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnSmall01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetSizeSmall"/>
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeSmall/ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnSmall01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationIndustry" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetSizeSmall"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationIndustry" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsSmall)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnSmall01" Type="ClassPopulationPlanet">
@@ -672,8 +694,9 @@
 
   <!-- +3 IndustryOnSmall -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnSmall02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetSizeSmall"/>
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeSmall/ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnSmall02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationIndustry" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetSizeSmall"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationIndustry" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsSmall)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnSmall02" Type="ClassPopulationPlanet">
@@ -687,8 +710,9 @@
 
   <!-- +4 IndustryOnSmall -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnSmall03" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="4" Path="FAKEFORGUI/./PlanetSizeSmall"/>
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="4" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeSmall/ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnSmall03" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationIndustry" Operation="Addition"    Value="4"   Path="FAKEFORGUI/./PlanetSizeSmall"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationIndustry" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsSmall)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnSmall03" Type="ClassPopulationPlanet">
@@ -698,8 +722,9 @@
 
   <!-- +5 IndustryOnSmall -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnSmall04" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetSizeSmall"/>
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeSmall/ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnSmall04" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationIndustry" Operation="Addition"    Value="5"   Path="FAKEFORGUI/./PlanetSizeSmall"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationIndustry" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsSmall)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnSmall04" Type="ClassPopulationPlanet">
@@ -714,8 +739,9 @@
   <!-- Industry on Medium -->
   <!-- +1 IndustryOnMedium -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnMedium00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetSizeMedium"/>
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeMedium/ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnMedium00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationIndustry" Operation="Addition"    Value="1"   Path="FAKEFORGUI/./PlanetSizeMedium"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationIndustry" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMedium)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnMedium00" Type="ClassPopulationPlanet">
@@ -729,8 +755,9 @@
 
   <!-- +2 IndustryOnMedium -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnMedium01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetSizeMedium"/>
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeMedium/ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnMedium01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationIndustry" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetSizeMedium"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationIndustry" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMedium)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnMedium01" Type="ClassPopulationPlanet">
@@ -740,8 +767,9 @@
 
   <!-- +3 IndustryOnMedium -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnMedium02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetSizeMedium"/>
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeMedium/ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnMedium02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationIndustry" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetSizeMedium"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationIndustry" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMedium)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnMedium02" Type="ClassPopulationPlanet">
@@ -755,8 +783,9 @@
 
   <!-- +4 IndustryOnMedium -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnMedium03" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="4" Path="FAKEFORGUI/./PlanetSizeMedium"/>
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="4" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeMedium/ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnMedium03" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationIndustry" Operation="Addition"    Value="4"   Path="FAKEFORGUI/./PlanetSizeMedium"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationIndustry" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMedium)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnMedium03" Type="ClassPopulationPlanet">
@@ -766,8 +795,9 @@
 
   <!-- +5 IndustryOnMedium -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnMedium04" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetSizeMedium"/>
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeMedium/ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnMedium04" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationIndustry" Operation="Addition"    Value="5"   Path="FAKEFORGUI/./PlanetSizeMedium"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationIndustry" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMedium)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnMedium04" Type="ClassPopulationPlanet">
@@ -782,8 +812,9 @@
   <!-- Industry on Large -->
   <!-- +1 IndustryOnLarge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnLarge00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetSizeLarge"/>
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeLarge/ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnLarge00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationIndustry" Operation="Addition"    Value="1"   Path="FAKEFORGUI/./PlanetSizeLarge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationIndustry" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsLarge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnLarge00" Type="ClassPopulationPlanet">
@@ -797,8 +828,9 @@
 
   <!-- +2 IndustryOnLarge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnLarge01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetSizeLarge"/>
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeLarge/ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnLarge01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationIndustry" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetSizeLarge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationIndustry" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsLarge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnLarge01" Type="ClassPopulationPlanet">
@@ -808,8 +840,9 @@
 
   <!-- +3 IndustryOnLarge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnLarge02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetSizeLarge"/>
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeLarge/ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnLarge02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationIndustry" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetSizeLarge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationIndustry" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsLarge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnLarge02" Type="ClassPopulationPlanet">
@@ -823,8 +856,9 @@
 
   <!-- +4 IndustryOnLarge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnLarge03" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="4" Path="FAKEFORGUI/./PlanetSizeLarge"/>
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="4" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeLarge/ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnLarge03" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationIndustry" Operation="Addition"    Value="4"   Path="FAKEFORGUI/./PlanetSizeLarge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationIndustry" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsLarge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnLarge03" Type="ClassPopulationPlanet">
@@ -834,8 +868,9 @@
 
   <!-- +5 IndustryOnLarge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnLarge04" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetSizeLarge"/>
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeLarge/ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnLarge04" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationIndustry" Operation="Addition"    Value="5"   Path="FAKEFORGUI/./PlanetSizeLarge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationIndustry" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsLarge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnLarge04" Type="ClassPopulationPlanet">
@@ -850,8 +885,9 @@
   <!-- Industry on Huge -->
   <!-- +1 IndustryOnHuge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnHuge00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetSizeHuge"/>
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeHuge/ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnHuge00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationIndustry" Operation="Addition"    Value="1"   Path="FAKEFORGUI/./PlanetSizeHuge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationIndustry" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHuge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnHuge00" Type="ClassPopulationPlanet">
@@ -865,8 +901,9 @@
 
   <!-- +2 IndustryOnHuge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnHuge01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetSizeHuge"/>
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeHuge/ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnHuge01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationIndustry" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetSizeHuge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationIndustry" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHuge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnHuge01" Type="ClassPopulationPlanet">
@@ -876,8 +913,9 @@
 
   <!-- +3 IndustryOnHuge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnHuge02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetSizeHuge"/>
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeHuge/ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnHuge02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationIndustry" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetSizeHuge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationIndustry" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHuge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnHuge02" Type="ClassPopulationPlanet">
@@ -891,8 +929,9 @@
 
   <!-- +4 IndustryOnHuge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnHuge03" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="4" Path="FAKEFORGUI/./PlanetSizeHuge"/>
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="4" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeHuge/ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnHuge03" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationIndustry" Operation="Addition"    Value="4"   Path="FAKEFORGUI/./PlanetSizeHuge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationIndustry" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHuge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnHuge03" Type="ClassPopulationPlanet">
@@ -902,8 +941,9 @@
 
   <!-- +5 IndustryOnHuge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnHuge04" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetSizeHuge"/>
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeHuge/ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnHuge04" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationIndustry" Operation="Addition"    Value="5"   Path="FAKEFORGUI/./PlanetSizeHuge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationIndustry" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHuge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnHuge04" Type="ClassPopulationPlanet">
@@ -918,8 +958,9 @@
   <!-- Industry on Strategic -->
   <!-- +2 IndustryOnStrategic -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnStrategic00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetHasDepositStrategic"/>
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet,PlanetHasDepositStrategic/ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnStrategic00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationIndustry" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetHasDepositStrategic"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationIndustry" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetHasStrategicDeposit)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnStrategic00" Type="ClassPopulationPlanet">
@@ -934,8 +975,9 @@
   <!-- Industry on Luxury -->
   <!-- +2 IndustryOnLuxury -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnLuxury00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetHasDepositLuxury"/>
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet,PlanetHasDepositLuxury/ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnLuxury00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationIndustry" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetHasDepositLuxury"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationIndustry" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetHasLuxuryDeposit)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnLuxury00" Type="ClassPopulationPlanet">
@@ -950,8 +992,9 @@
   <!-- Industry on Anomaly -->
   <!-- +5 IndustryOnAnomaly -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryOnAnomaly00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetAnomaly"/>
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetAnomaly/ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnAnomaly00,ClassPopulation" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationIndustry" Operation="Addition"    Value="5"   Path="FAKEFORGUI/./PlanetAnomaly"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationIndustry" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetHasAnomaly)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryOnAnomaly00" Type="ClassPopulationPlanet">
@@ -966,7 +1009,8 @@
   <!-- Industry per Minor Faction -->
   <!-- +1 IndustryPerMinorFaction -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryPerMinorFaction00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryPerMinorFaction00,ClassPopulation"/>
+	<Modifier       TargetProperty="BonusPopulationIndustry" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationIndustry" Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryPerMinorFaction00" Type="ClassPopulationPlanet">
@@ -979,7 +1023,8 @@
   <!-- Industry per Backdoor -->
   <!-- +1 IndustryPerBackdoor -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomIndustryPerBackdoor00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryPerBackdoor00,ClassPopulation"/>
+	<Modifier       TargetProperty="BonusPopulationIndustry" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationIndustry" Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomIndustryPerBackdoor00" Type="ClassPopulationPlanet">
@@ -992,8 +1037,9 @@
 
   <!-- Industry per Temple -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitPrimaryCustomIndustryPerTemple00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationIndustry"          Operation="Addition"    Value="2"       Path="FAKEFORGUI/./PlanetWithTemple"/>
-    <Modifier TargetProperty="BonusPopulationIndustry"          Operation="Addition"    Value="2"       Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimaryCustomIndustryPerTemple00,ClassPopulation" TooltipHidden="true" />
+    <Modifier       TargetProperty="BonusPopulationIndustry"	Operation="Addition"    Value="2"   Path="FAKEFORGUI./PlanetWithTemple"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue0"	    Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationIndustry"	Operation="Addition"    Left="$(PopulationAuxValue0)"    BinaryOperation="Multiplication" Right="$(PlanetHasTemple)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitPrimaryCustomIndustryPerTemple00" Type="ClassPopulationPlanet">
@@ -1001,9 +1047,11 @@
     <BinaryModifier     TargetProperty="BonusPopulationIndustry"    Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PlanetHasTemple)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +1 IndustryLevel-->
+  <!-- +2 Industry per System Level-->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitPrimaryCustomIndustryLevel00" Type="WithPopulationPlanet">
-    <BinaryModifier TargetProperty="BonusPopulationIndustry" Operation="Addition" Left="2" BinaryOperation="Multiplication" Right="$(PopulationSystemLevel)"  Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimaryCustomIndustryLevel00,ClassPopulation" TooltipHidden="true" SearchValueFromPath="true"/>
+    <Modifier       TargetProperty="BonusPopulationIndustry"	Operation="Addition"    Value="2"   Path="FAKEFORGUI./SystemLevel"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationIndustry"	Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PopulationSystemLevel)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitPrimaryCustomIndustryLevel00" Type="ClassPopulationPlanet">

--- a/Endless Space Competitive Mod/Simulation/Traits/SimulationDescriptors[3_Dust].xml
+++ b/Endless Space Competitive Mod/Simulation/Traits/SimulationDescriptors[3_Dust].xml
@@ -3,87 +3,67 @@
   xmlns:xsd="http://www.w3.org/2001/XMLSchema" xsi:noNamespaceSchemaLocation="../../Schemas/PopulationModifiersTrait.xsd">
   <!-- Primary -->
 
-
   <!-- Dust -->
 
-
   <!-- +1 Dust -->
-
-
-
--  <SimulationDescriptor Type="WithPopulationPlanet" Name="WithPopulationPlanetModifiersTraitPrimaryCustomDust00">
-    <Modifier Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimaryCustomDust00, ClassPopulation" Value="1" Operation="Addition" TargetProperty="BonusPopulationDust"/>
+  <SimulationDescriptor Type="WithPopulationPlanet" Name="WithPopulationPlanetModifiersTraitPrimaryCustomDust00">
+	<Modifier       TargetProperty="BonusPopulationDust"    Operation="Addition"    Value="1"   Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationDust"    Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-
--  <SimulationDescriptor Type="ClassPopulationPlanet" Name="ClassPopulationPlanetModifiersTraitPrimaryCustomDust00">
+  <SimulationDescriptor Type="ClassPopulationPlanet" Name="ClassPopulationPlanetModifiersTraitPrimaryCustomDust00">
     <Modifier Path="ClassPopulation" Value="1" Operation="Addition" TargetProperty="BonusPopulationDust"/>
   </SimulationDescriptor>
 
-
--  <SimulationDescriptor Type="ClassPopulationAssimilated" Name="ClassPopulationAssimilatedPrimaryCustomDust00">
+  <SimulationDescriptor Type="ClassPopulationAssimilated" Name="ClassPopulationAssimilatedPrimaryCustomDust00">
     <Modifier Path="ClassPopulation" Value="2" Operation="Addition" TargetProperty="BonusPopulationDust"/>
   </SimulationDescriptor>
 
   <!-- +2 Dust -->
-
-
-
--  <SimulationDescriptor Type="WithPopulationPlanet" Name="WithPopulationPlanetModifiersTraitPrimaryCustomDust01">
-    <Modifier Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimaryCustomDust01, ClassPopulation" Value="2" Operation="Addition" TargetProperty="BonusPopulationDust"/>
+  <SimulationDescriptor Type="WithPopulationPlanet" Name="WithPopulationPlanetModifiersTraitPrimaryCustomDust01">
+	<Modifier       TargetProperty="BonusPopulationDust"    Operation="Addition"    Value="2"   Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationDust"    Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-
--  <SimulationDescriptor Type="ClassPopulationPlanet" Name="ClassPopulationPlanetModifiersTraitPrimaryCustomDust01">
+  <SimulationDescriptor Type="ClassPopulationPlanet" Name="ClassPopulationPlanetModifiersTraitPrimaryCustomDust01">
     <Modifier Path="ClassPopulation" Value="2" Operation="Addition" TargetProperty="BonusPopulationDust"/>
   </SimulationDescriptor>
 
   <!-- +3 Dust -->
-
-
-
--  <SimulationDescriptor Type="WithPopulationPlanet" Name="WithPopulationPlanetModifiersTraitPrimaryCustomDust02">
-    <Modifier Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimaryCustomDust02, ClassPopulation" Value="3" Operation="Addition" TargetProperty="BonusPopulationDust"/>
+  <SimulationDescriptor Type="WithPopulationPlanet" Name="WithPopulationPlanetModifiersTraitPrimaryCustomDust02">
+	<Modifier       TargetProperty="BonusPopulationDust"    Operation="Addition"    Value="3"   Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationDust"    Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-
--  <SimulationDescriptor Type="ClassPopulationPlanet" Name="ClassPopulationPlanetModifiersTraitPrimaryCustomDust02">
+  <SimulationDescriptor Type="ClassPopulationPlanet" Name="ClassPopulationPlanetModifiersTraitPrimaryCustomDust02">
     <Modifier Path="ClassPopulation" Value="3" Operation="Addition" TargetProperty="BonusPopulationDust"/>
   </SimulationDescriptor>
 
-
--  <SimulationDescriptor Type="ClassPopulationAssimilated" Name="ClassPopulationAssimilatedPrimaryCustomDust02">
+  <SimulationDescriptor Type="ClassPopulationAssimilated" Name="ClassPopulationAssimilatedPrimaryCustomDust02">
     <Modifier Path="ClassPopulation" Value="3" Operation="Addition" TargetProperty="BonusPopulationDust"/>
   </SimulationDescriptor>
 
   <!-- +4 Dust -->
-
-
-
--  <SimulationDescriptor Type="WithPopulationPlanet" Name="WithPopulationPlanetModifiersTraitPrimaryCustomDust03">
-    <Modifier Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimaryCustomDust03, ClassPopulation" Value="4" Operation="Addition" TargetProperty="BonusPopulationDust"/>
+  <SimulationDescriptor Type="WithPopulationPlanet" Name="WithPopulationPlanetModifiersTraitPrimaryCustomDust03">
+	<Modifier       TargetProperty="BonusPopulationDust"    Operation="Addition"    Value="4"   Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationDust"    Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-
--  <SimulationDescriptor Type="ClassPopulationPlanet" Name="ClassPopulationPlanetModifiersTraitPrimaryCustomDust03">
+  <SimulationDescriptor Type="ClassPopulationPlanet" Name="ClassPopulationPlanetModifiersTraitPrimaryCustomDust03">
     <Modifier Path="ClassPopulation" Value="4" Operation="Addition" TargetProperty="BonusPopulationDust"/>
   </SimulationDescriptor>
 
   <!-- +5 Dust -->
-
-
-
--  <SimulationDescriptor Type="WithPopulationPlanet" Name="WithPopulationPlanetModifiersTraitPrimaryCustomDust04">
-    <Modifier Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimaryCustomDust04, ClassPopulation" Value="5" Operation="Addition" TargetProperty="BonusPopulationDust"/>
+  <SimulationDescriptor Type="WithPopulationPlanet" Name="WithPopulationPlanetModifiersTraitPrimaryCustomDust04">
+	<Modifier       TargetProperty="BonusPopulationDust"    Operation="Addition"    Value="5"   Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationDust"    Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-
--  <SimulationDescriptor Type="ClassPopulationPlanet" Name="ClassPopulationPlanetModifiersTraitPrimaryCustomDust04">
+  <SimulationDescriptor Type="ClassPopulationPlanet" Name="ClassPopulationPlanetModifiersTraitPrimaryCustomDust04">
     <Modifier Path="ClassPopulation" Value="5" Operation="Addition" TargetProperty="BonusPopulationDust"/>
   </SimulationDescriptor>
 
-
--  <SimulationDescriptor Type="ClassPopulationAssimilated" Name="ClassPopulationAssimilatedPrimaryCustomDust04">
+  <SimulationDescriptor Type="ClassPopulationAssimilated" Name="ClassPopulationAssimilatedPrimaryCustomDust04">
     <Modifier Path="ClassPopulation" Value="4" Operation="Addition" TargetProperty="BonusPopulationDust"/>
   </SimulationDescriptor>
 
@@ -91,8 +71,9 @@
   <!-- Dust on Cold -->
   <!-- +1 DustOnCold -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnCold00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeCold/ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnCold00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDust"    Operation="Addition"    Value="1"   Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDust"    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsCold)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnCold00" Type="ClassPopulationPlanet">
@@ -106,8 +87,9 @@
 
   <!-- +2 DustOnCold -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnCold01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeCold/ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnCold01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDust"    Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDust"    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsCold)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnCold01" Type="ClassPopulationPlanet">
@@ -117,8 +99,9 @@
 
   <!-- +3 DustOnCold -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnCold02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeCold/ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnCold02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDust"    Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDust"    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsCold)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnCold02" Type="ClassPopulationPlanet">
@@ -132,8 +115,9 @@
 
   <!-- +4 DustOnCold -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnCold03" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="4" Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="4" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeCold/ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnCold03" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDust"    Operation="Addition"    Value="4"   Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDust"    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsCold)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnCold03" Type="ClassPopulationPlanet">
@@ -143,8 +127,9 @@
 
   <!-- +5 DustOnCold -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnCold04" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeCold/ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnCold04" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDust"    Operation="Addition"    Value="5"   Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDust"    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsCold)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnCold04" Type="ClassPopulationPlanet">
@@ -159,8 +144,9 @@
   <!-- Dust on Temperate -->
   <!-- +1 DustOnTemperate -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnTemperate00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTemperate/ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnTemperate00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDust"    Operation="Addition"    Value="1"   Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDust"    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTemperate)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnTemperate00" Type="ClassPopulationPlanet">
@@ -174,8 +160,9 @@
 
   <!-- +2 DustOnTemperate -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnTemperate01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTemperate/ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnTemperate01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDust"    Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDust"    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTemperate)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnTemperate01" Type="ClassPopulationPlanet">
@@ -185,8 +172,9 @@
 
   <!-- +3 DustOnTemperate -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnTemperate02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTemperate/ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnTemperate02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDust"    Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDust"    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTemperate)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnTemperate02" Type="ClassPopulationPlanet">
@@ -200,8 +188,9 @@
 
   <!-- +4 DustOnTemperate -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnTemperate03" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="4" Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="4" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTemperate/ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnTemperate03" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDust"    Operation="Addition"    Value="4"   Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDust"    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTemperate)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnTemperate03" Type="ClassPopulationPlanet">
@@ -211,8 +200,9 @@
 
   <!-- +5 DustOnTemperate -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnTemperate04" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTemperate/ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnTemperate04" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDust"    Operation="Addition"    Value="5"   Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDust"    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTemperate)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnTemperate04" Type="ClassPopulationPlanet">
@@ -227,8 +217,9 @@
   <!-- Dust on Hot -->
   <!-- +1 DustOnHot -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnHot00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeHot/ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnHot00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDust"    Operation="Addition"    Value="1"   Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDust"    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHot)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnHot00" Type="ClassPopulationPlanet">
@@ -242,8 +233,9 @@
 
   <!-- +2 DustOnHot -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnHot01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeHot/ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnHot01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDust"    Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDust"    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHot)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnHot01" Type="ClassPopulationPlanet">
@@ -253,8 +245,9 @@
 
   <!-- +3 DustOnHot -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnHot02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeHot/ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnHot02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDust"    Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDust"    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHot)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnHot02" Type="ClassPopulationPlanet">
@@ -268,8 +261,9 @@
 
   <!-- +4 DustOnHot -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnHot03" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="4" Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="4" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeHot/ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnHot03" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDust"    Operation="Addition"    Value="4"   Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDust"    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHot)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnHot03" Type="ClassPopulationPlanet">
@@ -279,8 +273,9 @@
 
   <!-- +5 DustOnHot -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnHot04" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeHot/ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnHot04" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDust"    Operation="Addition"    Value="5"   Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDust"    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHot)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnHot04" Type="ClassPopulationPlanet">
@@ -295,8 +290,9 @@
   <!-- Dust on Teeming -->
   <!-- +1 DustOnTeeming -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnTeeming00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTeeming/ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnTeeming00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDust"    Operation="Addition"    Value="1"   Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDust"    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnTeeming00" Type="ClassPopulationPlanet">
@@ -310,8 +306,9 @@
 
   <!-- +2 DustOnTeeming -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnTeeming01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTeeming/ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnTeeming01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDust"    Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDust"    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnTeeming01" Type="ClassPopulationPlanet">
@@ -321,8 +318,9 @@
 
   <!-- +3 DustOnTeeming -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnTeeming02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTeeming/ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnTeeming02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDust"    Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDust"    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnTeeming02" Type="ClassPopulationPlanet">
@@ -336,8 +334,9 @@
 
   <!-- +4 DustOnTeeming -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnTeeming03" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="4" Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="4" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTeeming/ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnTeeming03" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDust"    Operation="Addition"    Value="4"   Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDust"    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnTeeming03" Type="ClassPopulationPlanet">
@@ -347,8 +346,9 @@
 
   <!-- +5 DustOnTeeming -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnTeeming04" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTeeming/ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnTeeming04" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDust"    Operation="Addition"    Value="5"   Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDust"    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnTeeming04" Type="ClassPopulationPlanet">
@@ -363,8 +363,9 @@
   <!-- Dust on Meager -->
   <!-- +1 DustOnMeager -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnMeager00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeMeager/ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnMeager00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDust"    Operation="Addition"    Value="1"   Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDust"    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMeager)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnMeager00" Type="ClassPopulationPlanet">
@@ -378,8 +379,9 @@
 
   <!-- +2 DustOnMeager -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnMeager01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeMeager/ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnMeager01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDust"    Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDust"    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMeager)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnMeager01" Type="ClassPopulationPlanet">
@@ -389,8 +391,9 @@
 
   <!-- +3 DustOnMeager -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnMeager02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeMeager/ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnMeager02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDust"    Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDust"    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMeager)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnMeager02" Type="ClassPopulationPlanet">
@@ -404,8 +407,9 @@
 
   <!-- +4 DustOnMeager -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnMeager03" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="4" Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="4" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeMeager/ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnMeager03" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDust"    Operation="Addition"    Value="4"   Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDust"    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMeager)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnMeager03" Type="ClassPopulationPlanet">
@@ -415,8 +419,9 @@
 
   <!-- +5 DustOnMeager -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnMeager04" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeMeager/ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnMeager04" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDust"    Operation="Addition"    Value="5"   Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDust"    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMeager)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnMeager04" Type="ClassPopulationPlanet">
@@ -431,8 +436,9 @@
   <!-- Dust on Gas -->
   <!-- +3 DustOnGas -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnGas00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeGas/ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnGas00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDust"    Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDust"    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsGas)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnGas00" Type="ClassPopulationPlanet">
@@ -446,8 +452,9 @@
 
   <!-- +5 DustOnGas -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnGas01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeGas/ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnGas01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDust"    Operation="Addition"    Value="5"   Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDust"    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsGas)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnGas01" Type="ClassPopulationPlanet">
@@ -461,8 +468,9 @@
 
   <!-- +10 DustOnGas -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnGas02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="10" Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="10" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeGas/ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnGas02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDust"    Operation="Addition"    Value="10"   Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="10"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDust"    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsGas)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnGas02" Type="ClassPopulationPlanet">
@@ -476,8 +484,9 @@
 
   <!-- +12 DustOnGas -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnGas03" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="12" Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="12" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeGas/ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnGas03" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDust"    Operation="Addition"    Value="12"   Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="12"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDust"    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsGas)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnGas03" Type="ClassPopulationPlanet">
@@ -487,8 +496,9 @@
 
   <!-- +15 DustOnGas -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnGas04" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="15" Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="15" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeGas/ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnGas04" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDust"    Operation="Addition"    Value="15"   Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="15"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDust"    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsGas)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnGas04" Type="ClassPopulationPlanet">
@@ -503,9 +513,10 @@
   <!-- Dust on Happy -->
   <!-- +1 DustOnHappy -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnHappy00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="1" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="1" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
-    <BinaryModifier TargetProperty="BonusPopulationDust" Operation="Addition" Left="1" BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnHappy00" TooltipHidden="true" SearchValueFromPath="true"/>
+    <Modifier		TargetProperty="BonusPopulationDust"			Operation="Addition" Value="1" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
+    <Modifier		TargetProperty="BonusPopulationDust"			Operation="Addition" Value="1" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"			Operation="Addition" Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDust"			Operation="Addition" Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnHappy00" Type="ClassPopulationPlanet">
@@ -520,9 +531,10 @@
 
   <!-- +2 DustOnHappy -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnHappy01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="2" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="2" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
-    <BinaryModifier TargetProperty="BonusPopulationDust" Operation="Addition" Left="2" BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnHappy01" TooltipHidden="true" SearchValueFromPath="true"/>
+    <Modifier		TargetProperty="BonusPopulationDust"			Operation="Addition" Value="2" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
+    <Modifier		TargetProperty="BonusPopulationDust"			Operation="Addition" Value="2" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"			Operation="Addition" Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDust"			Operation="Addition" Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnHappy01" Type="ClassPopulationPlanet">
@@ -533,9 +545,10 @@
 
   <!-- +3 DustOnHappy -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnHappy02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="3" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="3" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
-    <BinaryModifier TargetProperty="BonusPopulationDust" Operation="Addition" Left="3" BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnHappy02" TooltipHidden="true" SearchValueFromPath="true"/>
+    <Modifier		TargetProperty="BonusPopulationDust"			Operation="Addition" Value="3" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
+    <Modifier		TargetProperty="BonusPopulationDust"			Operation="Addition" Value="3" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"			Operation="Addition" Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDust"			Operation="Addition" Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnHappy02" Type="ClassPopulationPlanet">
@@ -550,9 +563,10 @@
 
   <!-- +4 DustOnHappy -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnHappy03" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="4" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="4" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
-    <BinaryModifier TargetProperty="BonusPopulationDust" Operation="Addition" Left="4" BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnHappy03" TooltipHidden="true" SearchValueFromPath="true"/>
+    <Modifier		TargetProperty="BonusPopulationDust"			Operation="Addition" Value="4" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
+    <Modifier		TargetProperty="BonusPopulationDust"			Operation="Addition" Value="4" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"			Operation="Addition" Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDust"			Operation="Addition" Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnHappy03" Type="ClassPopulationPlanet">
@@ -563,9 +577,10 @@
 
   <!-- +5 DustOnHappy -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnHappy04" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="5" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="5" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
-    <BinaryModifier TargetProperty="BonusPopulationDust" Operation="Addition" Left="5" BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnHappy04" TooltipHidden="true" SearchValueFromPath="true"/>
+    <Modifier		TargetProperty="BonusPopulationDust"			Operation="Addition" Value="5" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
+    <Modifier		TargetProperty="BonusPopulationDust"			Operation="Addition" Value="5" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"			Operation="Addition" Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDust"			Operation="Addition" Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnHappy04" Type="ClassPopulationPlanet">
@@ -581,8 +596,9 @@
   <!-- Dust on Tiny -->
   <!-- +1 DustOnTiny -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnTiny00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetSizeTiny"/>
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeTiny/ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnTiny00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDust"	    Operation="Addition"    Value="1"   Path="FAKEFORGUI./PlanetSizeTiny"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDust"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTiny)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnTiny00" Type="ClassPopulationPlanet">
@@ -596,8 +612,9 @@
 
   <!-- +2 DustOnTiny -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnTiny01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetSizeTiny"/>
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeTiny/ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnTiny01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDust"	    Operation="Addition"    Value="2"   Path="FAKEFORGUI./PlanetSizeTiny"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDust"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTiny)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnTiny01" Type="ClassPopulationPlanet">
@@ -607,8 +624,9 @@
 
   <!-- +3 DustOnTiny -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnTiny02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetSizeTiny"/>
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeTiny/ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnTiny02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDust"	    Operation="Addition"    Value="3"   Path="FAKEFORGUI./PlanetSizeTiny"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDust"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTiny)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnTiny02" Type="ClassPopulationPlanet">
@@ -622,8 +640,9 @@
 
   <!-- +4 DustOnTiny -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnTiny03" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="4" Path="FAKEFORGUI/./PlanetSizeTiny"/>
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="4" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeTiny/ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnTiny03" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDust"	    Operation="Addition"    Value="4"   Path="FAKEFORGUI./PlanetSizeTiny"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDust"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTiny)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnTiny03" Type="ClassPopulationPlanet">
@@ -633,8 +652,9 @@
 
   <!-- +5 DustOnTiny -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnTiny04" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetSizeTiny"/>
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeTiny/ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnTiny04" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDust"	    Operation="Addition"    Value="5"   Path="FAKEFORGUI./PlanetSizeTiny"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDust"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTiny)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnTiny04" Type="ClassPopulationPlanet">
@@ -649,8 +669,9 @@
   <!-- Dust on Small -->
   <!-- +1 DustOnSmall -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnSmall00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetSizeSmall"/>
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeSmall/ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnSmall00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDust"	    Operation="Addition"    Value="1"   Path="FAKEFORGUI./PlanetSizeSmall"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDust"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsSmall)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnSmall00" Type="ClassPopulationPlanet">
@@ -664,8 +685,9 @@
 
   <!-- +2 DustOnSmall -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnSmall01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetSizeSmall"/>
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeSmall/ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnSmall01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDust"	    Operation="Addition"    Value="2"   Path="FAKEFORGUI./PlanetSizeSmall"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDust"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsSmall)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnSmall01" Type="ClassPopulationPlanet">
@@ -675,8 +697,9 @@
 
   <!-- +3 DustOnSmall -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnSmall02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetSizeSmall"/>
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeSmall/ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnSmall02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDust"	    Operation="Addition"    Value="3"   Path="FAKEFORGUI./PlanetSizeSmall"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDust"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsSmall)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnSmall02" Type="ClassPopulationPlanet">
@@ -690,8 +713,9 @@
 
   <!-- +4 DustOnSmall -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnSmall03" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="4" Path="FAKEFORGUI/./PlanetSizeSmall"/>
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="4" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeSmall/ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnSmall03" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDust"	    Operation="Addition"    Value="4"   Path="FAKEFORGUI./PlanetSizeSmall"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDust"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsSmall)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnSmall03" Type="ClassPopulationPlanet">
@@ -701,8 +725,9 @@
 
   <!-- +5 DustOnSmall -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnSmall04" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetSizeSmall"/>
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeSmall/ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnSmall04" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDust"	    Operation="Addition"    Value="5"   Path="FAKEFORGUI./PlanetSizeSmall"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDust"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsSmall)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnSmall04" Type="ClassPopulationPlanet">
@@ -717,8 +742,9 @@
   <!-- Dust on Medium -->
   <!-- +1 DustOnMedium -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnMedium00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetSizeMedium"/>
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeMedium/ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnMedium00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDust"	    Operation="Addition"    Value="1"   Path="FAKEFORGUI./PlanetSizeMedium"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDust"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMedium)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnMedium00" Type="ClassPopulationPlanet">
@@ -732,8 +758,9 @@
 
   <!-- +2 DustOnMedium -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnMedium01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetSizeMedium"/>
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeMedium/ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnMedium01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDust"	    Operation="Addition"    Value="2"   Path="FAKEFORGUI./PlanetSizeMedium"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDust"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMedium)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnMedium01" Type="ClassPopulationPlanet">
@@ -743,8 +770,9 @@
 
   <!-- +3 DustOnMedium -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnMedium02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetSizeMedium"/>
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeMedium/ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnMedium02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDust"	    Operation="Addition"    Value="3"   Path="FAKEFORGUI./PlanetSizeMedium"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDust"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMedium)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnMedium02" Type="ClassPopulationPlanet">
@@ -758,8 +786,9 @@
 
   <!-- +4 DustOnMedium -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnMedium03" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="4" Path="FAKEFORGUI/./PlanetSizeMedium"/>
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="4" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeMedium/ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnMedium03" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDust"	    Operation="Addition"    Value="4"   Path="FAKEFORGUI./PlanetSizeMedium"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDust"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMedium)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnMedium03" Type="ClassPopulationPlanet">
@@ -769,8 +798,9 @@
 
   <!-- +5 DustOnMedium -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnMedium04" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetSizeMedium"/>
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeMedium/ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnMedium04" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDust"	    Operation="Addition"    Value="5"   Path="FAKEFORGUI./PlanetSizeMedium"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDust"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMedium)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnMedium04" Type="ClassPopulationPlanet">
@@ -785,8 +815,9 @@
   <!-- Dust on Large -->
   <!-- +1 DustOnLarge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnLarge00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetSizeLarge"/>
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeLarge/ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnLarge00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDust"	    Operation="Addition"    Value="1"   Path="FAKEFORGUI./PlanetSizeLarge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDust"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsLarge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnLarge00" Type="ClassPopulationPlanet">
@@ -800,8 +831,9 @@
 
   <!-- +2 DustOnLarge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnLarge01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetSizeLarge"/>
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeLarge/ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnLarge01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDust"	    Operation="Addition"    Value="2"   Path="FAKEFORGUI./PlanetSizeLarge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDust"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsLarge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnLarge01" Type="ClassPopulationPlanet">
@@ -811,8 +843,9 @@
 
   <!-- +3 DustOnLarge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnLarge02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetSizeLarge"/>
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeLarge/ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnLarge02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDust"	    Operation="Addition"    Value="3"   Path="FAKEFORGUI./PlanetSizeLarge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDust"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsLarge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnLarge02" Type="ClassPopulationPlanet">
@@ -826,8 +859,9 @@
 
   <!-- +4 DustOnLarge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnLarge03" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="4" Path="FAKEFORGUI/./PlanetSizeLarge"/>
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="4" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeLarge/ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnLarge03" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDust"	    Operation="Addition"    Value="4"   Path="FAKEFORGUI./PlanetSizeLarge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDust"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsLarge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnLarge03" Type="ClassPopulationPlanet">
@@ -837,8 +871,9 @@
 
   <!-- +5 DustOnLarge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnLarge04" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetSizeLarge"/>
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeLarge/ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnLarge04" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDust"	    Operation="Addition"    Value="5"   Path="FAKEFORGUI./PlanetSizeLarge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDust"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsLarge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnLarge04" Type="ClassPopulationPlanet">
@@ -853,8 +888,9 @@
   <!-- Dust on Huge -->
   <!-- +1 DustOnHuge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnHuge00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetSizeHuge"/>
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeHuge/ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnHuge00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDust"	    Operation="Addition"    Value="1"   Path="FAKEFORGUI./PlanetSizeHuge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDust"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHuge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnHuge00" Type="ClassPopulationPlanet">
@@ -868,8 +904,9 @@
 
   <!-- +2 DustOnHuge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnHuge01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetSizeHuge"/>
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeHuge/ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnHuge01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDust"	    Operation="Addition"    Value="2"   Path="FAKEFORGUI./PlanetSizeHuge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDust"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHuge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnHuge01" Type="ClassPopulationPlanet">
@@ -879,8 +916,9 @@
 
   <!-- +3 DustOnHuge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnHuge02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetSizeHuge"/>
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeHuge/ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnHuge02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDust"	    Operation="Addition"    Value="3"   Path="FAKEFORGUI./PlanetSizeHuge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDust"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHuge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnHuge02" Type="ClassPopulationPlanet">
@@ -894,8 +932,9 @@
 
   <!-- +4 DustOnHuge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnHuge03" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="4" Path="FAKEFORGUI/./PlanetSizeHuge"/>
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="4" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeHuge/ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnHuge03" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDust"	    Operation="Addition"    Value="4"   Path="FAKEFORGUI./PlanetSizeHuge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDust"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHuge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnHuge03" Type="ClassPopulationPlanet">
@@ -905,8 +944,9 @@
 
   <!-- +5 DustOnHuge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnHuge04" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetSizeHuge"/>
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeHuge/ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnHuge04" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDust"	    Operation="Addition"    Value="5"   Path="FAKEFORGUI./PlanetSizeHuge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDust"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHuge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnHuge04" Type="ClassPopulationPlanet">
@@ -921,8 +961,9 @@
   <!-- Dust on Strategic -->
   <!-- +2 DustOnStrategic -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnStrategic00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetHasDepositStrategic"/>
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet,PlanetHasDepositStrategic/ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnStrategic00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDust"	    Operation="Addition"    Value="2"   Path="FAKEFORGUI./PlanetHasDepositStrategic"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDust"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetHasStrategicDeposit)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnStrategic00" Type="ClassPopulationPlanet">
@@ -937,8 +978,9 @@
   <!-- Dust on Luxury -->
   <!-- +2 DustOnLuxury -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnLuxury00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetHasDepositLuxury"/>
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet,PlanetHasDepositLuxury/ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnLuxury00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDust"	    Operation="Addition"    Value="2"   Path="FAKEFORGUI./PlanetHasDepositLuxury"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDust"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetHasLuxuryDeposit)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnLuxury00" Type="ClassPopulationPlanet">
@@ -953,8 +995,9 @@
   <!-- Dust on Anomaly -->
   <!-- +5 DustOnAnomaly -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustOnAnomaly00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetAnomaly"/>
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetAnomaly/ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnAnomaly00,ClassPopulation" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDust"	    Operation="Addition"    Value="5"   Path="FAKEFORGUI./PlanetAnomaly"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDust"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetHasAnomaly)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDustOnAnomaly00" Type="ClassPopulationPlanet">
@@ -969,7 +1012,8 @@
   <!-- Dust per Minor Faction -->
   <!-- +1 DustPerMinorFaction -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustPerMinorFaction00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitSecondaryCustomDustPerMinorFaction00,ClassPopulation"/>
+	<Modifier       TargetProperty="BonusPopulationDust"    Operation="Addition"    Value="3"   Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationDust"    Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDustPerMinorFaction00" Type="ClassPopulationPlanet">
@@ -982,7 +1026,8 @@
   <!-- Dust per Backdoor -->
   <!-- +1 DustPerBackdoor -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDustPerBackdoor00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitSecondaryCustomDustPerBackdoor00,ClassPopulation"/>
+	<Modifier       TargetProperty="BonusPopulationDust"    Operation="Addition"    Value="2"   Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationDust"    Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDustPerBackdoor00" Type="ClassPopulationPlanet">
@@ -995,8 +1040,9 @@
 
   <!-- Dust per Temple -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitPrimaryCustomDustPerTemple00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetWithTemple"/>
-    <Modifier TargetProperty="BonusPopulationDust" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimaryCustomDustPerTemple00,ClassPopulation" TooltipHidden="true" />
+    <Modifier       TargetProperty="BonusPopulationDust"	    Operation="Addition"    Value="2"   Path="FAKEFORGUI./PlanetWithTemple"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue0"	    Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDust"	    Operation="Addition"    Left="$(PopulationAuxValue0)"    BinaryOperation="Multiplication" Right="$(PlanetHasTemple)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitPrimaryCustomDustPerTemple00" Type="ClassPopulationPlanet">
@@ -1006,7 +1052,9 @@
 
   <!-- +1 DustLevel-->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitPrimaryCustomDustLevel00" Type="WithPopulationPlanet">
-    <BinaryModifier TargetProperty="BonusPopulationDust" Operation="Addition" Left="2" BinaryOperation="Multiplication" Right="$(PopulationSystemLevel)" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimaryCustomDustLevel00,ClassPopulation" TooltipHidden="true" SearchValueFromPath="true"/>
+    <Modifier       TargetProperty="BonusPopulationDust"	    Operation="Addition"    Value="2"   Path="FAKEFORGUI./SystemLevel"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDust"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PopulationSystemLevel)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitPrimaryCustomDustLevel00" Type="ClassPopulationPlanet">

--- a/Endless Space Competitive Mod/Simulation/Traits/SimulationDescriptors[4_Science].xml
+++ b/Endless Space Competitive Mod/Simulation/Traits/SimulationDescriptors[4_Science].xml
@@ -2,93 +2,75 @@
 <Datatable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xsi:noNamespaceSchemaLocation="../../Schemas/Amplitude.Unity.Simulation.SimulationDescriptor.xsd">
   <!-- Primary -->
 
+  <!-- +1 Science -->
+  <SimulationDescriptor Type="WithPopulationPlanet" Name="WithPopulationPlanetModifiersTraitPrimaryCustomScience00">
+	<Modifier       TargetProperty="BonusPopulationScience" Operation="Addition"    Value="1"   Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+  </SimulationDescriptor>
 
-<!-- +1 Science -->
+  <SimulationDescriptor Type="ClassPopulationPlanet" Name="ClassPopulationPlanetModifiersTraitPrimaryCustomScience00">
+    <Modifier Path="ClassPopulation" Value="1" Operation="Addition" TargetProperty="BonusPopulationScience"/>
+  </SimulationDescriptor>
 
-
-
--<SimulationDescriptor Type="WithPopulationPlanet" Name="WithPopulationPlanetModifiersTraitPrimaryCustomScience00">
-<Modifier Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimaryCustomScience00, ClassPopulation" Value="1" Operation="Addition" TargetProperty="BonusPopulationScience"/>
-</SimulationDescriptor>
-
-
--<SimulationDescriptor Type="ClassPopulationPlanet" Name="ClassPopulationPlanetModifiersTraitPrimaryCustomScience00">
-<Modifier Path="ClassPopulation" Value="1" Operation="Addition" TargetProperty="BonusPopulationScience"/>
-</SimulationDescriptor>
-
-
--<SimulationDescriptor Type="ClassPopulationAssimilated" Name="ClassPopulationAssimilatedPrimaryCustomScience00">
-<Modifier Path="ClassPopulation" Value="2" Operation="Addition" TargetProperty="BonusPopulationScience"/>
-</SimulationDescriptor>
+  <SimulationDescriptor Type="ClassPopulationAssimilated" Name="ClassPopulationAssimilatedPrimaryCustomScience00">
+    <Modifier Path="ClassPopulation" Value="2" Operation="Addition" TargetProperty="BonusPopulationScience"/>
+  </SimulationDescriptor>
   
   <!-- +2 Science -->
+  <SimulationDescriptor Type="WithPopulationPlanet" Name="WithPopulationPlanetModifiersTraitPrimaryCustomScience01">
+	<Modifier       TargetProperty="BonusPopulationScience" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+  </SimulationDescriptor>
 
+  <SimulationDescriptor Type="ClassPopulationPlanet" Name="ClassPopulationPlanetModifiersTraitPrimaryCustomScience01">
+    <Modifier Path="ClassPopulation" Value="2" Operation="Addition" TargetProperty="BonusPopulationScience"/>
+  </SimulationDescriptor>
 
+  <!-- +3 Science -->
+  <SimulationDescriptor Type="WithPopulationPlanet" Name="WithPopulationPlanetModifiersTraitPrimaryCustomScience02">
+	<Modifier       TargetProperty="BonusPopulationScience" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+  </SimulationDescriptor>
 
--<SimulationDescriptor Type="WithPopulationPlanet" Name="WithPopulationPlanetModifiersTraitPrimaryCustomScience01">
-<Modifier Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimaryCustomScience01, ClassPopulation" Value="2" Operation="Addition" TargetProperty="BonusPopulationScience"/>
-</SimulationDescriptor>
+  <SimulationDescriptor Type="ClassPopulationPlanet" Name="ClassPopulationPlanetModifiersTraitPrimaryCustomScience02">
+    <Modifier Path="ClassPopulation" Value="3" Operation="Addition" TargetProperty="BonusPopulationScience"/>
+  </SimulationDescriptor>
 
+  <SimulationDescriptor Type="ClassPopulationAssimilated" Name="ClassPopulationAssimilatedPrimaryCustomScience02">
+    <Modifier Path="ClassPopulation" Value="3" Operation="Addition" TargetProperty="BonusPopulationScience"/>
+  </SimulationDescriptor>
 
--<SimulationDescriptor Type="ClassPopulationPlanet" Name="ClassPopulationPlanetModifiersTraitPrimaryCustomScience01">
-<Modifier Path="ClassPopulation" Value="2" Operation="Addition" TargetProperty="BonusPopulationScience"/>
-</SimulationDescriptor>
+  <!-- +4 Science -->
+  <SimulationDescriptor Type="WithPopulationPlanet" Name="WithPopulationPlanetModifiersTraitPrimaryCustomScience03">
+	<Modifier       TargetProperty="BonusPopulationScience" Operation="Addition"    Value="4"   Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+  </SimulationDescriptor>
 
-<!-- +3 Science -->
+  <SimulationDescriptor Type="ClassPopulationPlanet" Name="ClassPopulationPlanetModifiersTraitPrimaryCustomScience03">
+    <Modifier Path="ClassPopulation" Value="4" Operation="Addition" TargetProperty="BonusPopulationScience"/>
+  </SimulationDescriptor>
 
+  <!-- +5 Science -->
+  <SimulationDescriptor Type="WithPopulationPlanet" Name="WithPopulationPlanetModifiersTraitPrimaryCustomScience04">
+	<Modifier       TargetProperty="BonusPopulationScience" Operation="Addition"    Value="5"   Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+  </SimulationDescriptor>
 
+  <SimulationDescriptor Type="ClassPopulationPlanet" Name="ClassPopulationPlanetModifiersTraitPrimaryCustomScience04">
+    <Modifier Path="ClassPopulation" Value="5" Operation="Addition" TargetProperty="BonusPopulationScience"/>
+  </SimulationDescriptor>
 
--<SimulationDescriptor Type="WithPopulationPlanet" Name="WithPopulationPlanetModifiersTraitPrimaryCustomScience02">
-<Modifier Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimaryCustomScience02, ClassPopulation" Value="3" Operation="Addition" TargetProperty="BonusPopulationScience"/>
-</SimulationDescriptor>
-
-
--<SimulationDescriptor Type="ClassPopulationPlanet" Name="ClassPopulationPlanetModifiersTraitPrimaryCustomScience02">
-<Modifier Path="ClassPopulation" Value="3" Operation="Addition" TargetProperty="BonusPopulationScience"/>
-</SimulationDescriptor>
-
-
--<SimulationDescriptor Type="ClassPopulationAssimilated" Name="ClassPopulationAssimilatedPrimaryCustomScience02">
-<Modifier Path="ClassPopulation" Value="3" Operation="Addition" TargetProperty="BonusPopulationScience"/>
-</SimulationDescriptor>
-
-<!-- +4 Science -->
-
-
-
--<SimulationDescriptor Type="WithPopulationPlanet" Name="WithPopulationPlanetModifiersTraitPrimaryCustomScience03">
-<Modifier Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimaryCustomScience03, ClassPopulation" Value="4" Operation="Addition" TargetProperty="BonusPopulationScience"/>
-</SimulationDescriptor>
-
-
--<SimulationDescriptor Type="ClassPopulationPlanet" Name="ClassPopulationPlanetModifiersTraitPrimaryCustomScience03">
-<Modifier Path="ClassPopulation" Value="4" Operation="Addition" TargetProperty="BonusPopulationScience"/>
-</SimulationDescriptor>
-
-<!-- +5 Science -->
-
-
-
--<SimulationDescriptor Type="WithPopulationPlanet" Name="WithPopulationPlanetModifiersTraitPrimaryCustomScience04">
-<Modifier Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimaryCustomScience04, ClassPopulation" Value="5" Operation="Addition" TargetProperty="BonusPopulationScience"/>
-</SimulationDescriptor>
-
-
--<SimulationDescriptor Type="ClassPopulationPlanet" Name="ClassPopulationPlanetModifiersTraitPrimaryCustomScience04">
-<Modifier Path="ClassPopulation" Value="5" Operation="Addition" TargetProperty="BonusPopulationScience"/>
-</SimulationDescriptor>
-
-
--<SimulationDescriptor Type="ClassPopulationAssimilated" Name="ClassPopulationAssimilatedPrimaryCustomScience04">
-<Modifier Path="ClassPopulation" Value="4" Operation="Addition" TargetProperty="BonusPopulationScience"/>
-</SimulationDescriptor>
+  <SimulationDescriptor Type="ClassPopulationAssimilated" Name="ClassPopulationAssimilatedPrimaryCustomScience04">
+    <Modifier Path="ClassPopulation" Value="4" Operation="Addition" TargetProperty="BonusPopulationScience"/>
+  </SimulationDescriptor>
   
   <!-- Secondary -->
   <!-- Science on Cold -->
   <!-- +1 ScienceOnCold -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnCold00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeCold/ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnCold00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScience" Operation="Addition"    Value="1"   Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsCold)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnCold00" Type="ClassPopulationPlanet">
@@ -102,8 +84,9 @@
 
   <!-- +2 ScienceOnCold -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnCold01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeCold/ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnCold01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScience" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsCold)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnCold01" Type="ClassPopulationPlanet">
@@ -113,8 +96,9 @@
 
   <!-- +3 ScienceOnCold -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnCold02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeCold/ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnCold02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScience" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsCold)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnCold02" Type="ClassPopulationPlanet">
@@ -128,8 +112,9 @@
 
   <!-- +4 ScienceOnCold -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnCold03" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="4" Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="4" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeCold/ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnCold03" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScience" Operation="Addition"    Value="4"   Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsCold)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnCold03" Type="ClassPopulationPlanet">
@@ -139,8 +124,9 @@
 
   <!-- +5 ScienceOnCold -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnCold04" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeCold/ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnCold04" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScience" Operation="Addition"    Value="5"   Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsCold)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnCold04" Type="ClassPopulationPlanet">
@@ -155,8 +141,9 @@
   <!-- Science on Temperate -->
   <!-- +1 ScienceOnTemperate -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnTemperate00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTemperate/ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnTemperate00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScience" Operation="Addition"    Value="1"   Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTemperate)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnTemperate00" Type="ClassPopulationPlanet">
@@ -170,8 +157,9 @@
   
   <!-- +2 ScienceOnTemperate -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnTemperate01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTemperate/ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnTemperate01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScience" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTemperate)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnTemperate01" Type="ClassPopulationPlanet">
@@ -181,8 +169,9 @@
 
   <!-- +3 ScienceOnTemperate -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnTemperate02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTemperate/ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnTemperate02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScience" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTemperate)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnTemperate02" Type="ClassPopulationPlanet">
@@ -196,8 +185,9 @@
 
   <!-- +4 ScienceOnTemperate -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnTemperate03" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="4" Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="4" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTemperate/ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnTemperate03" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScience" Operation="Addition"    Value="4"   Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTemperate)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnTemperate03" Type="ClassPopulationPlanet">
@@ -207,8 +197,9 @@
 
   <!-- +5 ScienceOnTemperate -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnTemperate04" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTemperate/ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnTemperate04" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScience" Operation="Addition"    Value="5"   Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTemperate)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnTemperate04" Type="ClassPopulationPlanet">
@@ -223,8 +214,9 @@
   <!-- Science on Hot -->
   <!-- +1 ScienceOnHot -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnHot00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeHot/ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnHot00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScience" Operation="Addition"    Value="1"   Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHot)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnHot00" Type="ClassPopulationPlanet">
@@ -238,8 +230,9 @@
   
   <!-- +2 ScienceOnHot -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnHot01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeHot/ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnHot01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScience" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHot)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnHot01" Type="ClassPopulationPlanet">
@@ -249,8 +242,9 @@
 
   <!-- +3 ScienceOnHot -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnHot02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeHot/ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnHot02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScience" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHot)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnHot02" Type="ClassPopulationPlanet">
@@ -264,8 +258,9 @@
 
   <!-- +4 ScienceOnHot -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnHot03" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="4" Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="4" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeHot/ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnHot03" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScience" Operation="Addition"    Value="4"   Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHot)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnHot03" Type="ClassPopulationPlanet">
@@ -275,8 +270,9 @@
 
   <!-- +5 ScienceOnHot -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnHot04" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeHot/ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnHot04" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScience" Operation="Addition"    Value="5"   Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHot)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnHot04" Type="ClassPopulationPlanet">
@@ -291,8 +287,9 @@
   <!-- Science on Teeming -->
   <!-- +1 ScienceOnTeeming -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnTeeming00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTeeming/ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnTeeming00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScience" Operation="Addition"    Value="1"   Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnTeeming00" Type="ClassPopulationPlanet">
@@ -306,8 +303,9 @@
 
   <!-- +2 ScienceOnTeeming -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnTeeming01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTeeming/ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnTeeming01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScience" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnTeeming01" Type="ClassPopulationPlanet">
@@ -317,8 +315,9 @@
 
   <!-- +3 ScienceOnTeeming -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnTeeming02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTeeming/ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnTeeming02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScience" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnTeeming02" Type="ClassPopulationPlanet">
@@ -332,8 +331,9 @@
 
   <!-- +4 ScienceOnTeeming -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnTeeming03" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="4" Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="4" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTeeming/ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnTeeming03" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScience" Operation="Addition"    Value="4"   Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnTeeming03" Type="ClassPopulationPlanet">
@@ -343,8 +343,9 @@
 
   <!-- +5 ScienceOnTeeming -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnTeeming04" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTeeming/ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnTeeming04" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScience" Operation="Addition"    Value="5"   Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnTeeming04" Type="ClassPopulationPlanet">
@@ -359,8 +360,9 @@
   <!-- Science on Meager -->
   <!-- +1 ScienceOnMeager -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnMeager00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeMeager/ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnMeager00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScience" Operation="Addition"    Value="1"   Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMeager)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnMeager00" Type="ClassPopulationPlanet">
@@ -374,8 +376,9 @@
   
   <!-- +2 ScienceOnMeager -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnMeager01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeMeager/ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnMeager01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScience" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMeager)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnMeager01" Type="ClassPopulationPlanet">
@@ -385,8 +388,9 @@
 
   <!-- +3 ScienceOnMeager -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnMeager02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeMeager/ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnMeager02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScience" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMeager)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnMeager02" Type="ClassPopulationPlanet">
@@ -400,8 +404,9 @@
 
   <!-- +4 ScienceOnMeager -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnMeager03" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="4" Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="4" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeMeager/ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnMeager03" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScience" Operation="Addition"    Value="4"   Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMeager)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnMeager03" Type="ClassPopulationPlanet">
@@ -411,8 +416,9 @@
 
   <!-- +5 ScienceOnMeager -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnMeager04" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeMeager/ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnMeager04" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScience" Operation="Addition"    Value="5"   Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMeager)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnMeager04" Type="ClassPopulationPlanet">
@@ -425,10 +431,11 @@
   </SimulationDescriptor>
 
   <!-- Science on Gas -->
-  <!-- +1 ScienceOnGas -->
+  <!-- +3 ScienceOnGas -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnGas00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeGas/ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnGas00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScience" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsGas)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnGas00" Type="ClassPopulationPlanet">
@@ -440,10 +447,11 @@
     <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="2" Path="ClassPopulation"/>
   </SimulationDescriptor>
   
-  <!-- +2 ScienceOnGas -->
+  <!-- +5 ScienceOnGas -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnGas01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeGas/ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnGas01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScience" Operation="Addition"    Value="5"   Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsGas)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnGas01" Type="ClassPopulationPlanet">
@@ -451,10 +459,11 @@
     <BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition" Left="5" BinaryOperation="Multiplication" Right="$(PlanetIsGas)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +3 ScienceOnGas -->
+  <!-- +10 ScienceOnGas -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnGas02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="10" Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="10" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeGas/ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnGas02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScience" Operation="Addition"    Value="10"   Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="10"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsGas)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnGas02" Type="ClassPopulationPlanet">
@@ -466,10 +475,11 @@
     <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="4" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +4 ScienceOnGas -->
+  <!-- +12 ScienceOnGas -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnGas03" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="12" Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="12" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeGas/ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnGas03" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScience" Operation="Addition"    Value="12"   Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="12"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsGas)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnGas03" Type="ClassPopulationPlanet">
@@ -477,10 +487,11 @@
     <BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition" Left="12" BinaryOperation="Multiplication" Right="$(PlanetIsGas)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +5 ScienceOnGas -->
+  <!-- +15 ScienceOnGas -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnGas04" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="15" Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="15" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeGas/ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnGas04" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScience" Operation="Addition"    Value="15"   Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="15"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsGas)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnGas04" Type="ClassPopulationPlanet">
@@ -495,9 +506,10 @@
   <!-- Science on Happy -->
   <!-- +1 ScienceOnHappy -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnHappy00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="1" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="1" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
-    <BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition" Left="1" BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)"  Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnHappy00" TooltipHidden="true" SearchValueFromPath="true"/>
+    <Modifier		TargetProperty="BonusPopulationScience"			Operation="Addition" Value="1" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
+    <Modifier		TargetProperty="BonusPopulationScience"			Operation="Addition" Value="1" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"			Operation="Addition" Left="1"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScience"			Operation="Addition" Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnHappy00" Type="ClassPopulationPlanet">
@@ -512,9 +524,10 @@
 
   <!-- +2 ScienceOnHappy -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnHappy01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="2" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="2" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
-    <BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition" Left="2" BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnHappy01" TooltipHidden="true" SearchValueFromPath="true"/>
+    <Modifier		TargetProperty="BonusPopulationScience"			Operation="Addition" Value="2" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
+    <Modifier		TargetProperty="BonusPopulationScience"			Operation="Addition" Value="2" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"			Operation="Addition" Left="2"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScience"			Operation="Addition" Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnHappy01" Type="ClassPopulationPlanet">
@@ -525,9 +538,10 @@
 
   <!-- +3 ScienceOnHappy -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnHappy02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="3" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="3" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
-    <BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition" Left="3" BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnHappy02" TooltipHidden="true" SearchValueFromPath="true"/>
+    <Modifier		TargetProperty="BonusPopulationScience"			Operation="Addition" Value="3" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
+    <Modifier		TargetProperty="BonusPopulationScience"			Operation="Addition" Value="3" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"			Operation="Addition" Left="3"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScience"			Operation="Addition" Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnHappy02" Type="ClassPopulationPlanet">
@@ -542,9 +556,10 @@
 
   <!-- +4 ScienceOnHappy -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnHappy03" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="4" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="4" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
-    <BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition" Left="4" BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnHappy03" TooltipHidden="true" SearchValueFromPath="true"/>
+    <Modifier		TargetProperty="BonusPopulationScience"			Operation="Addition" Value="4" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
+    <Modifier		TargetProperty="BonusPopulationScience"			Operation="Addition" Value="4" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"			Operation="Addition" Left="4"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScience"			Operation="Addition" Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnHappy03" Type="ClassPopulationPlanet">
@@ -555,9 +570,10 @@
 
   <!-- +5 ScienceOnHappy -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnHappy04" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="5" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="5" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
-    <BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition" Left="5" BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnHappy04" TooltipHidden="true" SearchValueFromPath="true"/>
+    <Modifier		TargetProperty="BonusPopulationScience"			Operation="Addition" Value="5" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
+    <Modifier		TargetProperty="BonusPopulationScience"			Operation="Addition" Value="5" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"			Operation="Addition" Left="5"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScience"			Operation="Addition" Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnHappy04" Type="ClassPopulationPlanet">
@@ -573,8 +589,9 @@
   <!-- Science on Tiny -->
   <!-- +1 ScienceOnTiny -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnTiny00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetSizeTiny"/>
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeTiny/ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnTiny00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScience" Operation="Addition"    Value="1"   Path="FAKEFORGUI/./PlanetSizeTiny"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTiny)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnTiny00" Type="ClassPopulationPlanet">
@@ -588,8 +605,9 @@
 
   <!-- +2 ScienceOnTiny -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnTiny01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetSizeTiny"/>
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeTiny/ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnTiny01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScience" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetSizeTiny"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTiny)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnTiny01" Type="ClassPopulationPlanet">
@@ -599,8 +617,9 @@
 
   <!-- +3 ScienceOnTiny -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnTiny02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetSizeTiny"/>
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeTiny/ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnTiny02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScience" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetSizeTiny"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTiny)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnTiny02" Type="ClassPopulationPlanet">
@@ -614,8 +633,9 @@
 
   <!-- +4 ScienceOnTiny -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnTiny03" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="4" Path="FAKEFORGUI/./PlanetSizeTiny"/>
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="4" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeTiny/ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnTiny03" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScience" Operation="Addition"    Value="4"   Path="FAKEFORGUI/./PlanetSizeTiny"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTiny)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnTiny03" Type="ClassPopulationPlanet">
@@ -625,8 +645,9 @@
 
   <!-- +5 ScienceOnTiny -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnTiny04" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetSizeTiny"/>
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeTiny/ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnTiny04" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScience" Operation="Addition"    Value="5"   Path="FAKEFORGUI/./PlanetSizeTiny"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTiny)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnTiny04" Type="ClassPopulationPlanet">
@@ -641,8 +662,9 @@
   <!-- Science on Small -->
   <!-- +1 ScienceOnSmall -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnSmall00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetSizeSmall"/>
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeSmall/ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnSmall00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScience" Operation="Addition"    Value="1"   Path="FAKEFORGUI/./PlanetSizeSmall"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsSmall)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnSmall00" Type="ClassPopulationPlanet">
@@ -656,8 +678,9 @@
 
   <!-- +2 ScienceOnSmall -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnSmall01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetSizeSmall"/>
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeSmall/ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnSmall01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScience" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetSizeSmall"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsSmall)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnSmall01" Type="ClassPopulationPlanet">
@@ -667,8 +690,9 @@
 
   <!-- +3 ScienceOnSmall -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnSmall02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetSizeSmall"/>
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeSmall/ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnSmall02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScience" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetSizeSmall"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsSmall)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnSmall02" Type="ClassPopulationPlanet">
@@ -682,8 +706,9 @@
 
   <!-- +4 ScienceOnSmall -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnSmall03" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="4" Path="FAKEFORGUI/./PlanetSizeSmall"/>
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="4" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeSmall/ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnSmall03" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScience" Operation="Addition"    Value="4"   Path="FAKEFORGUI/./PlanetSizeSmall"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsSmall)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnSmall03" Type="ClassPopulationPlanet">
@@ -693,8 +718,9 @@
 
   <!-- +5 ScienceOnSmall -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnSmall04" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetSizeSmall"/>
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeSmall/ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnSmall04" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScience" Operation="Addition"    Value="5"   Path="FAKEFORGUI/./PlanetSizeSmall"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsSmall)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnSmall04" Type="ClassPopulationPlanet">
@@ -709,8 +735,9 @@
   <!-- Science on Medium -->
   <!-- +1 ScienceOnMedium -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnMedium00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetSizeMedium"/>
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeMedium/ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnMedium00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScience" Operation="Addition"    Value="1"   Path="FAKEFORGUI/./PlanetSizeMedium"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMedium)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnMedium00" Type="ClassPopulationPlanet">
@@ -724,8 +751,9 @@
 
   <!-- +2 ScienceOnMedium -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnMedium01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetSizeMedium"/>
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeMedium/ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnMedium01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScience" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetSizeMedium"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMedium)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnMedium01" Type="ClassPopulationPlanet">
@@ -735,8 +763,9 @@
 
   <!-- +3 ScienceOnMedium -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnMedium02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetSizeMedium"/>
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeMedium/ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnMedium02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScience" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetSizeMedium"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMedium)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnMedium02" Type="ClassPopulationPlanet">
@@ -750,8 +779,9 @@
 
   <!-- +4 ScienceOnMedium -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnMedium03" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="4" Path="FAKEFORGUI/./PlanetSizeMedium"/>
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="4" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeMedium/ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnMedium03" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScience" Operation="Addition"    Value="4"   Path="FAKEFORGUI/./PlanetSizeMedium"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMedium)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnMedium03" Type="ClassPopulationPlanet">
@@ -761,8 +791,9 @@
 
   <!-- +5 ScienceOnMedium -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnMedium04" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetSizeMedium"/>
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeMedium/ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnMedium04" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScience" Operation="Addition"    Value="5"   Path="FAKEFORGUI/./PlanetSizeMedium"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMedium)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnMedium04" Type="ClassPopulationPlanet">
@@ -777,8 +808,9 @@
   <!-- Science on Large -->
   <!-- +1 ScienceOnLarge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnLarge00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetSizeLarge"/>
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeLarge/ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnLarge00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScience" Operation="Addition"    Value="1"   Path="FAKEFORGUI/./PlanetSizeLarge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsLarge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnLarge00" Type="ClassPopulationPlanet">
@@ -792,8 +824,9 @@
 
   <!-- +2 ScienceOnLarge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnLarge01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetSizeLarge"/>
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeLarge/ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnLarge01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScience" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetSizeLarge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsLarge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnLarge01" Type="ClassPopulationPlanet">
@@ -803,8 +836,9 @@
 
   <!-- +3 ScienceOnLarge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnLarge02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetSizeLarge"/>
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeLarge/ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnLarge02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScience" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetSizeLarge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsLarge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnLarge02" Type="ClassPopulationPlanet">
@@ -818,8 +852,9 @@
 
   <!-- +4 ScienceOnLarge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnLarge03" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="4" Path="FAKEFORGUI/./PlanetSizeLarge"/>
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="4" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeLarge/ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnLarge03" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScience" Operation="Addition"    Value="4"   Path="FAKEFORGUI/./PlanetSizeLarge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsLarge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnLarge03" Type="ClassPopulationPlanet">
@@ -829,8 +864,9 @@
 
   <!-- +5 ScienceOnLarge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnLarge04" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetSizeLarge"/>
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeLarge/ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnLarge04" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScience" Operation="Addition"    Value="5"   Path="FAKEFORGUI/./PlanetSizeLarge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsLarge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnLarge04" Type="ClassPopulationPlanet">
@@ -845,8 +881,9 @@
   <!-- Science on Huge -->
   <!-- +1 ScienceOnHuge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnHuge00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetSizeHuge"/>
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeHuge/ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnHuge00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScience" Operation="Addition"    Value="1"   Path="FAKEFORGUI/./PlanetSizeHuge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHuge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnHuge00" Type="ClassPopulationPlanet">
@@ -860,8 +897,9 @@
 
   <!-- +2 ScienceOnHuge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnHuge01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetSizeHuge"/>
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeHuge/ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnHuge01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScience" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetSizeHuge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHuge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnHuge01" Type="ClassPopulationPlanet">
@@ -871,8 +909,9 @@
 
   <!-- +3 ScienceOnHuge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnHuge02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetSizeHuge"/>
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeHuge/ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnHuge02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScience" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetSizeHuge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHuge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnHuge02" Type="ClassPopulationPlanet">
@@ -886,8 +925,9 @@
 
   <!-- +4 ScienceOnHuge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnHuge03" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="4" Path="FAKEFORGUI/./PlanetSizeHuge"/>
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="4" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeHuge/ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnHuge03" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScience" Operation="Addition"    Value="4"   Path="FAKEFORGUI/./PlanetSizeHuge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHuge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnHuge03" Type="ClassPopulationPlanet">
@@ -897,8 +937,9 @@
 
   <!-- +5 ScienceOnHuge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnHuge04" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetSizeHuge"/>
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeHuge/ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnHuge04" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScience" Operation="Addition"    Value="5"   Path="FAKEFORGUI/./PlanetSizeHuge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHuge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnHuge04" Type="ClassPopulationPlanet">
@@ -913,8 +954,9 @@
   <!-- Science on Strategic -->
   <!-- +2 ScienceOnStrategic -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnStrategic00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetHasDepositStrategic"/>
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet,PlanetHasDepositStrategic/ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnStrategic00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScience" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetHasDepositStrategic"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetHasStrategicDeposit)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnStrategic00" Type="ClassPopulationPlanet">
@@ -929,8 +971,9 @@
   <!-- Science on Luxury -->
   <!-- +2 ScienceOnLuxury -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnLuxury00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetHasDepositLuxury"/>
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet,PlanetHasDepositLuxury/ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnLuxury00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScience" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetHasDepositLuxury"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetHasLuxuryDeposit)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnLuxury00" Type="ClassPopulationPlanet">
@@ -945,8 +988,9 @@
   <!-- Science on Anomaly -->
   <!-- +3 ScienceOnAnomaly -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnAnomaly000" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetAnomaly"/>
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetAnomaly/ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnAnomaly00,ClassPopulation" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScience" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetAnomaly"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetHasAnomaly)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnAnomaly000" Type="ClassPopulationPlanet">
@@ -960,8 +1004,9 @@
   
   <!-- +5 ScienceOnAnomaly -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomScienceOnAnomaly00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetAnomaly"/>
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetAnomaly/ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnAnomaly00,ClassPopulation" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScience" Operation="Addition"    Value="5"   Path="FAKEFORGUI/./PlanetAnomaly"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetHasAnomaly)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnAnomaly00" Type="ClassPopulationPlanet">
@@ -981,7 +1026,8 @@
   <!-- Science per Minor Faction -->
   <!-- +1 SciencePerMinorFaction -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomSciencePerMinorFaction00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitSecondaryCustomSciencePerMinorFaction00,ClassPopulation"/>
+	<Modifier       TargetProperty="BonusPopulationScience" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomSciencePerMinorFaction00" Type="ClassPopulationPlanet">
@@ -994,7 +1040,8 @@
   <!-- Science per Backdoor -->
   <!-- +1 SciencePerBackdoor -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomSciencePerBackdoor00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationScience" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitSecondaryCustomSciencePerBackdoor00,ClassPopulation"/>
+	<Modifier       TargetProperty="BonusPopulationScience" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomSciencePerBackdoor00" Type="ClassPopulationPlanet">
@@ -1007,8 +1054,9 @@
 
   <!-- Science per Temple -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitPrimaryCustomSciencePerTemple00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationScience"          Operation="Addition"    Value="2"       Path="FAKEFORGUI/./PlanetWithTemple"/>
-    <Modifier TargetProperty="BonusPopulationScience"          Operation="Addition"    Value="2"       Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimaryCustomSciencePerTemple00,ClassPopulation" TooltipHidden="true" />
+    <Modifier       TargetProperty="BonusPopulationScience" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetWithTemple"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue0"	Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition"    Left="$(PopulationAuxValue0)"    BinaryOperation="Multiplication" Right="$(PlanetHasTemple)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitPrimaryCustomSciencePerTemple00" Type="ClassPopulationPlanet">
@@ -1016,9 +1064,11 @@
     <BinaryModifier     TargetProperty="BonusPopulationScience"    Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PlanetHasTemple)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +1 ScienceLevel-->
+  <!-- +2 Science per System Level -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitPrimaryCustomScienceLevel00" Type="WithPopulationPlanet">
-    <BinaryModifier TargetProperty="BonusPopulationScience" Operation="Addition" Left="2" BinaryOperation="Multiplication" Right="$(PopulationSystemLevel)"  Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimaryCustomScienceLevel00,ClassPopulation" TooltipHidden="true" SearchValueFromPath="true"/>
+    <Modifier       TargetProperty="BonusPopulationScience"	    Operation="Addition"    Value="2"   Path="FAKEFORGUI./SystemLevel"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScience"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PopulationSystemLevel)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitPrimaryCustomScienceLevel00" Type="ClassPopulationPlanet">

--- a/Endless Space Competitive Mod/Simulation/Traits/SimulationDescriptors[5_Influence].xml
+++ b/Endless Space Competitive Mod/Simulation/Traits/SimulationDescriptors[5_Influence].xml
@@ -4,7 +4,8 @@
   <!-- Prestige -->
   <!-- +1 Prestige -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitPrimaryCustomPrestige00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimaryCustomPrestige00,ClassPopulation"/>
+	<Modifier       TargetProperty="BonusPopulationPrestige" Operation="Addition"    Value="1"   Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationPrestige" Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitPrimaryCustomPrestige00" Type="ClassPopulationPlanet">
@@ -17,7 +18,8 @@
 
   <!-- +2 Prestige -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitPrimaryCustomPrestige01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimaryCustomPrestige01,ClassPopulation"/>
+	<Modifier       TargetProperty="BonusPopulationPrestige" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationPrestige" Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitPrimaryCustomPrestige01" Type="ClassPopulationPlanet">
@@ -26,7 +28,8 @@
 
   <!-- +3 Prestige -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitPrimaryCustomPrestige02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimaryCustomPrestige02,ClassPopulation"/>
+	<Modifier       TargetProperty="BonusPopulationPrestige" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationPrestige" Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitPrimaryCustomPrestige02" Type="ClassPopulationPlanet">
@@ -41,8 +44,9 @@
   <!-- Prestige on Cold -->
   <!-- +1 PrestigeOnCold -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnCold00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeCold/ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnCold00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationPrestige" Operation="Addition"    Value="1"   Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestige" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsCold)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnCold00" Type="ClassPopulationPlanet">
@@ -56,8 +60,9 @@
 
   <!-- +2 PrestigeOnCold -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnCold01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeCold/ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnCold01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationPrestige" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestige" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsCold)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnCold01" Type="ClassPopulationPlanet">
@@ -67,8 +72,9 @@
 
   <!-- +3 PrestigeOnCold -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnCold02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeCold/ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnCold02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationPrestige" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestige" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsCold)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnCold02" Type="ClassPopulationPlanet">
@@ -83,8 +89,9 @@
   <!-- Prestige on Temperate -->
   <!-- +1 PrestigeOnTemperate -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnTemperate00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTemperate/ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnTemperate00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationPrestige" Operation="Addition"    Value="1"   Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestige" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTemperate)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnTemperate00" Type="ClassPopulationPlanet">
@@ -98,8 +105,9 @@
 
   <!-- +2 PrestigeOnTemperate -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnTemperate01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTemperate/ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnTemperate01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationPrestige" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestige" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTemperate)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnTemperate01" Type="ClassPopulationPlanet">
@@ -109,8 +117,9 @@
 
   <!-- +3 PrestigeOnTemperate -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnTemperate02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTemperate/ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnTemperate02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationPrestige" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestige" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTemperate)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnTemperate02" Type="ClassPopulationPlanet">
@@ -125,8 +134,9 @@
   <!-- Prestige on Hot -->
   <!-- +1 PrestigeOnHot -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnHot00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeHot/ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnHot00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationPrestige" Operation="Addition"    Value="1"   Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestige" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHot)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnHot00" Type="ClassPopulationPlanet">
@@ -140,8 +150,9 @@
 
   <!-- +2 PrestigeOnHot -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnHot01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeHot/ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnHot01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationPrestige" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestige" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHot)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnHot01" Type="ClassPopulationPlanet">
@@ -151,8 +162,9 @@
 
   <!-- +3 PrestigeOnHot -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnHot02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeHot/ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnHot02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationPrestige" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestige" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHot)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnHot02" Type="ClassPopulationPlanet">
@@ -167,8 +179,9 @@
   <!-- Prestige on Teeming -->
   <!-- +1 PrestigeOnTeeming -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnTeeming00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTeeming/ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnTeeming00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationPrestige" Operation="Addition"    Value="1"   Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestige" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnTeeming00" Type="ClassPopulationPlanet">
@@ -182,8 +195,9 @@
 
   <!-- +2 PrestigeOnTeeming -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnTeeming01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTeeming/ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnTeeming01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationPrestige" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestige" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnTeeming01" Type="ClassPopulationPlanet">
@@ -193,8 +207,9 @@
 
   <!-- +3 PrestigeOnTeeming -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnTeeming02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTeeming/ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnTeeming02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationPrestige" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestige" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnTeeming02" Type="ClassPopulationPlanet">
@@ -209,8 +224,9 @@
   <!-- Prestige on Meager -->
   <!-- +1 PrestigeOnMeager -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnMeager00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeMeager/ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnMeager00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationPrestige" Operation="Addition"    Value="1"   Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestige" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMeager)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnMeager00" Type="ClassPopulationPlanet">
@@ -224,8 +240,9 @@
 
   <!-- +2 PrestigeOnMeager -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnMeager01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeMeager/ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnMeager01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationPrestige" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestige" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMeager)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnMeager01" Type="ClassPopulationPlanet">
@@ -235,8 +252,9 @@
 
   <!-- +3 PrestigeOnMeager -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnMeager02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeMeager/ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnMeager02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationPrestige" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestige" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMeager)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnMeager02" Type="ClassPopulationPlanet">
@@ -251,8 +269,9 @@
   <!-- Prestige on Gas -->
   <!-- +2 PrestigeOnGas -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnGas00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeGas/ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnGas00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationPrestige" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestige" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsGas)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnGas00" Type="ClassPopulationPlanet">
@@ -266,8 +285,9 @@
 
   <!-- +3 PrestigeOnGas -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnGas01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeGas/ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnGas01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationPrestige" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestige" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsGas)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnGas01" Type="ClassPopulationPlanet">
@@ -281,8 +301,9 @@
 
   <!-- +5 PrestigeOnGas -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnGas02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeGas/ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnGas02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationPrestige" Operation="Addition"    Value="5"   Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestige" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsGas)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnGas02" Type="ClassPopulationPlanet">
@@ -297,9 +318,10 @@
   <!-- Prestige on Happy -->
   <!-- +1 PrestigeOnHappy -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnHappy00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="1" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="1" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
-    <BinaryModifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Left="1" BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)"  Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnHappy00" TooltipHidden="true" SearchValueFromPath="true"/>
+    <Modifier		TargetProperty="BonusPopulationPrestige"		Operation="Addition" Value="1" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
+    <Modifier		TargetProperty="BonusPopulationPrestige"		Operation="Addition" Value="1" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"			Operation="Addition" Left="1"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestige"		Operation="Addition" Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnHappy00" Type="ClassPopulationPlanet">
@@ -314,9 +336,10 @@
 
   <!-- +2 PrestigeOnHappy -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnHappy01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="2" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="2" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
-    <BinaryModifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Left="2" BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnHappy01" TooltipHidden="true" SearchValueFromPath="true"/>
+    <Modifier		TargetProperty="BonusPopulationPrestige"		Operation="Addition" Value="2" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
+    <Modifier		TargetProperty="BonusPopulationPrestige"		Operation="Addition" Value="2" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"			Operation="Addition" Left="2"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestige"		Operation="Addition" Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnHappy01" Type="ClassPopulationPlanet">
@@ -327,9 +350,10 @@
 
   <!-- +3 PrestigeOnHappy -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnHappy02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="3" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="3" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
-    <BinaryModifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Left="3" BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnHappy02" TooltipHidden="true" SearchValueFromPath="true"/>
+    <Modifier		TargetProperty="BonusPopulationPrestige"		Operation="Addition" Value="3" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
+    <Modifier		TargetProperty="BonusPopulationPrestige"		Operation="Addition" Value="3" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"			Operation="Addition" Left="3"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestige"		Operation="Addition" Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnHappy02" Type="ClassPopulationPlanet">
@@ -345,8 +369,9 @@
   <!-- Prestige on Tiny -->
   <!-- +1 PrestigeOnTiny -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnTiny00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetSizeTiny"/>
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeTiny/ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnTiny00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationPrestige" Operation="Addition"    Value="1"   Path="FAKEFORGUI/./PlanetSizeTiny"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestige" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTiny)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnTiny00" Type="ClassPopulationPlanet">
@@ -360,8 +385,9 @@
 
   <!-- +2 PrestigeOnTiny -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnTiny01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetSizeTiny"/>
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeTiny/ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnTiny01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationPrestige" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetSizeTiny"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestige" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTiny)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnTiny01" Type="ClassPopulationPlanet">
@@ -371,8 +397,9 @@
 
   <!-- +3 PrestigeOnTiny -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnTiny02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetSizeTiny"/>
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeTiny/ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnTiny02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationPrestige" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetSizeTiny"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestige" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTiny)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnTiny02" Type="ClassPopulationPlanet">
@@ -387,8 +414,9 @@
   <!-- Prestige on Small -->
   <!-- +1 PrestigeOnSmall -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnSmall00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetSizeSmall"/>
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeSmall/ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnSmall00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationPrestige" Operation="Addition"    Value="1"   Path="FAKEFORGUI/./PlanetSizeSmall"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestige" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsSmall)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnSmall00" Type="ClassPopulationPlanet">
@@ -402,8 +430,9 @@
 
   <!-- +2 PrestigeOnSmall -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnSmall01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetSizeSmall"/>
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeSmall/ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnSmall01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationPrestige" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetSizeSmall"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestige" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsSmall)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnSmall01" Type="ClassPopulationPlanet">
@@ -413,8 +442,9 @@
 
   <!-- +3 PrestigeOnSmall -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnSmall02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetSizeSmall"/>
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeSmall/ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnSmall02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationPrestige" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetSizeSmall"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestige" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsSmall)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnSmall02" Type="ClassPopulationPlanet">
@@ -429,8 +459,9 @@
   <!-- Prestige on Medium -->
   <!-- +1 PrestigeOnMedium -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnMedium00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetSizeMedium"/>
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeMedium/ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnMedium00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationPrestige" Operation="Addition"    Value="1"   Path="FAKEFORGUI/./PlanetSizeMedium"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestige" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMedium)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnMedium00" Type="ClassPopulationPlanet">
@@ -444,8 +475,9 @@
 
   <!-- +2 PrestigeOnMedium -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnMedium01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetSizeMedium"/>
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeMedium/ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnMedium01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationPrestige" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetSizeMedium"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestige" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMedium)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnMedium01" Type="ClassPopulationPlanet">
@@ -455,8 +487,9 @@
 
   <!-- +3 PrestigeOnMedium -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnMedium02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetSizeMedium"/>
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeMedium/ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnMedium02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationPrestige" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetSizeMedium"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestige" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMedium)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnMedium02" Type="ClassPopulationPlanet">
@@ -471,8 +504,9 @@
   <!-- Prestige on Large -->
   <!-- +1 PrestigeOnLarge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnLarge00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetSizeLarge"/>
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeLarge/ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnLarge00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationPrestige" Operation="Addition"    Value="1"   Path="FAKEFORGUI/./PlanetSizeLarge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestige" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsLarge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnLarge00" Type="ClassPopulationPlanet">
@@ -486,8 +520,9 @@
 
   <!-- +2 PrestigeOnLarge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnLarge01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetSizeLarge"/>
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeLarge/ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnLarge01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationPrestige" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetSizeLarge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestige" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsLarge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnLarge01" Type="ClassPopulationPlanet">
@@ -497,8 +532,9 @@
 
   <!-- +3 PrestigeOnLarge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnLarge02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetSizeLarge"/>
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeLarge/ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnLarge02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationPrestige" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetSizeLarge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestige" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsLarge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnLarge02" Type="ClassPopulationPlanet">
@@ -513,8 +549,9 @@
   <!-- Prestige on Huge -->
   <!-- +1 PrestigeOnHuge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnHuge00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetSizeHuge"/>
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeHuge/ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnHuge00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationPrestige" Operation="Addition"    Value="1"   Path="FAKEFORGUI/./PlanetSizeHuge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestige" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHuge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnHuge00" Type="ClassPopulationPlanet">
@@ -528,8 +565,9 @@
 
   <!-- +2 PrestigeOnHuge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnHuge01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetSizeHuge"/>
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeHuge/ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnHuge01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationPrestige" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetSizeHuge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestige" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHuge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnHuge01" Type="ClassPopulationPlanet">
@@ -539,8 +577,9 @@
 
   <!-- +3 PrestigeOnHuge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnHuge02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetSizeHuge"/>
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeHuge/ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnHuge02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationPrestige" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetSizeHuge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestige" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHuge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnHuge02" Type="ClassPopulationPlanet">
@@ -553,10 +592,11 @@
   </SimulationDescriptor>
 
   <!-- Prestige on Strategic -->
-  <!-- +1 PrestigeOnStrategic -->
+  <!-- +2 PrestigeOnStrategic -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnStrategic00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetHasDepositStrategic"/>
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet,PlanetHasDepositStrategic/ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnStrategic00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationPrestige" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetHasDepositStrategic"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestige" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetHasStrategicDeposit)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnStrategic00" Type="ClassPopulationPlanet">
@@ -571,8 +611,9 @@
   <!-- Prestige on Luxury -->
   <!-- +1 PrestigeOnLuxury -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnLuxury00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetHasDepositLuxury"/>
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet,PlanetHasDepositLuxury/ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnLuxury00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationPrestige" Operation="Addition"    Value="1"   Path="FAKEFORGUI/./PlanetHasDepositLuxury"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestige" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetHasLuxuryDeposit)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnLuxury00" Type="ClassPopulationPlanet">
@@ -587,8 +628,9 @@
   <!-- Prestige on Anomaly -->
   <!-- +3 PrestigeOnAnomaly -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnAnomaly00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetAnomaly"/>
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetAnomaly/ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnAnomaly00,ClassPopulation" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationPrestige" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetAnomaly"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestige" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetHasAnomaly)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigeOnAnomaly00" Type="ClassPopulationPlanet">
@@ -603,7 +645,8 @@
   <!-- Prestige per Minor Faction -->
   <!-- +2 PrestigePerMinorFaction -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigePerMinorFaction00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigePerMinorFaction00,ClassPopulation"/>
+	<Modifier       TargetProperty="BonusPopulationPrestige" Operation="Addition"    Value="1"   Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationPrestige" Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigePerMinorFaction00" Type="ClassPopulationPlanet">
@@ -616,7 +659,8 @@
   <!-- Prestige per Backdoor -->
   <!-- +2 PrestigePerBackdoor -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomPrestigePerBackdoor00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigePerBackdoor00,ClassPopulation"/>
+	<Modifier       TargetProperty="BonusPopulationPrestige" Operation="Addition"    Value="1"   Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationPrestige" Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomPrestigePerBackdoor00" Type="ClassPopulationPlanet">
@@ -629,8 +673,9 @@
 
   <!-- Prestige per Temple -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitPrimaryCustomPrestigePerTemple00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationPrestige"          Operation="Addition"    Value="1"       Path="FAKEFORGUI/./PlanetWithTemple"/>
-    <Modifier TargetProperty="BonusPopulationPrestige"          Operation="Addition"    Value="1"       Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimaryCustomPrestigePerTemple00,ClassPopulation" TooltipHidden="true" />
+    <Modifier       TargetProperty="BonusPopulationPrestige" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetWithTemple"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue0"	 Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestige" Operation="Addition"    Left="$(PopulationAuxValue0)"    BinaryOperation="Multiplication" Right="$(PlanetHasTemple)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitPrimaryCustomPrestigePerTemple00" Type="ClassPopulationPlanet">
@@ -638,9 +683,11 @@
     <BinaryModifier     TargetProperty="BonusPopulationPrestige"    Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PlanetHasTemple)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +1 PrestigeLevel-->
+  <!-- +1 Prestige per System Level -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitPrimaryCustomPrestigeLevel00" Type="WithPopulationPlanet">
-    <BinaryModifier TargetProperty="BonusPopulationPrestige" Operation="Addition" Left="1" BinaryOperation="Multiplication" Right="$(PopulationSystemLevel)"  Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimaryCustomPrestigeLevel00,ClassPopulation" TooltipHidden="true" SearchValueFromPath="true"/>
+    <Modifier       TargetProperty="BonusPopulationPrestige"    Operation="Addition"    Value="1"   Path="FAKEFORGUI./SystemLevel"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestige"    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PopulationSystemLevel)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitPrimaryCustomPrestigeLevel00" Type="ClassPopulationPlanet">

--- a/Endless Space Competitive Mod/Simulation/Traits/SimulationDescriptors[6_Happiness].xml
+++ b/Endless Space Competitive Mod/Simulation/Traits/SimulationDescriptors[6_Happiness].xml
@@ -3,81 +3,87 @@
 <!-- Primary -->
 <!-- Happiness -->
 <!-- +2 Happiness / +30 System manpower capacity-->
-<SimulationDescriptor Type="WithPopulationPlanet" Name="WithPopulationPlanetModifiersTraitPrimaryCustomHappiness00">
-<Modifier Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimaryCustomHappiness00,ClassPopulation" Value="2" Operation="Addition" TargetProperty="BonusPopulationHappiness"/>
-<Modifier Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimaryCustomHappiness00,ClassPopulation" Value="30" Operation="Addition" TargetProperty="BonusPopulationDefenseHissho"/>
-</SimulationDescriptor>
+  <SimulationDescriptor Type="WithPopulationPlanet" Name="WithPopulationPlanetModifiersTraitPrimaryCustomHappiness00">
+	<Modifier       TargetProperty="BonusPopulationHappiness"        Operation="Addition"    Value="2"   Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationHappiness"        Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+	<Modifier       TargetProperty="BonusPopulationDefenseHissho"    Operation="Addition"    Value="30"  Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationDefenseHissho"    Operation="Addition"    Left="30"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+  </SimulationDescriptor>
 
-<SimulationDescriptor Type="ClassPopulationPlanet" Name="ClassPopulationPlanetModifiersTraitPrimaryCustomHappiness00">
-<Modifier Path="ClassPopulation" Value="2" Operation="Addition" TargetProperty="BonusPopulationHappiness"/>
-<Modifier Path="ClassPopulation" Value="30" Operation="Addition" TargetProperty="BonusPopulationDefenseHissho"/>
-</SimulationDescriptor>
+  <SimulationDescriptor Type="ClassPopulationPlanet" Name="ClassPopulationPlanetModifiersTraitPrimaryCustomHappiness00">
+    <Modifier Path="ClassPopulation" Value="2" Operation="Addition" TargetProperty="BonusPopulationHappiness"/>
+    <Modifier Path="ClassPopulation" Value="30" Operation="Addition" TargetProperty="BonusPopulationDefenseHissho"/>
+  </SimulationDescriptor>
 
-<SimulationDescriptor Type="ClassPopulationAssimilated" Name="ClassPopulationAssimilatedPrimaryCustomHappiness00">
-<Modifier Path="ClassPopulation" Value="2" Operation="Addition" TargetProperty="BonusPopulationHappiness"/>
-</SimulationDescriptor>
+  <SimulationDescriptor Type="ClassPopulationAssimilated" Name="ClassPopulationAssimilatedPrimaryCustomHappiness00">
+    <Modifier Path="ClassPopulation" Value="2" Operation="Addition" TargetProperty="BonusPopulationHappiness"/>
+  </SimulationDescriptor>
 
 <!-- +2 Happiness / +1 Influence-->
-<SimulationDescriptor Type="WithPopulationPlanet" Name="WithPopulationPlanetModifiersTraitPrimaryCustomHappinessPrestige00">
-<Modifier Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimaryCustomHappiness00,ClassPopulation" Value="2" Operation="Addition" TargetProperty="BonusPopulationHappiness"/>
-<Modifier Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimaryCustomHappiness00,ClassPopulation" Value="1" Operation="Addition" TargetProperty="BonusPopulationPrestigeHissho"/>
-</SimulationDescriptor>
+  <SimulationDescriptor Type="WithPopulationPlanet" Name="WithPopulationPlanetModifiersTraitPrimaryCustomHappinessPrestige00">
+	<Modifier       TargetProperty="BonusPopulationHappiness"        Operation="Addition"    Value="2"   Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationHappiness"        Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+	<Modifier       TargetProperty="BonusPopulationPrestigeHissho"   Operation="Addition"    Value="1"   Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationPrestigeHissho"   Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+  </SimulationDescriptor>
 
-<SimulationDescriptor Type="ClassPopulationPlanet" Name="ClassPopulationPlanetModifiersTraitPrimaryCustomHappinessPrestige00">
-<Modifier Path="ClassPopulation" Value="2" Operation="Addition" TargetProperty="BonusPopulationHappiness"/>
-<Modifier Path="ClassPopulation" Value="1" Operation="Addition" TargetProperty="BonusPopulationPrestigeHissho"/>
-</SimulationDescriptor>
+  <SimulationDescriptor Type="ClassPopulationPlanet" Name="ClassPopulationPlanetModifiersTraitPrimaryCustomHappinessPrestige00">
+    <Modifier Path="ClassPopulation" Value="2" Operation="Addition" TargetProperty="BonusPopulationHappiness"/>
+    <Modifier Path="ClassPopulation" Value="1" Operation="Addition" TargetProperty="BonusPopulationPrestigeHissho"/>
+  </SimulationDescriptor>
 
-<SimulationDescriptor Type="ClassPopulationAssimilated" Name="ClassPopulationAssimilatedPrimaryCustomHappinessPrestige00">
-<Modifier Path="ClassPopulation" Value="2" Operation="Addition" TargetProperty="BonusPopulationHappiness"/>
-</SimulationDescriptor>
+  <SimulationDescriptor Type="ClassPopulationAssimilated" Name="ClassPopulationAssimilatedPrimaryCustomHappinessPrestige00">
+    <Modifier Path="ClassPopulation" Value="2" Operation="Addition" TargetProperty="BonusPopulationHappiness"/>
+  </SimulationDescriptor>
 
 <!-- +3 Happiness / +3 Science-->
-<SimulationDescriptor Type="WithPopulationPlanet" Name="WithPopulationPlanetModifiersTraitPrimaryCustomHappinessPrestige005">
-<Modifier Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimaryCustomHappiness00,ClassPopulation" Value="3" Operation="Addition" TargetProperty="BonusPopulationHappiness"/>
-<Modifier Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimaryCustomHappiness00,ClassPopulation" Value="3" Operation="Addition" TargetProperty="BonusPopulationScienceHissho"/>
-</SimulationDescriptor>
+  <SimulationDescriptor Type="WithPopulationPlanet" Name="WithPopulationPlanetModifiersTraitPrimaryCustomHappinessPrestige005">
+	<Modifier       TargetProperty="BonusPopulationHappiness"        Operation="Addition"    Value="3"   Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationHappiness"        Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+	<Modifier       TargetProperty="BonusPopulationScienceHissho"    Operation="Addition"    Value="3"   Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationScienceHissho"    Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+  </SimulationDescriptor>
 
-<SimulationDescriptor Type="ClassPopulationPlanet" Name="ClassPopulationPlanetModifiersTraitPrimaryCustomHappinessPrestige005">
-<Modifier Path="ClassPopulation" Value="3" Operation="Addition" TargetProperty="BonusPopulationHappiness"/>
-<Modifier Path="ClassPopulation" Value="3" Operation="Addition" TargetProperty="BonusPopulationScienceHissho"/>
-</SimulationDescriptor>
+  <SimulationDescriptor Type="ClassPopulationPlanet" Name="ClassPopulationPlanetModifiersTraitPrimaryCustomHappinessPrestige005">
+    <Modifier Path="ClassPopulation" Value="3" Operation="Addition" TargetProperty="BonusPopulationHappiness"/>
+    <Modifier Path="ClassPopulation" Value="3" Operation="Addition" TargetProperty="BonusPopulationScienceHissho"/>
+  </SimulationDescriptor>
 
 <SimulationDescriptor Type="ClassPopulationAssimilated" Name="ClassPopulationAssimilatedPrimaryCustomHappinessPrestige005">
-<Modifier Path="ClassPopulation" Value="3" Operation="Addition" TargetProperty="BonusPopulationHappiness"/>
+    <Modifier Path="ClassPopulation" Value="3" Operation="Addition" TargetProperty="BonusPopulationHappiness"/>
 </SimulationDescriptor>
 
 <!-- +4 Happiness -->
--<SimulationDescriptor Type="WithPopulationPlanet" Name="WithPopulationPlanetModifiersTraitPrimaryCustomHappiness01">
-<Modifier Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimaryCustomHappiness01,ClassPopulation" Value="4" Operation="Addition" TargetProperty="BonusPopulationHappiness"/>
-</SimulationDescriptor>
+  <SimulationDescriptor Type="WithPopulationPlanet" Name="WithPopulationPlanetModifiersTraitPrimaryCustomHappiness01">
+	<Modifier       TargetProperty="BonusPopulationHappiness"        Operation="Addition"    Value="4"   Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationHappiness"        Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+  </SimulationDescriptor>
 
-
--<SimulationDescriptor Type="ClassPopulationPlanet" Name="ClassPopulationPlanetModifiersTraitPrimaryCustomHappiness01">
-<Modifier Path="ClassPopulation" Value="4" Operation="Addition" TargetProperty="BonusPopulationHappiness"/>
-</SimulationDescriptor>
+  <SimulationDescriptor Type="ClassPopulationPlanet" Name="ClassPopulationPlanetModifiersTraitPrimaryCustomHappiness01">
+    <Modifier Path="ClassPopulation" Value="4" Operation="Addition" TargetProperty="BonusPopulationHappiness"/>
+  </SimulationDescriptor>
 
 <!-- +6 Happiness -->
--<SimulationDescriptor Type="WithPopulationPlanet" Name="WithPopulationPlanetModifiersTraitPrimaryCustomHappiness02">
-<Modifier Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimaryCustomHappiness02,ClassPopulation" Value="6" Operation="Addition" TargetProperty="BonusPopulationHappiness"/>
-</SimulationDescriptor>
+  <SimulationDescriptor Type="WithPopulationPlanet" Name="WithPopulationPlanetModifiersTraitPrimaryCustomHappiness02">
+	<Modifier       TargetProperty="BonusPopulationHappiness"        Operation="Addition"    Value="6"   Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationHappiness"        Operation="Addition"    Left="6"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+  </SimulationDescriptor>
 
+  <SimulationDescriptor Type="ClassPopulationPlanet" Name="ClassPopulationPlanetModifiersTraitPrimaryCustomHappiness02">
+    <Modifier Path="ClassPopulation" Value="6" Operation="Addition" TargetProperty="BonusPopulationHappiness"/>
+  </SimulationDescriptor>
 
--<SimulationDescriptor Type="ClassPopulationPlanet" Name="ClassPopulationPlanetModifiersTraitPrimaryCustomHappiness02">
-<Modifier Path="ClassPopulation" Value="6" Operation="Addition" TargetProperty="BonusPopulationHappiness"/>
-</SimulationDescriptor>
-
-
--<SimulationDescriptor Type="ClassPopulationAssimilated" Name="ClassPopulationAssimilatedPrimaryCustomHappiness02">
-<Modifier Path="ClassPopulation" Value="3" Operation="Addition" TargetProperty="BonusPopulationHappiness"/>
-</SimulationDescriptor>
+  <SimulationDescriptor Type="ClassPopulationAssimilated" Name="ClassPopulationAssimilatedPrimaryCustomHappiness02">
+    <Modifier Path="ClassPopulation" Value="3" Operation="Addition" TargetProperty="BonusPopulationHappiness"/>
+  </SimulationDescriptor>
 
   <!-- Secondary -->
   <!-- Happiness on Cold -->
   <!-- +1 HappinessOnCold -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnCold00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeCold/ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnCold00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="1"   Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsCold)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnCold00" Type="ClassPopulationPlanet">
@@ -91,8 +97,9 @@
 
   <!-- +2 HappinessOnCold -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnCold01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeCold/ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnCold01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsCold)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnCold01" Type="ClassPopulationPlanet">
@@ -102,8 +109,9 @@
 
   <!-- +3 HappinessOnCold -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnCold02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeCold/ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnCold02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsCold)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnCold02" Type="ClassPopulationPlanet">
@@ -117,8 +125,9 @@
 
   <!-- +4 HappinessOnCold -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnCold03" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="4" Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="4" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeCold/ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnCold03" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="4"   Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsCold)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnCold03" Type="ClassPopulationPlanet">
@@ -128,8 +137,9 @@
 
   <!-- +5 HappinessOnCold -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnCold04" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeCold/ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnCold04" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="5"   Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsCold)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnCold04" Type="ClassPopulationPlanet">
@@ -144,8 +154,9 @@
   <!-- Happiness on Temperate -->
   <!-- +1 HappinessOnTemperate -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTemperate00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTemperate/ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTemperate00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="1"   Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTemperate)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTemperate00" Type="ClassPopulationPlanet">
@@ -159,8 +170,9 @@
 
   <!-- +2 HappinessOnTemperate -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTemperate01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTemperate/ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTemperate01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTemperate)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTemperate01" Type="ClassPopulationPlanet">
@@ -170,8 +182,9 @@
 
   <!-- +3 HappinessOnTemperate -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTemperate02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTemperate/ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTemperate02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTemperate)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTemperate02" Type="ClassPopulationPlanet">
@@ -185,8 +198,9 @@
 
   <!-- +4 HappinessOnTemperate -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTemperate03" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="4" Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="4" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTemperate/ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTemperate03" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="4"   Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTemperate)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTemperate03" Type="ClassPopulationPlanet">
@@ -196,8 +210,9 @@
 
   <!-- +5 HappinessOnTemperate -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTemperate04" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTemperate/ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTemperate04" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="5"   Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTemperate)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTemperate04" Type="ClassPopulationPlanet">
@@ -212,8 +227,9 @@
   <!-- Happiness on Hot -->
   <!-- +1 HappinessOnHot -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHot00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeHot/ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHot00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="1"   Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHot)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHot00" Type="ClassPopulationPlanet">
@@ -227,10 +243,12 @@
 
   <!-- +2 HappinessOnHot / +2 Influence on hot-->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHot01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeHot/ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHot01" TooltipHidden="true"/>
-    <Modifier TargetProperty="BonusPopulationPrestigeHissho" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
-    <Modifier TargetProperty="BonusPopulationPrestigeHissho" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeHot/ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHot01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationHappiness"       Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"			Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationPrestigeHissho"  Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue2"			Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationHappiness"       Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHot)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestigeHissho"  Operation="Addition"    Left="$(PopulationAuxValue2)"    BinaryOperation="Multiplication" Right="$(PlanetIsHot)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHot01" Type="ClassPopulationPlanet">
@@ -242,8 +260,9 @@
 
   <!-- +3 HappinessOnHot -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHot02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeHot/ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHot02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHot)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHot02" Type="ClassPopulationPlanet">
@@ -257,8 +276,9 @@
 
   <!-- +4 HappinessOnHot -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHot03" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="4" Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="4" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeHot/ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHot03" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="4"   Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHot)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHot03" Type="ClassPopulationPlanet">
@@ -268,8 +288,9 @@
 
   <!-- +5 HappinessOnHot -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHot04" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeHot/ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHot04" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="5"   Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHot)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHot04" Type="ClassPopulationPlanet">
@@ -284,8 +305,9 @@
   <!-- Happiness on Teeming -->
   <!-- +1 HappinessOnTeeming -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTeeming00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTeeming/ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTeeming00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="1"   Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTeeming00" Type="ClassPopulationPlanet">
@@ -299,8 +321,9 @@
 
   <!-- +2 HappinessOnTeeming -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTeeming01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTeeming/ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTeeming01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTeeming01" Type="ClassPopulationPlanet">
@@ -310,8 +333,9 @@
 
   <!-- +3 HappinessOnTeeming -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTeeming02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTeeming/ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTeeming02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTeeming02" Type="ClassPopulationPlanet">
@@ -325,10 +349,12 @@
 
   <!-- +4 HappinessOnTeeming / +60 System manpower capacity on fertile-->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTeeming03" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="4" Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="4" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTeeming/ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTeeming03" TooltipHidden="true"/>
-    <Modifier TargetProperty="BonusPopulationDefenseHissho" Operation="Addition" Value="60" Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
-    <Modifier TargetProperty="BonusPopulationDefenseHissho" Operation="Addition" Value="60" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTeeming/ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTeeming03" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationHappiness"       Operation="Addition"    Value="4"   Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
+    <Modifier       TargetProperty="BonusPopulationDefenseHissho"   Operation="Addition"    Value="60"  Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"			Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue2"			Operation="Addition"    Left="60"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationHappiness"       Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDefenseHissho"   Operation="Addition"    Left="$(PopulationAuxValue2)"   BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTeeming03" Type="ClassPopulationPlanet">
@@ -344,8 +370,9 @@
   
   <!-- +5 HappinessOnTeeming -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTeeming04" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTeeming/ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTeeming04" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="5"   Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTeeming04" Type="ClassPopulationPlanet">
@@ -360,8 +387,9 @@
   <!-- Happiness on Meager -->
   <!-- +1 HappinessOnMeager -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnMeager00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeMeager/ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnMeager00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="1"   Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMeager)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnMeager00" Type="ClassPopulationPlanet">
@@ -375,10 +403,12 @@
 
   <!-- +2 HappinessOnMeager / +30 System manpower capacity-->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnMeager01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeMeager/ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnMeager01" TooltipHidden="true"/>
-    <Modifier TargetProperty="BonusPopulationDefenseHissho" Operation="Addition" Value="30" Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
-    <Modifier TargetProperty="BonusPopulationDefenseHissho" Operation="Addition" Value="30" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeMeager/ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnMeager01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationHappiness"       Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
+    <Modifier       TargetProperty="BonusPopulationDefenseHissho"   Operation="Addition"    Value="30"  Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"			Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue2"			Operation="Addition"    Left="30"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationHappiness"       Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDefenseHissho"   Operation="Addition"    Left="$(PopulationAuxValue2)"   BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnMeager01" Type="ClassPopulationPlanet">
@@ -394,10 +424,12 @@
   
   <!-- +2 HappinessOnMeager / +2 food-->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessFoodOnMeager01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeMeager/ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnMeager01" TooltipHidden="true"/>
-     <Modifier TargetProperty="BonusPopulationFoodHissho" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
-    <Modifier TargetProperty="BonusPopulationFoodHissho" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeMeager/ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnMeager01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationHappiness"       Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
+    <Modifier       TargetProperty="BonusPopulationFoodHissho"      Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"			Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue2"			Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationHappiness"       Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFoodHissho"      Operation="Addition"    Left="$(PopulationAuxValue2)"   BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessFoodOnMeager01" Type="ClassPopulationPlanet">
@@ -413,8 +445,9 @@
   
   <!-- +3 HappinessOnMeager -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnMeager02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeMeager/ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnMeager02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMeager)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnMeager02" Type="ClassPopulationPlanet">
@@ -428,8 +461,9 @@
 
   <!-- +4 HappinessOnMeager -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnMeager03" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="4" Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="4" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeMeager/ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnMeager03" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="4"   Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMeager)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnMeager03" Type="ClassPopulationPlanet">
@@ -439,8 +473,9 @@
 
   <!-- +5 HappinessOnMeager -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnMeager04" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeMeager/ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnMeager04" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="5"   Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMeager)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnMeager04" Type="ClassPopulationPlanet">
@@ -453,10 +488,11 @@
   </SimulationDescriptor>
 
   <!-- Happiness on Gas -->
-  <!-- +1 HappinessOnGas -->
+  <!-- +3 HappinessOnGas -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnGas00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeGas/ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnGas00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsGas)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnGas00" Type="ClassPopulationPlanet">
@@ -468,10 +504,11 @@
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="1" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +2 HappinessOnGas -->
+  <!-- +5 HappinessOnGas -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnGas01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeGas/ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnGas01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="5"   Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsGas)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnGas01" Type="ClassPopulationPlanet">
@@ -479,10 +516,11 @@
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="5" BinaryOperation="Multiplication" Right="$(PlanetIsGas)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +3 HappinessOnGas -->
+  <!-- +10 HappinessOnGas -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnGas02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="10" Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="10" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeGas/ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnGas02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="10"  Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="10"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsGas)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnGas02" Type="ClassPopulationPlanet">
@@ -494,10 +532,11 @@
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="3" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +4 HappinessOnGas -->
+  <!-- +12 HappinessOnGas -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnGas03" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="12" Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="12" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeGas/ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnGas03" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="12"  Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="12"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsGas)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnGas03" Type="ClassPopulationPlanet">
@@ -505,10 +544,11 @@
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="12" BinaryOperation="Multiplication" Right="$(PlanetIsGas)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +5 HappinessOnGas -->
+  <!-- +15 HappinessOnGas -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnGas04" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="15" Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="15" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeGas/ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnGas04" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="15"  Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="15"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsGas)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnGas04" Type="ClassPopulationPlanet">
@@ -523,9 +563,10 @@
   <!-- Happiness on Happy -->
   <!-- +1 HappinessOnHappy -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHappy00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="1" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="1" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
-    <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="1" BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)"  Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHappy00" TooltipHidden="true" SearchValueFromPath="true"/>
+    <Modifier		TargetProperty="BonusPopulationHappiness"		Operation="Addition" Value="1" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
+    <Modifier		TargetProperty="BonusPopulationHappiness"		Operation="Addition" Value="1" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"			Operation="Addition" Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationHappiness"		Operation="Addition" Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHappy00" Type="ClassPopulationPlanet">
@@ -540,9 +581,10 @@
 
   <!-- +2 HappinessOnHappy -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHappy01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="2" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="2" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
-    <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="2" BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHappy01" TooltipHidden="true" SearchValueFromPath="true"/>
+    <Modifier		TargetProperty="BonusPopulationHappiness"		Operation="Addition" Value="2" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
+    <Modifier		TargetProperty="BonusPopulationHappiness"		Operation="Addition" Value="2" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"			Operation="Addition" Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationHappiness"		Operation="Addition" Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHappy01" Type="ClassPopulationPlanet">
@@ -553,9 +595,10 @@
 
   <!-- +3 HappinessOnHappy -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHappy02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="3" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="3" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
-    <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="3" BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHappy02" TooltipHidden="true" SearchValueFromPath="true"/>
+    <Modifier		TargetProperty="BonusPopulationHappiness"		Operation="Addition" Value="3" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
+    <Modifier		TargetProperty="BonusPopulationHappiness"		Operation="Addition" Value="3" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"			Operation="Addition" Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationHappiness"		Operation="Addition" Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHappy02" Type="ClassPopulationPlanet">
@@ -570,9 +613,10 @@
 
   <!-- +4 HappinessOnHappy -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHappy03" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="4" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="4" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
-    <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="4" BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHappy03" TooltipHidden="true" SearchValueFromPath="true"/>
+    <Modifier		TargetProperty="BonusPopulationHappiness"		Operation="Addition" Value="4" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
+    <Modifier		TargetProperty="BonusPopulationHappiness"		Operation="Addition" Value="4" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"			Operation="Addition" Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationHappiness"		Operation="Addition" Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHappy03" Type="ClassPopulationPlanet">
@@ -583,9 +627,10 @@
 
   <!-- +5 HappinessOnHappy -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHappy04" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="5" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="5" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
-    <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="5" BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHappy04" TooltipHidden="true" SearchValueFromPath="true"/>
+    <Modifier		TargetProperty="BonusPopulationHappiness"		Operation="Addition" Value="5" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
+    <Modifier		TargetProperty="BonusPopulationHappiness"		Operation="Addition" Value="5" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"			Operation="Addition" Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationHappiness"		Operation="Addition" Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHappy04" Type="ClassPopulationPlanet">
@@ -601,8 +646,9 @@
   <!-- Happiness on Tiny -->
   <!-- +1 HappinessOnTiny -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTiny00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetSizeTiny"/>
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeTiny/ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTiny00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="1"   Path="FAKEFORGUI/./PlanetSizeTiny"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTiny)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTiny00" Type="ClassPopulationPlanet">
@@ -616,8 +662,9 @@
 
   <!-- +2 HappinessOnTiny -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTiny01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetSizeTiny"/>
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeTiny/ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTiny01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetSizeTiny"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTiny)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTiny01" Type="ClassPopulationPlanet">
@@ -627,8 +674,9 @@
 
   <!-- +3 HappinessOnTiny -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTiny02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetSizeTiny"/>
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeTiny/ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTiny02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetSizeTiny"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTiny)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTiny02" Type="ClassPopulationPlanet">
@@ -642,8 +690,9 @@
 
   <!-- +4 HappinessOnTiny -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTiny03" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="4" Path="FAKEFORGUI/./PlanetSizeTiny"/>
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="4" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeTiny/ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTiny03" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="4"   Path="FAKEFORGUI/./PlanetSizeTiny"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTiny)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTiny03" Type="ClassPopulationPlanet">
@@ -653,8 +702,9 @@
 
   <!-- +5 HappinessOnTiny -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTiny04" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetSizeTiny"/>
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeTiny/ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTiny04" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="5"   Path="FAKEFORGUI/./PlanetSizeTiny"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTiny)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTiny04" Type="ClassPopulationPlanet">
@@ -669,8 +719,9 @@
   <!-- Happiness on Small -->
   <!-- +1 HappinessOnSmall -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnSmall00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetSizeSmall"/>
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeSmall/ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnSmall00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="1"   Path="FAKEFORGUI/./PlanetSizeSmall"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsSmall)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnSmall00" Type="ClassPopulationPlanet">
@@ -684,8 +735,9 @@
 
   <!-- +2 HappinessOnSmall -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnSmall01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetSizeSmall"/>
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeSmall/ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnSmall01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetSizeSmall"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsSmall)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnSmall01" Type="ClassPopulationPlanet">
@@ -695,8 +747,9 @@
 
   <!-- +3 HappinessOnSmall -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnSmall02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetSizeSmall"/>
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeSmall/ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnSmall02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetSizeSmall"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsSmall)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnSmall02" Type="ClassPopulationPlanet">
@@ -710,8 +763,9 @@
 
   <!-- +4 HappinessOnSmall -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnSmall03" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="4" Path="FAKEFORGUI/./PlanetSizeSmall"/>
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="4" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeSmall/ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnSmall03" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="4"   Path="FAKEFORGUI/./PlanetSizeSmall"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsSmall)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnSmall03" Type="ClassPopulationPlanet">
@@ -721,8 +775,9 @@
 
   <!-- +5 HappinessOnSmall -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnSmall04" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetSizeSmall"/>
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeSmall/ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnSmall04" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="5"   Path="FAKEFORGUI/./PlanetSizeSmall"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsSmall)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnSmall04" Type="ClassPopulationPlanet">
@@ -737,8 +792,9 @@
   <!-- Happiness on Medium -->
   <!-- +1 HappinessOnMedium -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnMedium00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetSizeMedium"/>
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeMedium/ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnMedium00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="1"   Path="FAKEFORGUI/./PlanetSizeMedium"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMedium)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnMedium00" Type="ClassPopulationPlanet">
@@ -752,8 +808,9 @@
 
   <!-- +2 HappinessOnMedium -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnMedium01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetSizeMedium"/>
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeMedium/ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnMedium01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetSizeMedium"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMedium)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnMedium01" Type="ClassPopulationPlanet">
@@ -763,8 +820,9 @@
 
   <!-- +3 HappinessOnMedium -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnMedium02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetSizeMedium"/>
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeMedium/ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnMedium02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetSizeMedium"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMedium)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnMedium02" Type="ClassPopulationPlanet">
@@ -778,8 +836,9 @@
 
   <!-- +4 HappinessOnMedium -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnMedium03" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="4" Path="FAKEFORGUI/./PlanetSizeMedium"/>
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="4" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeMedium/ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnMedium03" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="4"   Path="FAKEFORGUI/./PlanetSizeMedium"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMedium)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnMedium03" Type="ClassPopulationPlanet">
@@ -789,8 +848,9 @@
 
   <!-- +5 HappinessOnMedium -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnMedium04" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetSizeMedium"/>
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeMedium/ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnMedium04" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="5"   Path="FAKEFORGUI/./PlanetSizeMedium"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMedium)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnMedium04" Type="ClassPopulationPlanet">
@@ -805,8 +865,9 @@
   <!-- Happiness on Large -->
   <!-- +1 HappinessOnLarge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnLarge00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetSizeLarge"/>
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeLarge/ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnLarge00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="1"   Path="FAKEFORGUI/./PlanetSizeLarge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsLarge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnLarge00" Type="ClassPopulationPlanet">
@@ -820,8 +881,9 @@
 
   <!-- +2 HappinessOnLarge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnLarge01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetSizeLarge"/>
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeLarge/ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnLarge01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetSizeLarge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsLarge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnLarge01" Type="ClassPopulationPlanet">
@@ -831,8 +893,9 @@
 
   <!-- +3 HappinessOnLarge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnLarge02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetSizeLarge"/>
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeLarge/ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnLarge02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetSizeLarge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsLarge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnLarge02" Type="ClassPopulationPlanet">
@@ -846,8 +909,9 @@
 
   <!-- +4 HappinessOnLarge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnLarge03" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="4" Path="FAKEFORGUI/./PlanetSizeLarge"/>
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="4" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeLarge/ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnLarge03" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="4"   Path="FAKEFORGUI/./PlanetSizeLarge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsLarge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnLarge03" Type="ClassPopulationPlanet">
@@ -857,8 +921,9 @@
 
   <!-- +5 HappinessOnLarge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnLarge04" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetSizeLarge"/>
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeLarge/ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnLarge04" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="5"   Path="FAKEFORGUI/./PlanetSizeLarge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsLarge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnLarge04" Type="ClassPopulationPlanet">
@@ -873,8 +938,9 @@
   <!-- Happiness on Huge -->
   <!-- +1 HappinessOnHuge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHuge00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetSizeHuge"/>
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeHuge/ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHuge00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="1"   Path="FAKEFORGUI/./PlanetSizeHuge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHuge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHuge00" Type="ClassPopulationPlanet">
@@ -888,8 +954,9 @@
 
   <!-- +2 HappinessOnHuge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHuge01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetSizeHuge"/>
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeHuge/ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHuge01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetSizeHuge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHuge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHuge01" Type="ClassPopulationPlanet">
@@ -899,8 +966,9 @@
 
   <!-- +3 HappinessOnHuge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHuge02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetSizeHuge"/>
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeHuge/ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHuge02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetSizeHuge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHuge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHuge02" Type="ClassPopulationPlanet">
@@ -914,8 +982,9 @@
 
   <!-- +4 HappinessOnHuge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHuge03" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="4" Path="FAKEFORGUI/./PlanetSizeHuge"/>
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="4" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeHuge/ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHuge03" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="4"   Path="FAKEFORGUI/./PlanetSizeHuge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHuge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHuge03" Type="ClassPopulationPlanet">
@@ -925,8 +994,9 @@
 
   <!-- +5 HappinessOnHuge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHuge04" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetSizeHuge"/>
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeHuge/ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHuge04" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="5"   Path="FAKEFORGUI/./PlanetSizeHuge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHuge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHuge04" Type="ClassPopulationPlanet">
@@ -941,8 +1011,9 @@
   <!-- Happiness on Strategic -->
   <!-- +2 HappinessOnStrategic -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnStrategic00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetHasDepositStrategic"/>
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet,PlanetHasDepositStrategic/ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnStrategic00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetHasDepositStrategic"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetHasStrategicDeposit)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnStrategic00" Type="ClassPopulationPlanet">
@@ -957,8 +1028,9 @@
   <!-- Happiness on Luxury -->
   <!-- +2 HappinessOnLuxury -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnLuxury00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetHasDepositLuxury"/>
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet,PlanetHasDepositLuxury/ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnLuxury00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetHasDepositLuxury"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetHasLuxuryDeposit)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnLuxury00" Type="ClassPopulationPlanet">
@@ -973,8 +1045,9 @@
   <!-- Happiness on Anomaly -->
   <!-- +5 HappinessOnAnomaly -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnAnomaly00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetAnomaly"/>
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetAnomaly/ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnAnomaly00,ClassPopulation" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="5"   Path="FAKEFORGUI/./PlanetAnomaly"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetHasAnomaly)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnAnomaly00" Type="ClassPopulationPlanet">
@@ -989,7 +1062,8 @@
   <!-- Happiness per Minor Faction -->
   <!-- +1 HappinessPerMinorFaction -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessPerMinorFaction00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessPerMinorFaction00,ClassPopulation"/>
+	<Modifier       TargetProperty="BonusPopulationHappiness"        Operation="Addition"    Value="3"   Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationHappiness"        Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessPerMinorFaction00" Type="ClassPopulationPlanet">
@@ -1002,7 +1076,8 @@
   <!-- Happiness per Backdoor -->
   <!-- +1 HappinessPerBackdoor -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessPerBackdoor00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessPerBackdoor00,ClassPopulation"/>
+	<Modifier       TargetProperty="BonusPopulationHappiness"        Operation="Addition"    Value="2"   Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationHappiness"        Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessPerBackdoor00" Type="ClassPopulationPlanet">
@@ -1015,8 +1090,9 @@
 
   <!-- Happiness per Temple -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitPrimaryCustomHappinessPerTemple00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationHappiness"          Operation="Addition"    Value="3"       Path="FAKEFORGUI/./PlanetWithTemple"/>
-    <Modifier TargetProperty="BonusPopulationHappiness"          Operation="Addition"    Value="3"       Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimaryCustomHappinessPerTemple00,ClassPopulation" TooltipHidden="true" />
+    <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetWithTemple"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue0"	  Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue0)"    BinaryOperation="Multiplication" Right="$(PlanetHasTemple)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitPrimaryCustomHappinessPerTemple00" Type="ClassPopulationPlanet">
@@ -1024,9 +1100,11 @@
     <BinaryModifier     TargetProperty="BonusPopulationHappiness"    Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PlanetHasTemple)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +1 HappinessLevel-->
+  <!-- +1 Happiness per System Level -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitPrimaryCustomHappinessLevel00" Type="WithPopulationPlanet">
-    <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="3" BinaryOperation="Multiplication" Right="$(PopulationSystemLevel)"  Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimaryCustomHappinessLevel00,ClassPopulation" TooltipHidden="true" SearchValueFromPath="true"/>
+    <Modifier       TargetProperty="BonusPopulationHappiness"   Operation="Addition"    Value="3"   Path="FAKEFORGUI./SystemLevel"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationHappiness"   Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PopulationSystemLevel)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitPrimaryCustomHappinessLevel00" Type="ClassPopulationPlanet">

--- a/Endless Space Competitive Mod/Simulation/Traits/SimulationDescriptors[7_Military].xml
+++ b/Endless Space Competitive Mod/Simulation/Traits/SimulationDescriptors[7_Military].xml
@@ -2,9 +2,10 @@
 <Datatable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xsi:noNamespaceSchemaLocation="../../Schemas/Amplitude.Unity.Simulation.SimulationDescriptor.xsd">
   <!-- Primary -->
   <!-- EmpireManpower -->
-  <!-- +1 EmpireManpower -->
+  <!-- +3 EmpireManpower -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitPrimaryCustomEmpireManpower00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimaryCustomEmpireManpower00,ClassPopulation"/>
+	<Modifier       TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitPrimaryCustomEmpireManpower00" Type="ClassPopulationPlanet">
@@ -15,9 +16,10 @@
     <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="2" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +2 EmpireManpower -->
+  <!-- +6 EmpireManpower -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitPrimaryCustomEmpireManpower01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="6" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimaryCustomEmpireManpower01,ClassPopulation"/>
+	<Modifier       TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Value="6"   Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Left="6"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitPrimaryCustomEmpireManpower01" Type="ClassPopulationPlanet">
@@ -28,9 +30,10 @@
     <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="4" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +3 EmpireManpower -->
+  <!-- +9 EmpireManpower -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitPrimaryCustomEmpireManpower02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="9" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimaryCustomEmpireManpower02,ClassPopulation"/>
+	<Modifier       TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Value="9"   Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Left="9"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitPrimaryCustomEmpireManpower02" Type="ClassPopulationPlanet">
@@ -42,9 +45,10 @@
   </SimulationDescriptor>
 
   <!-- SystemManpower -->
-  <!-- +1 SystemManpower -->
+  <!-- +5 SystemManpower -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitPrimaryCustomSystemManpower00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimaryCustomDefense00,ClassPopulation"/>
+	<Modifier       TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Value="5"   Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitPrimaryCustomSystemManpower00" Type="ClassPopulationPlanet">
@@ -55,18 +59,20 @@
     <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="5" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +2 SystemManpower -->
+  <!-- +10 SystemManpower -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitPrimaryCustomSystemManpower01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="10" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimaryCustomDefense01,ClassPopulation"/>
+	<Modifier       TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Value="10"  Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Left="10"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitPrimaryCustomSystemManpower01" Type="ClassPopulationPlanet">
     <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="10" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +3 SystemManpower -->
+  <!-- +15 SystemManpower -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitPrimaryCustomSystemManpower02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="15" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimaryCustomDefense02,ClassPopulation"/>
+	<Modifier       TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Value="15"  Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Left="15"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitPrimaryCustomSystemManpower02" Type="ClassPopulationPlanet">
@@ -78,9 +84,10 @@
   </SimulationDescriptor>
 
   <!-- GroundBattleBombardmentAttackerDamages -->
-  <!-- +25 GroundBattleBombardmentAttackerDamages -->
+  <!-- +50 GroundBattleBombardmentAttackerDamages -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitPrimaryCustomGroundBattleBombardmentAttackerDamages00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="50" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimaryCustomGroundBattleBombardmentAttackerDamages00,ClassPopulation"/>
+	<Modifier       TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Value="50"  Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Left="50"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitPrimaryCustomGroundBattleBombardmentAttackerDamages00" Type="ClassPopulationPlanet">
@@ -91,18 +98,20 @@
     <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="50" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +50 GroundBattleBombardmentAttackerDamages -->
+  <!-- +100 GroundBattleBombardmentAttackerDamages -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitPrimaryCustomGroundBattleBombardmentAttackerDamages01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="100" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimaryCustomGroundBattleBombardmentAttackerDamages01,ClassPopulation"/>
+	<Modifier       TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Value="100"  Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Left="100"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitPrimaryCustomGroundBattleBombardmentAttackerDamages01" Type="ClassPopulationPlanet">
     <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="100" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +75 GroundBattleBombardmentAttackerDamages -->
+  <!-- +150 GroundBattleBombardmentAttackerDamages -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitPrimaryCustomGroundBattleBombardmentAttackerDamages02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="150" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimaryCustomGroundBattleBombardmentAttackerDamages02,ClassPopulation"/>
+	<Modifier       TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Value="150"  Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Left="150"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitPrimaryCustomGroundBattleBombardmentAttackerDamages02" Type="ClassPopulationPlanet">
@@ -114,9 +123,10 @@
   </SimulationDescriptor>
 
   <!-- Defense -->
-  <!-- +25 Defense -->
+  <!-- +30 Defense -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitPrimaryCustomDefense00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="30" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimaryCustomDefense00,ClassPopulation"/>
+	<Modifier       TargetProperty="BonusPopulationDefense"		 Operation="Addition"    Value="30"  Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationDefense"		 Operation="Addition"    Left="30"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitPrimaryCustomDefense00" Type="ClassPopulationPlanet">
@@ -127,18 +137,20 @@
     <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="30" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +50 Defense -->
+  <!-- +60 Defense -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitPrimaryCustomDefense01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="60" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimaryCustomDefense01,ClassPopulation"/>
+	<Modifier       TargetProperty="BonusPopulationDefense"		 Operation="Addition"    Value="60"  Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationDefense"		 Operation="Addition"    Left="60"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitPrimaryCustomDefense01" Type="ClassPopulationPlanet">
     <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="60" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +75 Defense -->
+  <!-- +90 Defense -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitPrimaryCustomDefense02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="90" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimaryCustomDefense02,ClassPopulation"/>
+	<Modifier       TargetProperty="BonusPopulationDefense"		 Operation="Addition"    Value="90"  Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationDefense"		 Operation="Addition"    Left="90"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitPrimaryCustomDefense02" Type="ClassPopulationPlanet">
@@ -151,10 +163,11 @@
 
   <!-- Secondary -->
   <!-- EmpireManpower on Cold -->
-  <!-- +2 EmpireManpowerOnCold -->
+  <!-- +3 EmpireManpowerOnCold -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnCold00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeCold/ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnCold00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"		   Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsCold)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnCold00" Type="ClassPopulationPlanet">
@@ -166,10 +179,11 @@
     <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="3" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +4 EmpireManpowerOnCold -->
+  <!-- +6 EmpireManpowerOnCold -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnCold01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="6" Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="6" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeCold/ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnCold01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Value="6"   Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"		   Operation="Addition"    Left="6"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsCold)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnCold01" Type="ClassPopulationPlanet">
@@ -177,10 +191,11 @@
     <BinaryModifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Left="6" BinaryOperation="Multiplication" Right="$(PlanetIsCold)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +6 EmpireManpowerOnCold -->
+  <!-- +9 EmpireManpowerOnCold -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnCold02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="9" Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="9" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeCold/ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnCold02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Value="9"   Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"		   Operation="Addition"    Left="9"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsCold)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnCold02" Type="ClassPopulationPlanet">
@@ -193,10 +208,11 @@
   </SimulationDescriptor>
 
   <!-- EmpireManpower on Temperate -->
-  <!-- +2 EmpireManpowerOnTemperate -->
+  <!-- +3 EmpireManpowerOnTemperate -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnTemperate00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTemperate/ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnTemperate00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"		   Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTemperate)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnTemperate00" Type="ClassPopulationPlanet">
@@ -208,10 +224,11 @@
     <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="3" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +4 EmpireManpowerOnTemperate -->
+  <!-- +6 EmpireManpowerOnTemperate -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnTemperate01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="6" Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="6" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTemperate/ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnTemperate01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Value="6"   Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"		   Operation="Addition"    Left="6"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTemperate)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnTemperate01" Type="ClassPopulationPlanet">
@@ -219,10 +236,11 @@
     <BinaryModifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Left="6" BinaryOperation="Multiplication" Right="$(PlanetIsTemperate)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +6 EmpireManpowerOnTemperate -->
+  <!-- +9 EmpireManpowerOnTemperate -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnTemperate02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="9" Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="9" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTemperate/ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnTemperate02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Value="9"   Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"		   Operation="Addition"    Left="9"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTemperate)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnTemperate02" Type="ClassPopulationPlanet">
@@ -235,10 +253,11 @@
   </SimulationDescriptor>
 
   <!-- EmpireManpower on Hot -->
-  <!-- +2 EmpireManpowerOnHot -->
+  <!-- +3 EmpireManpowerOnHot -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnHot00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeHot/ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnHot00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"		   Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHot)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnHot00" Type="ClassPopulationPlanet">
@@ -250,10 +269,11 @@
     <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="3" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +4 EmpireManpowerOnHot -->
+  <!-- +6 EmpireManpowerOnHot -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnHot01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="6" Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="6" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeHot/ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnHot01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Value="6"   Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"		   Operation="Addition"    Left="6"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHot)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnHot01" Type="ClassPopulationPlanet">
@@ -261,10 +281,11 @@
     <BinaryModifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Left="6" BinaryOperation="Multiplication" Right="$(PlanetIsHot)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +6 EmpireManpowerOnHot -->
+  <!-- +9 EmpireManpowerOnHot -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnHot02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="9" Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="9" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeHot/ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnHot02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Value="9"   Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"		   Operation="Addition"    Left="9"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHot)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnHot02" Type="ClassPopulationPlanet">
@@ -277,10 +298,11 @@
   </SimulationDescriptor>
 
   <!-- EmpireManpower on Teeming -->
-  <!-- +2 EmpireManpowerOnTeeming -->
+  <!-- +3 EmpireManpowerOnTeeming -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnTeeming00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTeeming/ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnTeeming00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"		   Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnTeeming00" Type="ClassPopulationPlanet">
@@ -292,10 +314,11 @@
     <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="3" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +4 EmpireManpowerOnTeeming -->
+  <!-- +6 EmpireManpowerOnTeeming -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnTeeming01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="6" Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="6" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTeeming/ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnTeeming01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Value="6"   Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"		   Operation="Addition"    Left="6"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnTeeming01" Type="ClassPopulationPlanet">
@@ -303,10 +326,11 @@
     <BinaryModifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Left="6" BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +6 EmpireManpowerOnTeeming -->
+  <!-- +9 EmpireManpowerOnTeeming -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnTeeming02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="9" Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="9" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTeeming/ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnTeeming02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Value="9"   Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"		   Operation="Addition"    Left="9"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnTeeming02" Type="ClassPopulationPlanet">
@@ -319,10 +343,11 @@
   </SimulationDescriptor>
 
   <!-- EmpireManpower on Meager -->
-  <!-- +2 EmpireManpowerOnMeager -->
+  <!-- +3 EmpireManpowerOnMeager -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnMeager00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeMeager/ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnMeager00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"		   Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMeager)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnMeager00" Type="ClassPopulationPlanet">
@@ -334,10 +359,11 @@
     <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="3" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +4 EmpireManpowerOnMeager -->
+  <!-- +6 EmpireManpowerOnMeager -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnMeager01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="6" Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="6" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeMeager/ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnMeager01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Value="6"   Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"		   Operation="Addition"    Left="6"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMeager)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnMeager01" Type="ClassPopulationPlanet">
@@ -345,10 +371,11 @@
     <BinaryModifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Left="6" BinaryOperation="Multiplication" Right="$(PlanetIsMeager)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +6 EmpireManpowerOnMeager -->
+  <!-- +9 EmpireManpowerOnMeager -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnMeager02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="9" Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="9" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeMeager/ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnMeager02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Value="9"   Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"		   Operation="Addition"    Left="9"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMeager)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnMeager02" Type="ClassPopulationPlanet">
@@ -361,10 +388,11 @@
   </SimulationDescriptor>
 
   <!-- EmpireManpower on Gas -->
-  <!-- +3 EmpireManpowerOnGas -->
+  <!-- +6 EmpireManpowerOnGas -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnGas00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="6" Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="6" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeGas/ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnGas00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Value="6"   Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"		   Operation="Addition"    Left="6"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsGas)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnGas00" Type="ClassPopulationPlanet">
@@ -376,10 +404,11 @@
     <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="6" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +6 EmpireManpowerOnGas -->
+  <!-- +12 EmpireManpowerOnGas -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnGas01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="12" Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="12" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeGas/ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnGas01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Value="12"  Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"		   Operation="Addition"    Left="12"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsGas)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnGas01" Type="ClassPopulationPlanet">
@@ -391,10 +420,11 @@
     <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="9" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +10 EmpireManpowerOnGas -->
+  <!-- +18 EmpireManpowerOnGas -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnGas02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="18" Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="18" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeGas/ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnGas02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Value="18"  Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"		   Operation="Addition"    Left="18"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsGas)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnGas02" Type="ClassPopulationPlanet">
@@ -407,11 +437,12 @@
   </SimulationDescriptor>
 
   <!-- EmpireManpower on Happy -->
-  <!-- +2 EmpireManpowerOnHappy -->
+  <!-- +3 EmpireManpowerOnHappy -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnHappy00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="3" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="3" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
-    <BinaryModifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Left="3" BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)"  Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnHappy00" TooltipHidden="true" SearchValueFromPath="true"/>
+    <Modifier		TargetProperty="BonusPopulationEmpireManpower"	Operation="Addition" Value="3" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
+    <Modifier		TargetProperty="BonusPopulationEmpireManpower"	Operation="Addition" Value="3" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"			Operation="Addition" Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationEmpireManpower"	Operation="Addition" Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnHappy00" Type="ClassPopulationPlanet">
@@ -424,11 +455,12 @@
     <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="3" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +4 EmpireManpowerOnHappy -->
+  <!-- +6 EmpireManpowerOnHappy -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnHappy01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="6" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="6" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
-    <BinaryModifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Left="6" BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnHappy01" TooltipHidden="true" SearchValueFromPath="true"/>
+    <Modifier		TargetProperty="BonusPopulationEmpireManpower"	Operation="Addition" Value="6" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
+    <Modifier		TargetProperty="BonusPopulationEmpireManpower"	Operation="Addition" Value="6" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"			Operation="Addition" Left="6"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationEmpireManpower"	Operation="Addition" Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnHappy01" Type="ClassPopulationPlanet">
@@ -437,11 +469,12 @@
     <BinaryModifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Left="6" BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +6 EmpireManpowerOnHappy -->
+  <!-- +9 EmpireManpowerOnHappy -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnHappy02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="9" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="9" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
-    <BinaryModifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Left="9" BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnHappy02" TooltipHidden="true" SearchValueFromPath="true"/>
+    <Modifier		TargetProperty="BonusPopulationEmpireManpower"	Operation="Addition" Value="9" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
+    <Modifier		TargetProperty="BonusPopulationEmpireManpower"	Operation="Addition" Value="9" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"			Operation="Addition" Left="9"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationEmpireManpower"	Operation="Addition" Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnHappy02" Type="ClassPopulationPlanet">
@@ -455,10 +488,11 @@
   </SimulationDescriptor>
 
   <!-- EmpireManpower on Tiny -->
-  <!-- +1 EmpireManpowerOnTiny -->
+  <!-- +3 EmpireManpowerOnTiny -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnTiny00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetSizeTiny"/>
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeTiny/ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnTiny00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetSizeTiny"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"		   Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTiny)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnTiny00" Type="ClassPopulationPlanet">
@@ -470,10 +504,11 @@
     <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="3" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +2 EmpireManpowerOnTiny -->
+  <!-- +6 EmpireManpowerOnTiny -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnTiny01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="6" Path="FAKEFORGUI/./PlanetSizeTiny"/>
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="6" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeTiny/ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnTiny01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Value="6"   Path="FAKEFORGUI/./PlanetSizeTiny"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"		   Operation="Addition"    Left="6"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTiny)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnTiny01" Type="ClassPopulationPlanet">
@@ -481,10 +516,11 @@
     <BinaryModifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Left="6" BinaryOperation="Multiplication" Right="$(PlanetIsTiny)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +3 EmpireManpowerOnTiny -->
+  <!-- +9 EmpireManpowerOnTiny -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnTiny02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="9" Path="FAKEFORGUI/./PlanetSizeTiny"/>
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="9" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeTiny/ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnTiny02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Value="9"   Path="FAKEFORGUI/./PlanetSizeTiny"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"		   Operation="Addition"    Left="9"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTiny)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnTiny02" Type="ClassPopulationPlanet">
@@ -497,10 +533,11 @@
   </SimulationDescriptor>
 
   <!-- EmpireManpower on Small -->
-  <!-- +1 EmpireManpowerOnSmall -->
+  <!-- +3 EmpireManpowerOnSmall -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnSmall00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetSizeSmall"/>
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeSmall/ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnSmall00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetSizeSmall"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"		   Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsSmall)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnSmall00" Type="ClassPopulationPlanet">
@@ -512,10 +549,11 @@
     <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="1" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +2 EmpireManpowerOnSmall -->
+  <!-- +6 EmpireManpowerOnSmall -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnSmall01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="6" Path="FAKEFORGUI/./PlanetSizeSmall"/>
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="6" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeSmall/ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnSmall01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Value="6"   Path="FAKEFORGUI/./PlanetSizeSmall"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"		   Operation="Addition"    Left="6"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsSmall)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnSmall01" Type="ClassPopulationPlanet">
@@ -523,10 +561,11 @@
     <BinaryModifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Left="6" BinaryOperation="Multiplication" Right="$(PlanetIsSmall)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +3 EmpireManpowerOnSmall -->
+  <!-- +9 EmpireManpowerOnSmall -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnSmall02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="9" Path="FAKEFORGUI/./PlanetSizeSmall"/>
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="9" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeSmall/ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnSmall02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Value="9"   Path="FAKEFORGUI/./PlanetSizeSmall"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"		   Operation="Addition"    Left="9"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsSmall)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnSmall02" Type="ClassPopulationPlanet">
@@ -539,10 +578,11 @@
   </SimulationDescriptor>
 
   <!-- EmpireManpower on Medium -->
-  <!-- +1 EmpireManpowerOnMedium -->
+  <!-- +3 EmpireManpowerOnMedium -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnMedium00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetSizeMedium"/>
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeMedium/ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnMedium00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetSizeMedium"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"		   Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMedium)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnMedium00" Type="ClassPopulationPlanet">
@@ -554,10 +594,11 @@
     <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="3" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +2 EmpireManpowerOnMedium -->
+  <!-- +6 EmpireManpowerOnMedium -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnMedium01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="6" Path="FAKEFORGUI/./PlanetSizeMedium"/>
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="6" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeMedium/ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnMedium01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Value="6"   Path="FAKEFORGUI/./PlanetSizeMedium"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"		   Operation="Addition"    Left="6"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMedium)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnMedium01" Type="ClassPopulationPlanet">
@@ -565,10 +606,11 @@
     <BinaryModifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Left="6" BinaryOperation="Multiplication" Right="$(PlanetIsMedium)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +3 EmpireManpowerOnMedium -->
+  <!-- +9 EmpireManpowerOnMedium -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnMedium02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="9" Path="FAKEFORGUI/./PlanetSizeMedium"/>
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="9" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeMedium/ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnMedium02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Value="9"   Path="FAKEFORGUI/./PlanetSizeMedium"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"		   Operation="Addition"    Left="9"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMedium)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnMedium02" Type="ClassPopulationPlanet">
@@ -581,10 +623,11 @@
   </SimulationDescriptor>
 
   <!-- EmpireManpower on Large -->
-  <!-- +1 EmpireManpowerOnLarge -->
+  <!-- +3 EmpireManpowerOnLarge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnLarge00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetSizeLarge"/>
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeLarge/ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnLarge00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetSizeLarge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"		   Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsLarge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnLarge00" Type="ClassPopulationPlanet">
@@ -596,10 +639,11 @@
     <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="3" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +2 EmpireManpowerOnLarge -->
+  <!-- +6 EmpireManpowerOnLarge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnLarge01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="6" Path="FAKEFORGUI/./PlanetSizeLarge"/>
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="6" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeLarge/ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnLarge01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Value="6"   Path="FAKEFORGUI/./PlanetSizeLarge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"		   Operation="Addition"    Left="6"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsLarge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnLarge01" Type="ClassPopulationPlanet">
@@ -607,10 +651,11 @@
     <BinaryModifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Left="6" BinaryOperation="Multiplication" Right="$(PlanetIsLarge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +3 EmpireManpowerOnLarge -->
+  <!-- +9 EmpireManpowerOnLarge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnLarge02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="9" Path="FAKEFORGUI/./PlanetSizeLarge"/>
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="9" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeLarge/ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnLarge02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Value="9"   Path="FAKEFORGUI/./PlanetSizeLarge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"		   Operation="Addition"    Left="9"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsLarge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnLarge02" Type="ClassPopulationPlanet">
@@ -623,10 +668,11 @@
   </SimulationDescriptor>
 
   <!-- EmpireManpower on Huge -->
-  <!-- +1 EmpireManpowerOnHuge -->
+  <!-- +3 EmpireManpowerOnHuge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnHuge00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetSizeHuge"/>
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeHuge/ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnHuge00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetSizeHuge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"		   Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHuge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnHuge00" Type="ClassPopulationPlanet">
@@ -638,10 +684,11 @@
     <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="3" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +2 EmpireManpowerOnHuge -->
+  <!-- +6 EmpireManpowerOnHuge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnHuge01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="6" Path="FAKEFORGUI/./PlanetSizeHuge"/>
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="6" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeHuge/ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnHuge01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Value="6"   Path="FAKEFORGUI/./PlanetSizeHuge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"		   Operation="Addition"    Left="6"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHuge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnHuge01" Type="ClassPopulationPlanet">
@@ -649,10 +696,11 @@
     <BinaryModifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Left="6" BinaryOperation="Multiplication" Right="$(PlanetIsHuge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +3 EmpireManpowerOnHuge -->
+  <!-- +9 EmpireManpowerOnHuge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnHuge02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="9" Path="FAKEFORGUI/./PlanetSizeHuge"/>
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="9" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeHuge/ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnHuge02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Value="9"   Path="FAKEFORGUI/./PlanetSizeHuge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"		   Operation="Addition"    Left="9"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHuge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnHuge02" Type="ClassPopulationPlanet">
@@ -665,10 +713,11 @@
   </SimulationDescriptor>
 
   <!-- EmpireManpower on Strategic -->
-  <!-- +2 EmpireManpowerOnStrategic -->
+  <!-- +6 EmpireManpowerOnStrategic -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnStrategic00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="6" Path="FAKEFORGUI/./PlanetHasDepositStrategic"/>
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="6" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet,PlanetHasDepositStrategic/ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnStrategic00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Value="6"   Path="FAKEFORGUI/./PlanetHasDepositStrategic"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"		   Operation="Addition"    Left="6"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetHasStrategicDeposit)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnStrategic00" Type="ClassPopulationPlanet">
@@ -681,10 +730,11 @@
   </SimulationDescriptor>
 
   <!-- EmpireManpower on Luxury -->
-  <!-- +2 EmpireManpowerOnLuxury -->
+  <!-- +6 EmpireManpowerOnLuxury -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnLuxury00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="6" Path="FAKEFORGUI/./PlanetHasDepositLuxury"/>
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="6" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet,PlanetHasDepositLuxury/ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnLuxury00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Value="6"   Path="FAKEFORGUI/./PlanetHasDepositLuxury"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"		   Operation="Addition"    Left="6"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetHasLuxuryDeposit)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnLuxury00" Type="ClassPopulationPlanet">
@@ -697,10 +747,11 @@
   </SimulationDescriptor>
 
   <!-- EmpireManpower on Anomaly -->
-  <!-- +5 EmpireManpowerOnAnomaly -->
+  <!-- +12 EmpireManpowerOnAnomaly -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnAnomaly00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="12" Path="FAKEFORGUI/./PlanetAnomaly"/>
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="12" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetAnomaly/ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnAnomaly00,ClassPopulation" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Value="12"  Path="FAKEFORGUI/./PlanetAnomaly"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"		   Operation="Addition"    Left="12"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetHasAnomaly)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnAnomaly00" Type="ClassPopulationPlanet">
@@ -713,9 +764,10 @@
   </SimulationDescriptor>
 
   <!-- EmpireManpower per Minor Faction -->
-  <!-- +2 EmpireManpowerPerMinorFaction -->
+  <!-- +1 EmpireManpowerPerMinorFaction -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerPerMinorFaction00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerPerMinorFaction00,ClassPopulation"/>
+	<Modifier       TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Value="1"   Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerPerMinorFaction00" Type="ClassPopulationPlanet">
@@ -726,9 +778,10 @@
     <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="5" Path="ClassPopulation"/>
   </SimulationDescriptor>
   <!-- EmpireManpower per Backdoor -->
-  <!-- +2 EmpireManpowerPerBackdoor -->
+  <!-- +1 EmpireManpowerPerBackdoor -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerPerBackdoor00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerPerBackdoor00,ClassPopulation"/>
+	<Modifier       TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Value="1"   Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerPerBackdoor00" Type="ClassPopulationPlanet">
@@ -741,8 +794,9 @@
 
   <!-- EmpireManpower per Temple -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitPrimaryCustomEmpireManpowerPerTemple00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationEmpireManpower"          Operation="Addition"    Value="6"       Path="FAKEFORGUI/./PlanetWithTemple"/>
-    <Modifier TargetProperty="BonusPopulationEmpireManpower"          Operation="Addition"    Value="6"       Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimaryCustomEmpireManpowerPerTemple00,ClassPopulation" TooltipHidden="true" />
+    <Modifier       TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Value="6"   Path="FAKEFORGUI/./PlanetWithTemple"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue0"		   Operation="Addition"    Left="6"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Left="$(PopulationAuxValue0)"    BinaryOperation="Multiplication" Right="$(PlanetHasTemple)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitPrimaryCustomEmpireManpowerPerTemple00" Type="ClassPopulationPlanet">
@@ -750,9 +804,11 @@
     <BinaryModifier     TargetProperty="BonusPopulationEmpireManpower"    Operation="Addition"    Left="6"    BinaryOperation="Multiplication" Right="$(PlanetHasTemple)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +1 EmpireManpowerLevel-->
+  <!-- +3 EmpireManpower per System Level -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitPrimaryCustomEmpireManpowerLevel00" Type="WithPopulationPlanet">
-    <BinaryModifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Left="3" BinaryOperation="Multiplication" Right="$(PopulationSystemLevel)"  Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimaryCustomEmpireManpowerLevel00,ClassPopulation" TooltipHidden="true" SearchValueFromPath="true"/>
+    <Modifier       TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Value="3"   Path="FAKEFORGUI./SystemLevel"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"		   Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PopulationSystemLevel)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitPrimaryCustomEmpireManpowerLevel00" Type="ClassPopulationPlanet">
@@ -762,8 +818,9 @@
   <!-- SystemManpower on Cold -->
   <!-- +5 SystemManpowerOnCold -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnCold00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeCold/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnCold00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Value="5"   Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"		   Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsCold)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnCold00" Type="ClassPopulationPlanet">
@@ -777,8 +834,9 @@
 
   <!-- +10 SystemManpowerOnCold -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnCold01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="10" Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="10" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeCold/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnCold01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Value="10"  Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"		   Operation="Addition"    Left="10"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsCold)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnCold01" Type="ClassPopulationPlanet">
@@ -788,8 +846,9 @@
 
   <!-- +15 SystemManpowerOnCold -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnCold02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="15" Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="15" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeCold/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnCold02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Value="15"  Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"		   Operation="Addition"    Left="15"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsCold)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnCold02" Type="ClassPopulationPlanet">
@@ -804,8 +863,9 @@
   <!-- SystemManpower on Temperate -->
   <!-- +5 SystemManpowerOnTemperate -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnTemperate00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTemperate/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnTemperate00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Value="5"   Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"		   Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTemperate)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnTemperate00" Type="ClassPopulationPlanet">
@@ -819,8 +879,9 @@
 
   <!-- +10 SystemManpowerOnTemperate -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnTemperate01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="10" Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="10" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTemperate/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnTemperate01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Value="10"  Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"		   Operation="Addition"    Left="10"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTemperate)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnTemperate01" Type="ClassPopulationPlanet">
@@ -830,8 +891,9 @@
 
   <!-- +15 SystemManpowerOnTemperate -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnTemperate02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="15" Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="15" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTemperate/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnTemperate02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Value="15"  Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"		   Operation="Addition"    Left="15"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTemperate)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnTemperate02" Type="ClassPopulationPlanet">
@@ -846,8 +908,9 @@
   <!-- SystemManpower on Hot -->
   <!-- +5 SystemManpowerOnHot -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnHot00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeHot/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnHot00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Value="5"   Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"		   Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHot)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnHot00" Type="ClassPopulationPlanet">
@@ -861,8 +924,9 @@
 
   <!-- +10 SystemManpowerOnHot -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnHot01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="10" Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="10" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeHot/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnHot01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Value="10"  Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"		   Operation="Addition"    Left="10"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHot)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnHot01" Type="ClassPopulationPlanet">
@@ -872,8 +936,9 @@
 
   <!-- +15 SystemManpowerOnHot -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnHot02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="15" Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="15" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeHot/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnHot02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Value="15"  Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"		   Operation="Addition"    Left="15"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHot)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnHot02" Type="ClassPopulationPlanet">
@@ -888,8 +953,9 @@
   <!-- SystemManpower on Teeming -->
   <!-- +5 SystemManpowerOnTeeming -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnTeeming00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTeeming/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnTeeming00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Value="5"   Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"		   Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnTeeming00" Type="ClassPopulationPlanet">
@@ -903,8 +969,9 @@
 
   <!-- +10 SystemManpowerOnTeeming -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnTeeming01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="10" Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="10" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTeeming/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnTeeming01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Value="10"  Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"		   Operation="Addition"    Left="10"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnTeeming01" Type="ClassPopulationPlanet">
@@ -914,8 +981,9 @@
 
   <!-- +15 SystemManpowerOnTeeming -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnTeeming02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="15" Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="15" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTeeming/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnTeeming02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Value="15"  Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"		   Operation="Addition"    Left="15"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnTeeming02" Type="ClassPopulationPlanet">
@@ -930,8 +998,9 @@
   <!-- SystemManpower on Meager -->
   <!-- +5 SystemManpowerOnMeager -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnMeager00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeMeager/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnMeager00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Value="5"   Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"		   Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMeager)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnMeager00" Type="ClassPopulationPlanet">
@@ -945,8 +1014,9 @@
 
   <!-- +10 SystemManpowerOnMeager -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnMeager01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="10" Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="10" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeMeager/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnMeager01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Value="10"  Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"		   Operation="Addition"    Left="10"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMeager)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnMeager01" Type="ClassPopulationPlanet">
@@ -956,8 +1026,9 @@
 
   <!-- +15 SystemManpowerOnMeager -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnMeager02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="15" Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="15" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeMeager/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnMeager02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Value="15"  Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"		   Operation="Addition"    Left="15"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMeager)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnMeager02" Type="ClassPopulationPlanet">
@@ -972,8 +1043,9 @@
   <!-- SystemManpower on Gas -->
   <!-- +10 SystemManpowerOnGas -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnGas00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="10" Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="10" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeGas/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnGas00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Value="10"  Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"		   Operation="Addition"    Left="10"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsGas)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnGas00" Type="ClassPopulationPlanet">
@@ -987,8 +1059,9 @@
 
   <!-- +15 SystemManpowerOnGas -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnGas01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="15" Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="15" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeGas/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnGas01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Value="15"  Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"		   Operation="Addition"    Left="15"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsGas)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnGas01" Type="ClassPopulationPlanet">
@@ -1002,8 +1075,9 @@
 
   <!-- +20 SystemManpowerOnGas -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnGas02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="20" Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="20" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeGas/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnGas02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Value="20"  Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"		   Operation="Addition"    Left="20"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsGas)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnGas02" Type="ClassPopulationPlanet">
@@ -1018,9 +1092,10 @@
   <!-- SystemManpower on Happy -->
   <!-- +5 SystemManpowerOnHappy -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnHappy00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="5" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="5" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
-    <BinaryModifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Left="5" BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)"  Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnHappy00" TooltipHidden="true" SearchValueFromPath="true"/>
+    <Modifier		TargetProperty="BonusPopulationSystemManpower"	Operation="Addition" Value="5" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
+    <Modifier		TargetProperty="BonusPopulationSystemManpower"	Operation="Addition" Value="5" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"			Operation="Addition" Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationSystemManpower"	Operation="Addition" Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnHappy00" Type="ClassPopulationPlanet">
@@ -1035,9 +1110,10 @@
 
   <!-- +10 SystemManpowerOnHappy -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnHappy01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="10" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="10" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
-    <BinaryModifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Left="10" BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnHappy01" TooltipHidden="true" SearchValueFromPath="true"/>
+    <Modifier		TargetProperty="BonusPopulationSystemManpower"	Operation="Addition" Value="10" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
+    <Modifier		TargetProperty="BonusPopulationSystemManpower"	Operation="Addition" Value="10" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"			Operation="Addition" Left="10"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationSystemManpower"	Operation="Addition" Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnHappy01" Type="ClassPopulationPlanet">
@@ -1048,9 +1124,10 @@
 
   <!-- +15 SystemManpowerOnHappy -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnHappy02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="15" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="15" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
-    <BinaryModifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Left="15" BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnHappy02" TooltipHidden="true" SearchValueFromPath="true"/>
+    <Modifier		TargetProperty="BonusPopulationSystemManpower"	Operation="Addition" Value="15" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
+    <Modifier		TargetProperty="BonusPopulationSystemManpower"	Operation="Addition" Value="15" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"			Operation="Addition" Left="15"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationSystemManpower"	Operation="Addition" Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnHappy02" Type="ClassPopulationPlanet">
@@ -1064,10 +1141,11 @@
   </SimulationDescriptor>
 
   <!-- SystemManpower on Tiny -->
-  <!-- +1 SystemManpowerOnTiny -->
+  <!-- +5 SystemManpowerOnTiny -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnTiny00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetSizeTiny"/>
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeTiny/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnTiny00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Value="5"   Path="FAKEFORGUI/./PlanetSizeTiny"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"		   Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTiny)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnTiny00" Type="ClassPopulationPlanet">
@@ -1079,10 +1157,11 @@
     <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="5" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +2 SystemManpowerOnTiny -->
+  <!-- +10 SystemManpowerOnTiny -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnTiny01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="10" Path="FAKEFORGUI/./PlanetSizeTiny"/>
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="10" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeTiny/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnTiny01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Value="10"  Path="FAKEFORGUI/./PlanetSizeTiny"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"		   Operation="Addition"    Left="10"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTiny)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnTiny01" Type="ClassPopulationPlanet">
@@ -1090,10 +1169,11 @@
     <BinaryModifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Left="10" BinaryOperation="Multiplication" Right="$(PlanetIsTiny)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +3 SystemManpowerOnTiny -->
+  <!-- +15 SystemManpowerOnTiny -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnTiny02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="15" Path="FAKEFORGUI/./PlanetSizeTiny"/>
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="15" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeTiny/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnTiny02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Value="15"  Path="FAKEFORGUI/./PlanetSizeTiny"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"		   Operation="Addition"    Left="15"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTiny)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnTiny02" Type="ClassPopulationPlanet">
@@ -1106,10 +1186,11 @@
   </SimulationDescriptor>
 
   <!-- SystemManpower on Small -->
-  <!-- +1 SystemManpowerOnSmall -->
+  <!-- +5 SystemManpowerOnSmall -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnSmall00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetSizeSmall"/>
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeSmall/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnSmall00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Value="5"   Path="FAKEFORGUI/./PlanetSizeSmall"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"		   Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsSmall)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnSmall00" Type="ClassPopulationPlanet">
@@ -1121,10 +1202,11 @@
     <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="5" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +2 SystemManpowerOnSmall -->
+  <!-- +10 SystemManpowerOnSmall -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnSmall01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="10" Path="FAKEFORGUI/./PlanetSizeSmall"/>
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="10" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeSmall/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnSmall01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Value="10"  Path="FAKEFORGUI/./PlanetSizeSmall"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"		   Operation="Addition"    Left="10"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsSmall)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnSmall01" Type="ClassPopulationPlanet">
@@ -1132,10 +1214,11 @@
     <BinaryModifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Left="10" BinaryOperation="Multiplication" Right="$(PlanetIsSmall)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +3 SystemManpowerOnSmall -->
+  <!-- +15 SystemManpowerOnSmall -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnSmall02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="15" Path="FAKEFORGUI/./PlanetSizeSmall"/>
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="15" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeSmall/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnSmall02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Value="15"  Path="FAKEFORGUI/./PlanetSizeSmall"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"		   Operation="Addition"    Left="15"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsSmall)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnSmall02" Type="ClassPopulationPlanet">
@@ -1148,10 +1231,11 @@
   </SimulationDescriptor>
 
   <!-- SystemManpower on Medium -->
-  <!-- +1 SystemManpowerOnMedium -->
+  <!-- +5 SystemManpowerOnMedium -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnMedium00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetSizeMedium"/>
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeMedium/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnMedium00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Value="5"   Path="FAKEFORGUI/./PlanetSizeMedium"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"		   Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMedium)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnMedium00" Type="ClassPopulationPlanet">
@@ -1163,10 +1247,11 @@
     <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="5" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +2 SystemManpowerOnMedium -->
+  <!-- +10 SystemManpowerOnMedium -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnMedium01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="10" Path="FAKEFORGUI/./PlanetSizeMedium"/>
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="10" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeMedium/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnMedium01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Value="10"  Path="FAKEFORGUI/./PlanetSizeMedium"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"		   Operation="Addition"    Left="10"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMedium)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnMedium01" Type="ClassPopulationPlanet">
@@ -1174,10 +1259,11 @@
     <BinaryModifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Left="10" BinaryOperation="Multiplication" Right="$(PlanetIsMedium)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +3 SystemManpowerOnMedium -->
+  <!-- +15 SystemManpowerOnMedium -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnMedium02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="15" Path="FAKEFORGUI/./PlanetSizeMedium"/>
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="15" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeMedium/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnMedium02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Value="15"  Path="FAKEFORGUI/./PlanetSizeMedium"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"		   Operation="Addition"    Left="15"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMedium)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnMedium02" Type="ClassPopulationPlanet">
@@ -1190,10 +1276,11 @@
   </SimulationDescriptor>
 
   <!-- SystemManpower on Large -->
-  <!-- +1 SystemManpowerOnLarge -->
+  <!-- +5 SystemManpowerOnLarge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnLarge00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetSizeLarge"/>
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeLarge/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnLarge00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Value="5"   Path="FAKEFORGUI/./PlanetSizeLarge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"		   Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsLarge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnLarge00" Type="ClassPopulationPlanet">
@@ -1205,10 +1292,11 @@
     <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="5" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +2 SystemManpowerOnLarge -->
+  <!-- +10 SystemManpowerOnLarge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnLarge01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="10" Path="FAKEFORGUI/./PlanetSizeLarge"/>
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="10" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeLarge/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnLarge01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Value="10"  Path="FAKEFORGUI/./PlanetSizeLarge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"		   Operation="Addition"    Left="10"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsLarge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnLarge01" Type="ClassPopulationPlanet">
@@ -1216,10 +1304,11 @@
     <BinaryModifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Left="10" BinaryOperation="Multiplication" Right="$(PlanetIsLarge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +3 SystemManpowerOnLarge -->
+  <!-- +15 SystemManpowerOnLarge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnLarge02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="15" Path="FAKEFORGUI/./PlanetSizeLarge"/>
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="15" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeLarge/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnLarge02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Value="15"  Path="FAKEFORGUI/./PlanetSizeLarge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"		   Operation="Addition"    Left="15"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsLarge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnLarge02" Type="ClassPopulationPlanet">
@@ -1232,10 +1321,11 @@
   </SimulationDescriptor>
 
   <!-- SystemManpower on Huge -->
-  <!-- +1 SystemManpowerOnHuge -->
+  <!-- +5 SystemManpowerOnHuge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnHuge00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetSizeHuge"/>
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeHuge/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnHuge00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Value="5"   Path="FAKEFORGUI/./PlanetSizeHuge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"		   Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHuge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnHuge00" Type="ClassPopulationPlanet">
@@ -1247,10 +1337,11 @@
     <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="5" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +2 SystemManpowerOnHuge -->
+  <!-- +10 SystemManpowerOnHuge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnHuge01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="10" Path="FAKEFORGUI/./PlanetSizeHuge"/>
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="10" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeHuge/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnHuge01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Value="10"  Path="FAKEFORGUI/./PlanetSizeHuge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"		   Operation="Addition"    Left="10"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHuge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnHuge01" Type="ClassPopulationPlanet">
@@ -1258,10 +1349,11 @@
     <BinaryModifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Left="10" BinaryOperation="Multiplication" Right="$(PlanetIsHuge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +3 SystemManpowerOnHuge -->
+  <!-- +15 SystemManpowerOnHuge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnHuge02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="15" Path="FAKEFORGUI/./PlanetSizeHuge"/>
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="15" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeHuge/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnHuge02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Value="15"  Path="FAKEFORGUI/./PlanetSizeHuge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"		   Operation="Addition"    Left="15"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHuge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnHuge02" Type="ClassPopulationPlanet">
@@ -1276,8 +1368,9 @@
   <!-- SystemManpower on Strategic -->
   <!-- +10 SystemManpowerOnStrategic -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnStrategic00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="10" Path="FAKEFORGUI/./PlanetHasDepositStrategic"/>
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="10" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet,PlanetHasDepositStrategic/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnStrategic00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Value="10"  Path="FAKEFORGUI/./PlanetHasDepositStrategic"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"		   Operation="Addition"    Left="10"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetHasStrategicDeposit)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnStrategic00" Type="ClassPopulationPlanet">
@@ -1292,8 +1385,9 @@
   <!-- SystemManpower on Luxury -->
   <!-- +10 SystemManpowerOnLuxury -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnLuxury00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="10" Path="FAKEFORGUI/./PlanetHasDepositLuxury"/>
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="10" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet,PlanetHasDepositLuxury/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnLuxury00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Value="10"  Path="FAKEFORGUI/./PlanetHasDepositLuxury"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"		   Operation="Addition"    Left="10"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetHasLuxuryDeposit)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnLuxury00" Type="ClassPopulationPlanet">
@@ -1308,8 +1402,9 @@
   <!-- SystemManpower on Anomaly -->
   <!-- +15 SystemManpowerOnAnomaly -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnAnomaly00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="15" Path="FAKEFORGUI/./PlanetAnomaly"/>
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="15" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetAnomaly/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnAnomaly00,ClassPopulation" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Value="15"  Path="FAKEFORGUI/./PlanetAnomaly"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"		   Operation="Addition"    Left="15"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetHasAnomaly)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnAnomaly00" Type="ClassPopulationPlanet">
@@ -1324,7 +1419,8 @@
   <!-- SystemManpower per Minor Faction -->
   <!-- +5 SystemManpowerPerMinorFaction -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerPerMinorFaction00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitSecondaryCustomDefensePerMinorFaction00,ClassPopulation"/>
+	<Modifier       TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Value="5"   Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerPerMinorFaction00" Type="ClassPopulationPlanet">
@@ -1337,7 +1433,8 @@
   <!-- SystemManpower per Backdoor -->
   <!-- +5 SystemManpowerPerBackdoor -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerPerBackdoor00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitSecondaryCustomDefensePerBackdoor00,ClassPopulation"/>
+	<Modifier       TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Value="5"   Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerPerBackdoor00" Type="ClassPopulationPlanet">
@@ -1350,8 +1447,9 @@
 
   <!-- SystemManpower per Temple -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitPrimaryCustomSystemManpowerPerTemple00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationSystemManpower"          Operation="Addition"    Value="10"       Path="FAKEFORGUI/./PlanetWithTemple"/>
-    <Modifier TargetProperty="BonusPopulationSystemManpower"          Operation="Addition"    Value="10"       Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimaryCustomDefensePerTemple00,ClassPopulation" TooltipHidden="true" />
+    <Modifier       TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Value="10"  Path="FAKEFORGUI/./PlanetWithTemple"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue0"		   Operation="Addition"    Left="10"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Left="$(PopulationAuxValue0)"    BinaryOperation="Multiplication" Right="$(PlanetHasTemple)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitPrimaryCustomSystemManpowerPerTemple00" Type="ClassPopulationPlanet">
@@ -1359,9 +1457,11 @@
     <BinaryModifier     TargetProperty="BonusPopulationSystemManpower"    Operation="Addition"    Left="10"    BinaryOperation="Multiplication" Right="$(PlanetHasTemple)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +1 SystemManpowerLevel-->
+  <!-- +5 SystemManpower per System Level -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitPrimaryCustomSystemManpowerLevel00" Type="WithPopulationPlanet">
-    <BinaryModifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Left="5" BinaryOperation="Multiplication" Right="$(PopulationSystemLevel)"  Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimaryCustomDefenseLevel00,ClassPopulation" TooltipHidden="true" SearchValueFromPath="true"/>
+    <Modifier       TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Value="5"   Path="FAKEFORGUI./SystemLevel"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"		   Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PopulationSystemLevel)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitPrimaryCustomSystemManpowerLevel00" Type="ClassPopulationPlanet">
@@ -1369,10 +1469,11 @@
   </SimulationDescriptor>
 
   <!-- GroundBattleBombardmentAttackerDamages on Cold -->
-  <!-- +25 GroundBattleBombardmentAttackerDamagesOnCold -->
+  <!-- +50 GroundBattleBombardmentAttackerDamagesOnCold -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnCold00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="50" Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="50" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeCold/ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnCold00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Value="50"  Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"								   Operation="Addition"    Left="50"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsCold)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnCold00" Type="ClassPopulationPlanet">
@@ -1384,10 +1485,11 @@
     <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="50" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +50 GroundBattleBombardmentAttackerDamagesOnCold -->
+  <!-- +100 GroundBattleBombardmentAttackerDamagesOnCold -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnCold01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="100" Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="100" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeCold/ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnCold01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Value="100" Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"								   Operation="Addition"    Left="100"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsCold)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnCold01" Type="ClassPopulationPlanet">
@@ -1395,10 +1497,11 @@
     <BinaryModifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Left="100" BinaryOperation="Multiplication" Right="$(PlanetIsCold)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +75 GroundBattleBombardmentAttackerDamagesOnCold -->
+  <!-- +150 GroundBattleBombardmentAttackerDamagesOnCold -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnCold02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="150" Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="150" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeCold/ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnCold02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Value="150" Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"								   Operation="Addition"    Left="150"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsCold)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnCold02" Type="ClassPopulationPlanet">
@@ -1411,10 +1514,11 @@
   </SimulationDescriptor>
 
   <!-- GroundBattleBombardmentAttackerDamages on Temperate -->
-  <!-- +25 GroundBattleBombardmentAttackerDamagesOnTemperate -->
+  <!-- +50 GroundBattleBombardmentAttackerDamagesOnTemperate -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnTemperate00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="50" Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="50" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTemperate/ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnTemperate00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Value="50"  Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"								   Operation="Addition"    Left="50"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTemperate)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnTemperate00" Type="ClassPopulationPlanet">
@@ -1426,10 +1530,11 @@
     <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="50" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +50 GroundBattleBombardmentAttackerDamagesOnTemperate -->
+  <!-- +100 GroundBattleBombardmentAttackerDamagesOnTemperate -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnTemperate01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="100" Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="100" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTemperate/ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnTemperate01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Value="100" Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"								   Operation="Addition"    Left="100"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTemperate)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnTemperate01" Type="ClassPopulationPlanet">
@@ -1437,10 +1542,11 @@
     <BinaryModifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Left="100" BinaryOperation="Multiplication" Right="$(PlanetIsTemperate)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +75 GroundBattleBombardmentAttackerDamagesOnTemperate -->
+  <!-- +150 GroundBattleBombardmentAttackerDamagesOnTemperate -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnTemperate02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="150" Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="150" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTemperate/ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnTemperate02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Value="150" Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"								   Operation="Addition"    Left="150"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTemperate)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnTemperate02" Type="ClassPopulationPlanet">
@@ -1453,10 +1559,11 @@
   </SimulationDescriptor>
 
   <!-- GroundBattleBombardmentAttackerDamages on Hot -->
-  <!-- +25 GroundBattleBombardmentAttackerDamagesOnHot -->
+  <!-- +50 GroundBattleBombardmentAttackerDamagesOnHot -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnHot00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="50" Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="50" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeHot/ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnHot00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Value="50"  Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"								   Operation="Addition"    Left="50"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHot)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnHot00" Type="ClassPopulationPlanet">
@@ -1468,10 +1575,11 @@
     <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="50" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +50 GroundBattleBombardmentAttackerDamagesOnHot -->
+  <!-- +100 GroundBattleBombardmentAttackerDamagesOnHot -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnHot01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="100" Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="100" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeHot/ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnHot01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Value="100" Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"								   Operation="Addition"    Left="100"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHot)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnHot01" Type="ClassPopulationPlanet">
@@ -1479,10 +1587,11 @@
     <BinaryModifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Left="100" BinaryOperation="Multiplication" Right="$(PlanetIsHot)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +75 GroundBattleBombardmentAttackerDamagesOnHot -->
+  <!-- +150 GroundBattleBombardmentAttackerDamagesOnHot -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnHot02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="150" Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="150" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeHot/ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnHot02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Value="150" Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"								   Operation="Addition"    Left="150"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHot)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnHot02" Type="ClassPopulationPlanet">
@@ -1495,10 +1604,11 @@
   </SimulationDescriptor>
 
   <!-- GroundBattleBombardmentAttackerDamages on Teeming -->
-  <!-- +25 GroundBattleBombardmentAttackerDamagesOnTeeming -->
+  <!-- +50 GroundBattleBombardmentAttackerDamagesOnTeeming -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnTeeming00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="50" Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="50" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTeeming/ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnTeeming00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Value="50"  Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"								   Operation="Addition"    Left="50"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnTeeming00" Type="ClassPopulationPlanet">
@@ -1510,10 +1620,11 @@
     <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="50" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +50 GroundBattleBombardmentAttackerDamagesOnTeeming -->
+  <!-- +100 GroundBattleBombardmentAttackerDamagesOnTeeming -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnTeeming01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="100" Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="100" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTeeming/ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnTeeming01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Value="100" Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"								   Operation="Addition"    Left="100"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnTeeming01" Type="ClassPopulationPlanet">
@@ -1521,10 +1632,11 @@
     <BinaryModifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Left="100" BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +75 GroundBattleBombardmentAttackerDamagesOnTeeming -->
+  <!-- +150 GroundBattleBombardmentAttackerDamagesOnTeeming -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnTeeming02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="150" Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="150" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTeeming/ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnTeeming02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Value="150" Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"								   Operation="Addition"    Left="150"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnTeeming02" Type="ClassPopulationPlanet">
@@ -1537,10 +1649,11 @@
   </SimulationDescriptor>
 
   <!-- GroundBattleBombardmentAttackerDamages on Meager -->
-  <!-- +25 GroundBattleBombardmentAttackerDamagesOnMeager -->
+  <!-- +50 GroundBattleBombardmentAttackerDamagesOnMeager -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnMeager00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="50" Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="50" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeMeager/ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnMeager00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Value="50"  Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"								   Operation="Addition"    Left="50"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMeager)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnMeager00" Type="ClassPopulationPlanet">
@@ -1552,10 +1665,11 @@
     <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="50" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +50 GroundBattleBombardmentAttackerDamagesOnMeager -->
+  <!-- +100 GroundBattleBombardmentAttackerDamagesOnMeager -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnMeager01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="100" Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="100" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeMeager/ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnMeager01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Value="100" Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"								   Operation="Addition"    Left="100"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMeager)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnMeager01" Type="ClassPopulationPlanet">
@@ -1563,10 +1677,11 @@
     <BinaryModifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Left="100" BinaryOperation="Multiplication" Right="$(PlanetIsMeager)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +75 GroundBattleBombardmentAttackerDamagesOnMeager -->
+  <!-- +150 GroundBattleBombardmentAttackerDamagesOnMeager -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnMeager02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="150" Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="150" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeMeager/ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnMeager02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Value="150" Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"								   Operation="Addition"    Left="150"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMeager)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnMeager02" Type="ClassPopulationPlanet">
@@ -1579,10 +1694,11 @@
   </SimulationDescriptor>
 
   <!-- GroundBattleBombardmentAttackerDamages on Gas -->
-  <!-- +50 GroundBattleBombardmentAttackerDamagesOnGas -->
+  <!-- +100 GroundBattleBombardmentAttackerDamagesOnGas -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnGas00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="100" Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="100" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeGas/ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnGas00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Value="100" Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"								   Operation="Addition"    Left="100"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsGas)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnGas00" Type="ClassPopulationPlanet">
@@ -1594,10 +1710,11 @@
     <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="50" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +75 GroundBattleBombardmentAttackerDamagesOnGas -->
+  <!-- +150 GroundBattleBombardmentAttackerDamagesOnGas -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnGas01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="150" Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="150" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeGas/ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnGas01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Value="150" Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"								   Operation="Addition"    Left="150"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsGas)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnGas01" Type="ClassPopulationPlanet">
@@ -1609,10 +1726,11 @@
     <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="70" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +100 GroundBattleBombardmentAttackerDamagesOnGas -->
+  <!-- +200 GroundBattleBombardmentAttackerDamagesOnGas -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnGas02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="200" Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="200" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeGas/ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnGas02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Value="200" Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"								   Operation="Addition"    Left="200"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsGas)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnGas02" Type="ClassPopulationPlanet">
@@ -1625,11 +1743,12 @@
   </SimulationDescriptor>
 
   <!-- GroundBattleBombardmentAttackerDamages on Happy -->
-  <!-- +25 GroundBattleBombardmentAttackerDamagesOnHappy -->
+  <!-- +50 GroundBattleBombardmentAttackerDamagesOnHappy -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnHappy00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="50" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="50" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
-    <BinaryModifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Left="50" BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)"  Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnHappy00" TooltipHidden="true" SearchValueFromPath="true"/>
+    <Modifier		TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="50" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
+    <Modifier		TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="50" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"								   Operation="Addition" Left="50"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnHappy00" Type="ClassPopulationPlanet">
@@ -1642,11 +1761,12 @@
     <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="50" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +50 GroundBattleBombardmentAttackerDamagesOnHappy -->
+  <!-- +100 GroundBattleBombardmentAttackerDamagesOnHappy -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnHappy01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="100" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="100" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
-    <BinaryModifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Left="100" BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnHappy01" TooltipHidden="true" SearchValueFromPath="true"/>
+    <Modifier		TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="100" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
+    <Modifier		TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="100" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"								   Operation="Addition" Left="100"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnHappy01" Type="ClassPopulationPlanet">
@@ -1655,11 +1775,12 @@
     <BinaryModifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Left="100" BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +75 GroundBattleBombardmentAttackerDamagesOnHappy -->
+  <!-- +150 GroundBattleBombardmentAttackerDamagesOnHappy -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnHappy02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="150" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="150" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
-    <BinaryModifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Left="150" BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnHappy02" TooltipHidden="true" SearchValueFromPath="true"/>
+    <Modifier		TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="150" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
+    <Modifier		TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="150" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"								   Operation="Addition" Left="150"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnHappy02" Type="ClassPopulationPlanet">
@@ -1673,10 +1794,11 @@
   </SimulationDescriptor>
 
   <!-- GroundBattleBombardmentAttackerDamages on Tiny -->
-  <!-- +1 GroundBattleBombardmentAttackerDamagesOnTiny -->
+  <!-- +50 GroundBattleBombardmentAttackerDamagesOnTiny -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnTiny00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="50" Path="FAKEFORGUI/./PlanetSizeTiny"/>
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="50" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeTiny/ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnTiny00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Value="50"  Path="FAKEFORGUI/./PlanetSizeTiny"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"								   Operation="Addition"    Left="50"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTiny)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnTiny00" Type="ClassPopulationPlanet">
@@ -1688,10 +1810,11 @@
     <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="50" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +2 GroundBattleBombardmentAttackerDamagesOnTiny -->
+  <!-- +100 GroundBattleBombardmentAttackerDamagesOnTiny -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnTiny01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="100" Path="FAKEFORGUI/./PlanetSizeTiny"/>
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="100" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeTiny/ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnTiny01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Value="100" Path="FAKEFORGUI/./PlanetSizeTiny"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"								   Operation="Addition"    Left="100"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTiny)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnTiny01" Type="ClassPopulationPlanet">
@@ -1699,10 +1822,11 @@
     <BinaryModifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Left="100" BinaryOperation="Multiplication" Right="$(PlanetIsTiny)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +3 GroundBattleBombardmentAttackerDamagesOnTiny -->
+  <!-- +150 GroundBattleBombardmentAttackerDamagesOnTiny -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnTiny02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="150" Path="FAKEFORGUI/./PlanetSizeTiny"/>
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="150" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeTiny/ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnTiny02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Value="150" Path="FAKEFORGUI/./PlanetSizeTiny"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"								   Operation="Addition"    Left="150"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTiny)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnTiny02" Type="ClassPopulationPlanet">
@@ -1715,10 +1839,11 @@
   </SimulationDescriptor>
 
   <!-- GroundBattleBombardmentAttackerDamages on Small -->
-  <!-- +1 GroundBattleBombardmentAttackerDamagesOnSmall -->
+  <!-- +50 GroundBattleBombardmentAttackerDamagesOnSmall -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnSmall00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="50" Path="FAKEFORGUI/./PlanetSizeSmall"/>
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="50" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeSmall/ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnSmall00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Value="50"  Path="FAKEFORGUI/./PlanetSizeSmall"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"								   Operation="Addition"    Left="50"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsSmall)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnSmall00" Type="ClassPopulationPlanet">
@@ -1730,10 +1855,11 @@
     <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="50" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +2 GroundBattleBombardmentAttackerDamagesOnSmall -->
+  <!-- +100 GroundBattleBombardmentAttackerDamagesOnSmall -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnSmall01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="100" Path="FAKEFORGUI/./PlanetSizeSmall"/>
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="100" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeSmall/ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnSmall01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Value="100" Path="FAKEFORGUI/./PlanetSizeSmall"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"								   Operation="Addition"    Left="100"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsSmall)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnSmall01" Type="ClassPopulationPlanet">
@@ -1741,10 +1867,11 @@
     <BinaryModifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Left="100" BinaryOperation="Multiplication" Right="$(PlanetIsSmall)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +3 GroundBattleBombardmentAttackerDamagesOnSmall -->
+  <!-- +150 GroundBattleBombardmentAttackerDamagesOnSmall -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnSmall02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="150" Path="FAKEFORGUI/./PlanetSizeSmall"/>
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="150" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeSmall/ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnSmall02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Value="150"  Path="FAKEFORGUI/./PlanetSizeSmall"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"								   Operation="Addition"    Left="150"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsSmall)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnSmall02" Type="ClassPopulationPlanet">
@@ -1757,10 +1884,11 @@
   </SimulationDescriptor>
 
   <!-- GroundBattleBombardmentAttackerDamages on Medium -->
-  <!-- +1 GroundBattleBombardmentAttackerDamagesOnMedium -->
+  <!-- +50 GroundBattleBombardmentAttackerDamagesOnMedium -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnMedium00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="50" Path="FAKEFORGUI/./PlanetSizeMedium"/>
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="50" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeMedium/ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnMedium00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Value="50"  Path="FAKEFORGUI/./PlanetSizeMedium"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"								   Operation="Addition"    Left="50"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMedium)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnMedium00" Type="ClassPopulationPlanet">
@@ -1772,10 +1900,11 @@
     <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="50" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +2 GroundBattleBombardmentAttackerDamagesOnMedium -->
+  <!-- +100 GroundBattleBombardmentAttackerDamagesOnMedium -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnMedium01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="100" Path="FAKEFORGUI/./PlanetSizeMedium"/>
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="100" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeMedium/ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnMedium01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Value="100" Path="FAKEFORGUI/./PlanetSizeMedium"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"								   Operation="Addition"    Left="100"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMedium)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnMedium01" Type="ClassPopulationPlanet">
@@ -1783,10 +1912,11 @@
     <BinaryModifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Left="100" BinaryOperation="Multiplication" Right="$(PlanetIsMedium)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +3 GroundBattleBombardmentAttackerDamagesOnMedium -->
+  <!-- +150 GroundBattleBombardmentAttackerDamagesOnMedium -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnMedium02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="150" Path="FAKEFORGUI/./PlanetSizeMedium"/>
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="150" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeMedium/ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnMedium02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Value="150" Path="FAKEFORGUI/./PlanetSizeMedium"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"								   Operation="Addition"    Left="150"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMedium)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnMedium02" Type="ClassPopulationPlanet">
@@ -1799,10 +1929,11 @@
   </SimulationDescriptor>
 
   <!-- GroundBattleBombardmentAttackerDamages on Large -->
-  <!-- +1 GroundBattleBombardmentAttackerDamagesOnLarge -->
+  <!-- +50 GroundBattleBombardmentAttackerDamagesOnLarge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnLarge00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="50" Path="FAKEFORGUI/./PlanetSizeLarge"/>
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="50" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeLarge/ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnLarge00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Value="50"  Path="FAKEFORGUI/./PlanetSizeLarge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"								   Operation="Addition"    Left="50"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsLarge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnLarge00" Type="ClassPopulationPlanet">
@@ -1814,10 +1945,11 @@
     <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="50" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +2 GroundBattleBombardmentAttackerDamagesOnLarge -->
+  <!-- +100 GroundBattleBombardmentAttackerDamagesOnLarge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnLarge01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="100" Path="FAKEFORGUI/./PlanetSizeLarge"/>
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="100" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeLarge/ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnLarge01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Value="100" Path="FAKEFORGUI/./PlanetSizeLarge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"								   Operation="Addition"    Left="100"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsLarge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnLarge01" Type="ClassPopulationPlanet">
@@ -1825,10 +1957,11 @@
     <BinaryModifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Left="100" BinaryOperation="Multiplication" Right="$(PlanetIsLarge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +3 GroundBattleBombardmentAttackerDamagesOnLarge -->
+  <!-- +150 GroundBattleBombardmentAttackerDamagesOnLarge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnLarge02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="150" Path="FAKEFORGUI/./PlanetSizeLarge"/>
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="150" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeLarge/ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnLarge02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Value="150" Path="FAKEFORGUI/./PlanetSizeLarge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"								   Operation="Addition"    Left="150"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsLarge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnLarge02" Type="ClassPopulationPlanet">
@@ -1841,10 +1974,11 @@
   </SimulationDescriptor>
 
   <!-- GroundBattleBombardmentAttackerDamages on Huge -->
-  <!-- +1 GroundBattleBombardmentAttackerDamagesOnHuge -->
+  <!-- +50 GroundBattleBombardmentAttackerDamagesOnHuge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnHuge00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="50" Path="FAKEFORGUI/./PlanetSizeHuge"/>
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="50" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeHuge/ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnHuge00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Value="50"  Path="FAKEFORGUI/./PlanetSizeHuge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"								   Operation="Addition"    Left="50"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHuge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnHuge00" Type="ClassPopulationPlanet">
@@ -1856,10 +1990,11 @@
     <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="50" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +2 GroundBattleBombardmentAttackerDamagesOnHuge -->
+  <!-- +100 GroundBattleBombardmentAttackerDamagesOnHuge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnHuge01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="100" Path="FAKEFORGUI/./PlanetSizeHuge"/>
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="100" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeHuge/ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnHuge01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Value="100"  Path="FAKEFORGUI/./PlanetSizeHuge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"								   Operation="Addition"    Left="100"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHuge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnHuge01" Type="ClassPopulationPlanet">
@@ -1867,10 +2002,11 @@
     <BinaryModifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Left="100" BinaryOperation="Multiplication" Right="$(PlanetIsHuge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +3 GroundBattleBombardmentAttackerDamagesOnHuge -->
+  <!-- +150 GroundBattleBombardmentAttackerDamagesOnHuge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnHuge02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="150" Path="FAKEFORGUI/./PlanetSizeHuge"/>
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="150" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeHuge/ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnHuge02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Value="150" Path="FAKEFORGUI/./PlanetSizeHuge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"								   Operation="Addition"    Left="150"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHuge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnHuge02" Type="ClassPopulationPlanet">
@@ -1883,10 +2019,11 @@
   </SimulationDescriptor>
 
   <!-- GroundBattleBombardmentAttackerDamages on Strategic -->
-  <!-- +50 GroundBattleBombardmentAttackerDamagesOnStrategic -->
+  <!-- +100 GroundBattleBombardmentAttackerDamagesOnStrategic -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnStrategic00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="100" Path="FAKEFORGUI/./PlanetHasDepositStrategic"/>
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="100" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet,PlanetHasDepositStrategic/ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnStrategic00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Value="100" Path="FAKEFORGUI/./PlanetHasDepositStrategic"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"								   Operation="Addition"    Left="100"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetHasStrategicDeposit)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnStrategic00" Type="ClassPopulationPlanet">
@@ -1899,10 +2036,11 @@
   </SimulationDescriptor>
 
   <!-- GroundBattleBombardmentAttackerDamages on Luxury -->
-  <!-- +50 GroundBattleBombardmentAttackerDamagesOnLuxury -->
+  <!-- +100 GroundBattleBombardmentAttackerDamagesOnLuxury -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnLuxury00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="100" Path="FAKEFORGUI/./PlanetHasDepositLuxury"/>
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="100" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet,PlanetHasDepositLuxury/ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnLuxury00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Value="100" Path="FAKEFORGUI/./PlanetHasDepositLuxury"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"								   Operation="Addition"    Left="100"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetHasLuxuryDeposit)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnLuxury00" Type="ClassPopulationPlanet">
@@ -1915,10 +2053,11 @@
   </SimulationDescriptor>
   
   <!-- GroundBattleBombardmentAttackerDamages on Anomaly -->
-  <!-- +75 GroundBattleBombardmentAttackerDamagesOnAnomaly -->
+  <!-- +150 GroundBattleBombardmentAttackerDamagesOnAnomaly -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnAnomaly00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="150" Path="FAKEFORGUI/./PlanetAnomaly"/>
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="150" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetAnomaly/ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnAnomaly00,ClassPopulation" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Value="150" Path="FAKEFORGUI/./PlanetAnomaly"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"								   Operation="Addition"    Left="150"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetHasAnomaly)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnAnomaly00" Type="ClassPopulationPlanet">
@@ -1931,9 +2070,10 @@
   </SimulationDescriptor>
 
   <!-- GroundBattleBombardmentAttackerDamages per Minor Faction -->
-  <!-- +25 GroundBattleBombardmentAttackerDamagesPerMinorFaction -->
+  <!-- +50 GroundBattleBombardmentAttackerDamagesPerMinorFaction -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesPerMinorFaction00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="50" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesPerMinorFaction00,ClassPopulation"/>
+	<Modifier       TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Value="50"  Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Left="50"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesPerMinorFaction00" Type="ClassPopulationPlanet">
@@ -1944,9 +2084,10 @@
     <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="50" Path="ClassPopulation"/>
   </SimulationDescriptor>
   <!-- GroundBattleBombardmentAttackerDamages per Backdoor -->
-  <!-- +25 GroundBattleBombardmentAttackerDamagesPerBackdoor -->
+  <!-- +50 GroundBattleBombardmentAttackerDamagesPerBackdoor -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesPerBackdoor00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="50" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesPerBackdoor00,ClassPopulation"/>
+	<Modifier       TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Value="50"  Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Left="50"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesPerBackdoor00" Type="ClassPopulationPlanet">
@@ -1959,8 +2100,9 @@
 
   <!-- GroundBattleBombardmentAttackerDamages per Temple -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitPrimaryCustomGroundBattleBombardmentAttackerDamagesPerTemple00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages"          Operation="Addition"    Value="100"       Path="FAKEFORGUI/./PlanetWithTemple"/>
-    <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages"          Operation="Addition"    Value="100"       Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimaryCustomGroundBattleBombardmentAttackerDamagesPerTemple00,ClassPopulation" TooltipHidden="true" />
+    <Modifier       TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Value="150" Path="FAKEFORGUI/./PlanetWithTemple"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue0"								   Operation="Addition"    Left="150"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Left="$(PopulationAuxValue0)"    BinaryOperation="Multiplication" Right="$(PlanetHasTemple)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitPrimaryCustomGroundBattleBombardmentAttackerDamagesPerTemple00" Type="ClassPopulationPlanet">
@@ -1968,9 +2110,11 @@
     <BinaryModifier     TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages"    Operation="Addition"    Left="100"    BinaryOperation="Multiplication" Right="$(PlanetHasTemple)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +1 GroundBattleBombardmentAttackerDamages Level-->
+  <!-- +30 GroundBattleBombardmentAttackerDamages per System Level -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitPrimaryCustomGroundBattleBombardmentAttackerDamagesLevel00" Type="WithPopulationPlanet">
-    <BinaryModifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Left="30" BinaryOperation="Multiplication" Right="$(PopulationSystemLevel)"  Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimaryCustomGroundBattleBombardmentAttackerDamagesLevel00,ClassPopulation" TooltipHidden="true" SearchValueFromPath="true"/>
+    <Modifier       TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Value="30"  Path="FAKEFORGUI./SystemLevel"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"								   Operation="Addition"    Left="30"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PopulationSystemLevel)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitPrimaryCustomGroundBattleBombardmentAttackerDamagesLevel00" Type="ClassPopulationPlanet">
@@ -1978,10 +2122,11 @@
   </SimulationDescriptor>
 
   <!-- Defense on Cold -->
-  <!-- +25 DefenseOnCold -->
+  <!-- +50 DefenseOnCold -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDefenseOnCold00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="50" Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="50" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeCold/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnCold00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDefense" Operation="Addition"    Value="50"  Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="50"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDefense" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsCold)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnCold00" Type="ClassPopulationPlanet">
@@ -1993,10 +2138,11 @@
     <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="50" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +50 DefenseOnCold -->
+  <!-- +100 DefenseOnCold -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDefenseOnCold01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="100" Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="100" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeCold/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnCold01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDefense" Operation="Addition"    Value="100" Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="100"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDefense" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsCold)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnCold01" Type="ClassPopulationPlanet">
@@ -2004,10 +2150,11 @@
     <BinaryModifier TargetProperty="BonusPopulationDefense" Operation="Addition" Left="100" BinaryOperation="Multiplication" Right="$(PlanetIsCold)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +75 DefenseOnCold -->
+  <!-- +150 DefenseOnCold -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDefenseOnCold02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="150" Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="150" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeCold/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnCold02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDefense" Operation="Addition"    Value="150" Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="150"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDefense" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsCold)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnCold02" Type="ClassPopulationPlanet">
@@ -2020,10 +2167,11 @@
   </SimulationDescriptor>
 
   <!-- Defense on Temperate -->
-  <!-- +25 DefenseOnTemperate -->
+  <!-- +50 DefenseOnTemperate -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDefenseOnTemperate00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="50" Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="50" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTemperate/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnTemperate00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDefense" Operation="Addition"    Value="50"  Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="50"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDefense" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTemperate)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnTemperate00" Type="ClassPopulationPlanet">
@@ -2035,10 +2183,11 @@
     <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="05" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +50 DefenseOnTemperate -->
+  <!-- +100 DefenseOnTemperate -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDefenseOnTemperate01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="100" Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="100" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTemperate/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnTemperate01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDefense" Operation="Addition"    Value="100" Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="100"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDefense" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTemperate)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnTemperate01" Type="ClassPopulationPlanet">
@@ -2046,10 +2195,11 @@
     <BinaryModifier TargetProperty="BonusPopulationDefense" Operation="Addition" Left="100" BinaryOperation="Multiplication" Right="$(PlanetIsTemperate)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +75 DefenseOnTemperate -->
+  <!-- +150 DefenseOnTemperate -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDefenseOnTemperate02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="150" Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="150" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTemperate/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnTemperate02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDefense" Operation="Addition"    Value="150" Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="150"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDefense" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTemperate)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnTemperate02" Type="ClassPopulationPlanet">
@@ -2062,10 +2212,11 @@
   </SimulationDescriptor>
 
   <!-- Defense on Hot -->
-  <!-- +25 DefenseOnHot -->
+  <!-- +50 DefenseOnHot -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDefenseOnHot00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="50" Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="50" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeHot/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnHot00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDefense" Operation="Addition"    Value="50"  Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="50"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDefense" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHot)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnHot00" Type="ClassPopulationPlanet">
@@ -2077,10 +2228,11 @@
     <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="50" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +50 DefenseOnHot -->
+  <!-- +100 DefenseOnHot -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDefenseOnHot01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="100" Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="100" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeHot/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnHot01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDefense" Operation="Addition"    Value="100" Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="100"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDefense" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHot)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnHot01" Type="ClassPopulationPlanet">
@@ -2088,10 +2240,11 @@
     <BinaryModifier TargetProperty="BonusPopulationDefense" Operation="Addition" Left="100" BinaryOperation="Multiplication" Right="$(PlanetIsHot)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +75 DefenseOnHot -->
+  <!-- +150 DefenseOnHot -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDefenseOnHot02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="150" Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="150" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeHot/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnHot02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDefense" Operation="Addition"    Value="150" Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="150"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDefense" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHot)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnHot02" Type="ClassPopulationPlanet">
@@ -2104,10 +2257,11 @@
   </SimulationDescriptor>
 
   <!-- Defense on Teeming -->
-  <!-- +25 DefenseOnTeeming -->
+  <!-- +50 DefenseOnTeeming -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDefenseOnTeeming00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="50" Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="50" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTeeming/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnTeeming00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDefense" Operation="Addition"    Value="50"  Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="50"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDefense" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnTeeming00" Type="ClassPopulationPlanet">
@@ -2119,10 +2273,11 @@
     <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="50" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +50 DefenseOnTeeming -->
+  <!-- +100 DefenseOnTeeming -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDefenseOnTeeming01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="100" Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="100" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTeeming/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnTeeming01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDefense" Operation="Addition"    Value="100" Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="100"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDefense" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnTeeming01" Type="ClassPopulationPlanet">
@@ -2130,10 +2285,11 @@
     <BinaryModifier TargetProperty="BonusPopulationDefense" Operation="Addition" Left="100" BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +75 DefenseOnTeeming -->
+  <!-- +150 DefenseOnTeeming -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDefenseOnTeeming02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="150" Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="150" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTeeming/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnTeeming02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDefense" Operation="Addition"    Value="150" Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="150"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDefense" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnTeeming02" Type="ClassPopulationPlanet">
@@ -2146,10 +2302,11 @@
   </SimulationDescriptor>
 
   <!-- Defense on Meager -->
-  <!-- +25 DefenseOnMeager -->
+  <!-- +50 DefenseOnMeager -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDefenseOnMeager00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="50" Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="50" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeMeager/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnMeager00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDefense" Operation="Addition"    Value="50"  Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="50"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDefense" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMeager)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnMeager00" Type="ClassPopulationPlanet">
@@ -2161,10 +2318,11 @@
     <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="50" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +50 DefenseOnMeager -->
+  <!-- +100 DefenseOnMeager -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDefenseOnMeager01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="100" Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="100" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeMeager/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnMeager01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDefense" Operation="Addition"    Value="100" Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="100"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDefense" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMeager)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnMeager01" Type="ClassPopulationPlanet">
@@ -2172,10 +2330,11 @@
     <BinaryModifier TargetProperty="BonusPopulationDefense" Operation="Addition" Left="100" BinaryOperation="Multiplication" Right="$(PlanetIsMeager)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +75 DefenseOnMeager -->
+  <!-- +150 DefenseOnMeager -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDefenseOnMeager02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="150" Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="150" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeMeager/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnMeager02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDefense" Operation="Addition"    Value="150" Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="150"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDefense" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMeager)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnMeager02" Type="ClassPopulationPlanet">
@@ -2188,10 +2347,11 @@
   </SimulationDescriptor>
 
   <!-- Defense on Gas -->
-  <!-- +50 DefenseOnGas -->
+  <!-- +100 DefenseOnGas -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDefenseOnGas00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="100" Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="100" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeGas/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnGas00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDefense" Operation="Addition"    Value="100" Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="100"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDefense" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsGas)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnGas00" Type="ClassPopulationPlanet">
@@ -2203,10 +2363,11 @@
     <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="50" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +75 DefenseOnGas -->
+  <!-- +150 DefenseOnGas -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDefenseOnGas01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="150" Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="150" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeGas/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnGas01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDefense" Operation="Addition"    Value="150" Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="150"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDefense" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsGas)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnGas01" Type="ClassPopulationPlanet">
@@ -2218,10 +2379,11 @@
     <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="70" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +100 DefenseOnGas -->
+  <!-- +200 DefenseOnGas -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDefenseOnGas02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="200" Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="200" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeGas/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnGas02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDefense" Operation="Addition"    Value="200" Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="200"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDefense" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsGas)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnGas02" Type="ClassPopulationPlanet">
@@ -2234,11 +2396,12 @@
   </SimulationDescriptor>
 
   <!-- Defense on Happy -->
-  <!-- +25 DefenseOnHappy -->
+  <!-- +50 DefenseOnHappy -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDefenseOnHappy00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="50" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="50" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
-    <BinaryModifier TargetProperty="BonusPopulationDefense" Operation="Addition" Left="50" BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)"  Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnHappy00" TooltipHidden="true" SearchValueFromPath="true"/>
+    <Modifier		TargetProperty="BonusPopulationDefense"			Operation="Addition" Value="50" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
+    <Modifier		TargetProperty="BonusPopulationDefense"			Operation="Addition" Value="50" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"			Operation="Addition" Left="50"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDefense"			Operation="Addition" Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnHappy00" Type="ClassPopulationPlanet">
@@ -2251,11 +2414,12 @@
     <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="50" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +50 DefenseOnHappy -->
+  <!-- +100 DefenseOnHappy -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDefenseOnHappy01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="100" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="100" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
-    <BinaryModifier TargetProperty="BonusPopulationDefense" Operation="Addition" Left="100" BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnHappy01" TooltipHidden="true" SearchValueFromPath="true"/>
+    <Modifier		TargetProperty="BonusPopulationDefense"			Operation="Addition" Value="100" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
+    <Modifier		TargetProperty="BonusPopulationDefense"			Operation="Addition" Value="100" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"			Operation="Addition" Left="100"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDefense"			Operation="Addition" Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnHappy01" Type="ClassPopulationPlanet">
@@ -2264,11 +2428,12 @@
     <BinaryModifier TargetProperty="BonusPopulationDefense" Operation="Addition" Left="100" BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +75 DefenseOnHappy -->
+  <!-- +150 DefenseOnHappy -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDefenseOnHappy02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="150" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="150" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
-    <BinaryModifier TargetProperty="BonusPopulationDefense" Operation="Addition" Left="150" BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnHappy02" TooltipHidden="true" SearchValueFromPath="true"/>
+    <Modifier		TargetProperty="BonusPopulationDefense"			Operation="Addition" Value="150" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
+    <Modifier		TargetProperty="BonusPopulationDefense"			Operation="Addition" Value="150" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"			Operation="Addition" Left="150"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDefense"			Operation="Addition" Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnHappy02" Type="ClassPopulationPlanet">
@@ -2282,10 +2447,11 @@
   </SimulationDescriptor>
 
   <!-- Defense on Tiny -->
-  <!-- +1 DefenseOnTiny -->
+  <!-- +50 DefenseOnTiny -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDefenseOnTiny00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="50" Path="FAKEFORGUI/./PlanetSizeTiny"/>
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="50" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeTiny/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnTiny00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDefense" Operation="Addition"    Value="50"  Path="FAKEFORGUI/./PlanetSizeTiny"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="50"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDefense" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTiny)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnTiny00" Type="ClassPopulationPlanet">
@@ -2297,10 +2463,11 @@
     <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="50" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +2 DefenseOnTiny -->
+  <!-- +100 DefenseOnTiny -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDefenseOnTiny01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="100" Path="FAKEFORGUI/./PlanetSizeTiny"/>
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="100" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeTiny/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnTiny01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDefense" Operation="Addition"    Value="100" Path="FAKEFORGUI/./PlanetSizeTiny"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="100"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDefense" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTiny)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnTiny01" Type="ClassPopulationPlanet">
@@ -2308,10 +2475,11 @@
     <BinaryModifier TargetProperty="BonusPopulationDefense" Operation="Addition" Left="100" BinaryOperation="Multiplication" Right="$(PlanetIsTiny)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +3 DefenseOnTiny -->
+  <!-- +150 DefenseOnTiny -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDefenseOnTiny02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="150" Path="FAKEFORGUI/./PlanetSizeTiny"/>
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="150" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeTiny/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnTiny02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDefense" Operation="Addition"    Value="150" Path="FAKEFORGUI/./PlanetSizeTiny"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="150"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDefense" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTiny)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnTiny02" Type="ClassPopulationPlanet">
@@ -2324,10 +2492,11 @@
   </SimulationDescriptor>
 
   <!-- Defense on Small -->
-  <!-- +1 DefenseOnSmall -->
+  <!-- +50 DefenseOnSmall -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDefenseOnSmall00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="50" Path="FAKEFORGUI/./PlanetSizeSmall"/>
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="50" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeSmall/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnSmall00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDefense" Operation="Addition"    Value="50"  Path="FAKEFORGUI/./PlanetSizeSmall"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="50"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDefense" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsSmall)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnSmall00" Type="ClassPopulationPlanet">
@@ -2339,10 +2508,11 @@
     <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="50" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +2 DefenseOnSmall -->
+  <!-- +100 DefenseOnSmall -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDefenseOnSmall01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="100" Path="FAKEFORGUI/./PlanetSizeSmall"/>
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="100" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeSmall/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnSmall01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDefense" Operation="Addition"    Value="100" Path="FAKEFORGUI/./PlanetSizeSmall"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="100"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDefense" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsSmall)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnSmall01" Type="ClassPopulationPlanet">
@@ -2350,10 +2520,11 @@
     <BinaryModifier TargetProperty="BonusPopulationDefense" Operation="Addition" Left="100" BinaryOperation="Multiplication" Right="$(PlanetIsSmall)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +3 DefenseOnSmall -->
+  <!-- +150 DefenseOnSmall -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDefenseOnSmall02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="150" Path="FAKEFORGUI/./PlanetSizeSmall"/>
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="150" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeSmall/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnSmall02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDefense" Operation="Addition"    Value="150" Path="FAKEFORGUI/./PlanetSizeSmall"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="150"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDefense" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsSmall)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnSmall02" Type="ClassPopulationPlanet">
@@ -2366,10 +2537,11 @@
   </SimulationDescriptor>
 
   <!-- Defense on Medium -->
-  <!-- +1 DefenseOnMedium -->
+  <!-- +50 DefenseOnMedium -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDefenseOnMedium00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="50" Path="FAKEFORGUI/./PlanetSizeMedium"/>
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="50" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeMedium/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnMedium00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDefense" Operation="Addition"    Value="50"  Path="FAKEFORGUI/./PlanetSizeMedium"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="50"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDefense" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMedium)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnMedium00" Type="ClassPopulationPlanet">
@@ -2381,10 +2553,11 @@
     <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="50" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +2 DefenseOnMedium -->
+  <!-- +100 DefenseOnMedium -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDefenseOnMedium01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="100" Path="FAKEFORGUI/./PlanetSizeMedium"/>
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="100" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeMedium/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnMedium01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDefense" Operation="Addition"    Value="100" Path="FAKEFORGUI/./PlanetSizeMedium"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="100"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDefense" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMedium)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnMedium01" Type="ClassPopulationPlanet">
@@ -2392,10 +2565,11 @@
     <BinaryModifier TargetProperty="BonusPopulationDefense" Operation="Addition" Left="100" BinaryOperation="Multiplication" Right="$(PlanetIsMedium)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +3 DefenseOnMedium -->
+  <!-- +150 DefenseOnMedium -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDefenseOnMedium02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="150" Path="FAKEFORGUI/./PlanetSizeMedium"/>
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="150" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeMedium/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnMedium02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDefense" Operation="Addition"    Value="150" Path="FAKEFORGUI/./PlanetSizeMedium"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="150"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDefense" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMedium)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnMedium02" Type="ClassPopulationPlanet">
@@ -2408,10 +2582,11 @@
   </SimulationDescriptor>
 
   <!-- Defense on Large -->
-  <!-- +1 DefenseOnLarge -->
+  <!-- +50 DefenseOnLarge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDefenseOnLarge00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="50" Path="FAKEFORGUI/./PlanetSizeLarge"/>
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="50" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeLarge/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnLarge00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDefense" Operation="Addition"    Value="50"  Path="FAKEFORGUI/./PlanetSizeLarge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="50"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDefense" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsLarge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnLarge00" Type="ClassPopulationPlanet">
@@ -2423,10 +2598,11 @@
     <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="50" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +2 DefenseOnLarge -->
+  <!-- +100 DefenseOnLarge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDefenseOnLarge01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="100" Path="FAKEFORGUI/./PlanetSizeLarge"/>
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="100" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeLarge/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnLarge01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDefense" Operation="Addition"    Value="100" Path="FAKEFORGUI/./PlanetSizeLarge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="100"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDefense" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsLarge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnLarge01" Type="ClassPopulationPlanet">
@@ -2434,10 +2610,11 @@
     <BinaryModifier TargetProperty="BonusPopulationDefense" Operation="Addition" Left="100" BinaryOperation="Multiplication" Right="$(PlanetIsLarge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +3 DefenseOnLarge -->
+  <!-- +150 DefenseOnLarge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDefenseOnLarge02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="150" Path="FAKEFORGUI/./PlanetSizeLarge"/>
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="150" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeLarge/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnLarge02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDefense" Operation="Addition"    Value="150" Path="FAKEFORGUI/./PlanetSizeLarge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="150"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDefense" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsLarge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnLarge02" Type="ClassPopulationPlanet">
@@ -2450,10 +2627,11 @@
   </SimulationDescriptor>
 
   <!-- Defense on Huge -->
-  <!-- +1 DefenseOnHuge -->
+  <!-- +50 DefenseOnHuge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDefenseOnHuge00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="50" Path="FAKEFORGUI/./PlanetSizeHuge"/>
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="50" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeHuge/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnHuge00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDefense" Operation="Addition"    Value="50"  Path="FAKEFORGUI/./PlanetSizeHuge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="50"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDefense" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHuge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnHuge00" Type="ClassPopulationPlanet">
@@ -2465,10 +2643,11 @@
     <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="50" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +2 DefenseOnHuge -->
+  <!-- +100 DefenseOnHuge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDefenseOnHuge01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="100" Path="FAKEFORGUI/./PlanetSizeHuge"/>
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="100" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeHuge/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnHuge01" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDefense" Operation="Addition"    Value="100" Path="FAKEFORGUI/./PlanetSizeHuge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="100"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDefense" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHuge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnHuge01" Type="ClassPopulationPlanet">
@@ -2476,10 +2655,11 @@
     <BinaryModifier TargetProperty="BonusPopulationDefense" Operation="Addition" Left="100" BinaryOperation="Multiplication" Right="$(PlanetIsHuge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +3 DefenseOnHuge -->
+  <!-- +150 DefenseOnHuge -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDefenseOnHuge02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="150" Path="FAKEFORGUI/./PlanetSizeHuge"/>
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="150" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetSizeHuge/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnHuge02" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDefense" Operation="Addition"    Value="150" Path="FAKEFORGUI/./PlanetSizeHuge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="150"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDefense" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHuge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnHuge02" Type="ClassPopulationPlanet">
@@ -2492,26 +2672,28 @@
   </SimulationDescriptor>
 
   <!-- Defense on Strategic -->
-  <!-- +50 DefenseOnStrategic -->
+  <!-- +100 DefenseOnStrategic -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDefenseOnStrategic00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="60" Path="FAKEFORGUI/./PlanetHasDepositStrategic"/>
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="60" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet,PlanetHasDepositStrategic/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnStrategic00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDefense" Operation="Addition"    Value="100" Path="FAKEFORGUI/./PlanetHasDepositStrategic"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="100"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDefense" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetHasStrategicDeposit)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnStrategic00" Type="ClassPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="60" Path="FAKEFORGUI/./PlanetHasDepositStrategic"/>
-    <BinaryModifier TargetProperty="BonusPopulationDefense" Operation="Addition" Left="60" BinaryOperation="Multiplication" Right="$(PlanetHasStrategicDeposit)" TooltipHidden="true"/>
+    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="100" Path="FAKEFORGUI/./PlanetHasDepositStrategic"/>
+    <BinaryModifier TargetProperty="BonusPopulationDefense" Operation="Addition" Left="100" BinaryOperation="Multiplication" Right="$(PlanetHasStrategicDeposit)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationAssimilatedSecondaryCustomDefenseOnStrategic00" Type="ClassPopulationAssimilated">
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="30" Path="ClassPopulation"/>
+    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="50" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
   <!-- Defense on Luxury -->
-  <!-- +50 DefenseOnLuxury -->
+  <!-- +100 DefenseOnLuxury -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDefenseOnLuxury00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="100" Path="FAKEFORGUI/./PlanetHasDepositLuxury"/>
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="100" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet,PlanetHasDepositLuxury/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnLuxury00" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDefense" Operation="Addition"    Value="100" Path="FAKEFORGUI/./PlanetHasDepositLuxury"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="100"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDefense" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetHasLuxuryDeposit)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnLuxury00" Type="ClassPopulationPlanet">
@@ -2524,10 +2706,11 @@
   </SimulationDescriptor>
 
   <!-- Defense on Anomaly -->
-  <!-- +75 DefenseOnAnomaly -->
+  <!-- +150 DefenseOnAnomaly -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDefenseOnAnomaly00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="150" Path="FAKEFORGUI/./PlanetAnomaly"/>
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="150" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetAnomaly/ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnAnomaly00,ClassPopulation" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDefense" Operation="Addition"    Value="100" Path="FAKEFORGUI/./PlanetAnomaly"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="100"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDefense" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetHasAnomaly)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnAnomaly00" Type="ClassPopulationPlanet">
@@ -2540,9 +2723,10 @@
   </SimulationDescriptor>
 
   <!-- Defense per Minor Faction -->
-  <!-- +25 DefensePerMinorFaction -->
+  <!-- +50 DefensePerMinorFaction -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDefensePerMinorFaction00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="50" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitSecondaryCustomDefensePerMinorFaction00,ClassPopulation"/>
+	<Modifier       TargetProperty="BonusPopulationDefense" Operation="Addition"    Value="50"  Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationDefense" Operation="Addition"    Left="50"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefensePerMinorFaction00" Type="ClassPopulationPlanet">
@@ -2553,9 +2737,10 @@
     <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="50" Path="ClassPopulation"/>
   </SimulationDescriptor>
   <!-- Defense per Backdoor -->
-  <!-- +25 DefensePerBackdoor -->
+  <!-- +50 DefensePerBackdoor -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDefensePerBackdoor00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="50" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitSecondaryCustomDefensePerBackdoor00,ClassPopulation"/>
+	<Modifier       TargetProperty="BonusPopulationDefense" Operation="Addition"    Value="50"  Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationDefense" Operation="Addition"    Left="50"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefensePerBackdoor00" Type="ClassPopulationPlanet">
@@ -2568,8 +2753,9 @@
 
   <!-- Defense per Temple -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitPrimaryCustomDefensePerTemple00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDefense"          Operation="Addition"    Value="100"       Path="FAKEFORGUI/./PlanetWithTemple"/>
-    <Modifier TargetProperty="BonusPopulationDefense"          Operation="Addition"    Value="100"       Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimaryCustomDefensePerTemple00,ClassPopulation" TooltipHidden="true" />
+    <Modifier       TargetProperty="BonusPopulationDefense" Operation="Addition"    Value="100" Path="FAKEFORGUI/./PlanetWithTemple"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue0"	Operation="Addition"    Left="100"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDefense" Operation="Addition"    Left="$(PopulationAuxValue0)"    BinaryOperation="Multiplication" Right="$(PlanetHasTemple)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitPrimaryCustomDefensePerTemple00" Type="ClassPopulationPlanet">
@@ -2577,9 +2763,11 @@
     <BinaryModifier     TargetProperty="BonusPopulationDefense"    Operation="Addition"    Left="100"    BinaryOperation="Multiplication" Right="$(PlanetHasTemple)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +1 DefenseLevel-->
+  <!-- +30 Defense per System Level -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitPrimaryCustomDefenseLevel00" Type="WithPopulationPlanet">
-    <BinaryModifier TargetProperty="BonusPopulationDefense" Operation="Addition" Left="30" BinaryOperation="Multiplication" Right="$(PopulationSystemLevel)"  Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimaryCustomDefenseLevel00,ClassPopulation" TooltipHidden="true" SearchValueFromPath="true"/>
+    <Modifier       TargetProperty="BonusPopulationDefense"	    Operation="Addition"    Value="30"  Path="FAKEFORGUI./SystemLevel"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="30"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDefense"	    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PopulationSystemLevel)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitPrimaryCustomDefenseLevel00" Type="ClassPopulationPlanet">

--- a/Endless Space Competitive Mod/Simulation/Traits/SimulationDescriptors[8_Other].xml
+++ b/Endless Space Competitive Mod/Simulation/Traits/SimulationDescriptors[8_Other].xml
@@ -4,7 +4,8 @@
   <!-- FIDSI -->
   <!-- +1 FIDSI -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitPrimaryCustomFIDSI00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationFIDSI" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimaryCustomFIDSI00,ClassPopulation"/>
+	<Modifier       TargetProperty="BonusPopulationFIDSI"   Operation="Addition"    Value="1"   Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationFIDSI"   Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitPrimaryCustomFIDSI00" Type="ClassPopulationPlanet">
@@ -13,7 +14,8 @@
 
   <!-- +2 FIDSI -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitPrimaryCustomFIDSI01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationFIDSI" Operation="Addition" Value="2" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimaryCustomFIDSI01,ClassPopulation"/>
+	<Modifier       TargetProperty="BonusPopulationFIDSI"   Operation="Addition"    Value="2"   Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationFIDSI"   Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitPrimaryCustomFIDSI01" Type="ClassPopulationPlanet">
@@ -22,7 +24,8 @@
 
   <!-- +3 FIDSI -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitPrimaryCustomFIDSI02" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationFIDSI" Operation="Addition" Value="3" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimaryCustomFIDSILevel02,ClassPopulation"/>
+	<Modifier       TargetProperty="BonusPopulationFIDSI"   Operation="Addition"    Value="3"   Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationFIDSI"   Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitPrimaryCustomFIDSI02" Type="ClassPopulationPlanet">
@@ -33,28 +36,34 @@
     <Modifier TargetProperty="BonusPopulationFIDSI" Operation="Addition" Value="2" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- FIDSI Level -->
-  <!-- +1 FIDSILevel-->
+  <!-- FIDSI per System Level -->
+  <!-- +1 FIDSI per System Level -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitPrimaryCustomFIDSILevel00" Type="WithPopulationPlanet">
-    <BinaryModifier TargetProperty="BonusPopulationFIDSI" Operation="Addition" Left="1" BinaryOperation="Multiplication" Right="$(PopulationSystemLevel)"  Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimaryCustomFIDSILevel00,ClassPopulation" TooltipHidden="true" SearchValueFromPath="true"/>
+    <Modifier       TargetProperty="BonusPopulationFIDSI"	    Operation="Addition"    Value="1"   Path="FAKEFORGUI/./SystemLevel"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue0"	    Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFIDSI"	    Operation="Addition"    Left="$(PopulationAuxValue0)"    BinaryOperation="Multiplication" Right="$(PopulationSystemLevel)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitPrimaryCustomFIDSILevel00" Type="ClassPopulationPlanet">
     <BinaryModifier TargetProperty="BonusPopulationFIDSI" Operation="Addition" Left="1" BinaryOperation="Multiplication" Right="$(PopulationSystemLevel)"  Path="ClassPopulation" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +2 FIDSI Level -->
+  <!-- +2 FIDSI per System Level -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitPrimaryCustomFIDSILevel01" Type="WithPopulationPlanet">
-    <BinaryModifier TargetProperty="BonusPopulationFIDSI" Operation="Addition" Left="2" BinaryOperation="Multiplication" Right="$(PopulationSystemLevel)"  Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimaryCustomFIDSILevel01,ClassPopulation" TooltipHidden="true" SearchValueFromPath="true"/>
+    <Modifier       TargetProperty="BonusPopulationFIDSI"	    Operation="Addition"    Value="2"   Path="FAKEFORGUI/./SystemLevel"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue0"	    Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFIDSI"	    Operation="Addition"    Left="$(PopulationAuxValue0)"    BinaryOperation="Multiplication" Right="$(PopulationSystemLevel)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitPrimaryCustomFIDSILevel01" Type="ClassPopulationPlanet">
     <BinaryModifier TargetProperty="BonusPopulationFIDSI" Operation="Addition" Left="2" BinaryOperation="Multiplication" Right="$(PopulationSystemLevel)"  Path="ClassPopulation" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +3 FIDSI Level -->
+  <!-- +3 FIDSI per System Level -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitPrimaryCustomFIDSILevel02" Type="WithPopulationPlanet">
-    <BinaryModifier TargetProperty="BonusPopulationFIDSI" Operation="Addition" Left="3" BinaryOperation="Multiplication" Right="$(PopulationSystemLevel)"  Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimaryCustomFIDSILevel02,ClassPopulation" TooltipHidden="true" SearchValueFromPath="true"/>
+    <Modifier       TargetProperty="BonusPopulationFIDSI"	    Operation="Addition"    Value="3"   Path="FAKEFORGUI/./SystemLevel"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue0"	    Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFIDSI"	    Operation="Addition"    Left="$(PopulationAuxValue0)"    BinaryOperation="Multiplication" Right="$(PopulationSystemLevel)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitPrimaryCustomFIDSILevel02" Type="ClassPopulationPlanet">
@@ -62,9 +71,10 @@
   </SimulationDescriptor>
 
   <!-- Nakalim -->
-  <!-- +1 FID -->
+  <!-- +1 FIDS -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitPrimaryCustomFIDS00" Type="WithPopulationPlanet">
-    <Modifier       TargetProperty="BonusPopulationFIDS"      Operation="Addition"    Value="1"      Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimaryCustomFIDS00,ClassPopulation"/>
+	<Modifier       TargetProperty="BonusPopulationFIDS"    Operation="Addition"    Value="1"   Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationFIDS"    Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitPrimaryCustomFIDS00" Type="ClassPopulationPlanet">
@@ -73,13 +83,14 @@
 
   <!-- +1 FIDS per Temple -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomFIDSPerTemple00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationFIDS"          Operation="Addition"    Value="1"       Path="FAKEFORGUI/./PlanetWithTemple"/>
-    <Modifier TargetProperty="BonusPopulationFIDS"          Operation="Addition"    Value="1"       Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitSecondaryCustomFIDSPerTemple00,ClassPopulation" TooltipHidden="true" />
+    <Modifier       TargetProperty="BonusPopulationFIDS"	    Operation="Addition"    Value="1"   Path="FAKEFORGUI./PlanetWithTemple"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue0"	    Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFIDS"	    Operation="Addition"    Left="$(PopulationAuxValue0)"    BinaryOperation="Multiplication" Right="$(PlanetHasTemple)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomFIDSPerTemple00" Type="ClassPopulationPlanet">
-    <Modifier           TargetProperty="BonusPopulationHappiness"    Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetWithTemple"  />
-    <BinaryModifier     TargetProperty="BonusPopulationHappiness"    Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PlanetHasTemple)" TooltipHidden="true"/>
+    <Modifier           TargetProperty="BonusPopulationFIDS"    Operation="Addition"    Value="1"   Path="FAKEFORGUI/./PlanetWithTemple"  />
+    <BinaryModifier     TargetProperty="BonusPopulationFIDS"    Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PlanetHasTemple)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationAssimilatedPlanetFIDSNakalim" Type="ClassPopulationAssimilated">
@@ -109,10 +120,14 @@
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitPrimarySlowGrowthFIDS" Type="WithPopulationPlanet">
-    <Modifier       TargetProperty="BonusPopulationFood"        Operation="Addition"  Value="4"   Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimarySlowGrowthFIDS,ClassPopulation"/>
-    <Modifier       TargetProperty="BonusPopulationIndustry"    Operation="Addition"  Value="4"   Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimarySlowGrowthFIDS,ClassPopulation"/>
-    <Modifier       TargetProperty="BonusPopulationDust"        Operation="Addition"  Value="4"   Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimarySlowGrowthFIDS,ClassPopulation"/>
-    <Modifier       TargetProperty="BonusPopulationScience"     Operation="Addition"  Value="4"   Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimarySlowGrowthFIDS,ClassPopulation"/>
+    <Modifier		TargetProperty="BonusPopulationFood"      Operation="Addition"    Value="4"   Path="FAKEFORGUI/./ClassPopulation"/>
+    <Modifier		TargetProperty="BonusPopulationIndustry"  Operation="Addition"    Value="4"   Path="FAKEFORGUI/./ClassPopulation"/>
+    <Modifier		TargetProperty="BonusPopulationDust"      Operation="Addition"    Value="4"   Path="FAKEFORGUI/./ClassPopulation"/>
+    <Modifier		TargetProperty="BonusPopulationScience"   Operation="Addition"    Value="4"   Path="FAKEFORGUI/./ClassPopulation"/>
+    <BinaryModifier TargetProperty="BonusPopulationFood"      Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationIndustry"  Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDust"      Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScience"   Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <!--Craver assimlation bonus-->
@@ -122,8 +137,9 @@
   
   <!-- Luxury Deposit Value -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryLuxuryValue" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="ResourceBonus" Operation="Addition" Value="0.2" Path="FAKEFORGUI/./ClassPlanet/ResourceTypeLuxury"/>
-    <BinaryModifier TargetProperty="ResourceBonus" Operation="Addition" Left="0.2" BinaryOperation="Multiplication" Right="$(LuxuryBoostingPopulation)" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitSecondaryLuxuryValue,ClassPopulation/./ClassPlanet/ResourceTypeLuxury" TooltipHidden="true" SearchValueFromPath="true"/>
+    <Modifier       TargetProperty="ResourceBonus"		    Operation="Addition"    Value="0.2" Path="FAKEFORGUI/./ResourceTypeLuxury"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="0.2"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="ResourceBonus"		    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(LuxuryBoostingPopulation)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryLuxuryValue" Type="ClassPopulationPlanet">
@@ -140,8 +156,9 @@
 
   <!-- Strategic Deposit Value -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryStrategicValue" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="ResourceBonus" Operation="Addition" Value="0.2" Path="FAKEFORGUI/./ClassPlanet/ResourceTypeStrategic"/>
-    <BinaryModifier TargetProperty="ResourceBonus" Operation="Addition" Left="0.2" BinaryOperation="Multiplication" Right="$(StrategicBoostingPopulation)" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitSecondaryStrategicValue,ClassPopulation/./ClassPlanet/ResourceTypeStrategic" TooltipHidden="true" SearchValueFromPath="true"/>
+    <Modifier       TargetProperty="ResourceBonus"		    Operation="Addition"    Value="0.2" Path="FAKEFORGUI/./ResourceTypeStrategic"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="0.2"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="ResourceBonus"		    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(StrategicBoostingPopulation)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryStrategicValue" Type="ClassPopulationPlanet">

--- a/Endless Space Competitive Mod/Simulation/Traits/SimulationDescriptors[9_Vanilla].xml
+++ b/Endless Space Competitive Mod/Simulation/Traits/SimulationDescriptors[9_Vanilla].xml
@@ -9,8 +9,8 @@
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryAntiDepletion00" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="PlanetDepletionPerTurn" Operation="Subtraction" Value="0.5" Path="FAKEFORGUI/./ClassPlanet"/>
-    <Modifier TargetProperty="RepletionPerTurn" Operation="Addition" Value="0.5" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitSecondaryAntiDepletion00" TooltipHidden="true"/>
+	<Modifier       TargetProperty="PlanetDepletionPerTurn"	Operation="Subtraction" Value="0.5" Path="FAKEFORGUI/./ClassPlanet"/>
+	<BinaryModifier TargetProperty="RepletionPerTurn"		Operation="Addition"    Left="0.5"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationAssimilatedPlanetAntiDepletion00" Type="ClassPopulationAssimilated">
@@ -25,8 +25,8 @@
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryAntiDepletion01" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="PlanetDepletionPerTurn" Operation="Subtraction" Value="1" Path="FAKEFORGUI/./ClassPlanet"/>
-    <Modifier TargetProperty="RepletionPerTurn" Operation="Addition" Value="1" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitSecondaryAntiDepletion01" TooltipHidden="true"/>
+	<Modifier       TargetProperty="PlanetDepletionPerTurn"	Operation="Subtraction" Value="1"   Path="FAKEFORGUI/./ClassPlanet"/>
+	<BinaryModifier TargetProperty="RepletionPerTurn"		Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationAssimilatedPlanetAntiDepletion01" Type="ClassPopulationAssimilated">
@@ -65,27 +65,67 @@
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitPrimaryDefense" Type="WithPopulationPlanet">
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="40" Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/ClassPlanet/ClassPopulationPlanetModifiersTraitPrimaryDefense"/>
+	<Modifier       TargetProperty="BonusPopulationDefense"		 Operation="Addition"    Value="40"  Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationDefense"		 Operation="Addition"    Left="40"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationAssimilatedPlanetDefense" Type="ClassPopulationAssimilated">
     <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="20" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-	<!-- Arphar's Mess -->
-	<SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryInfluenceFertile" Type="ClassPopulationPlanet">
-		<Modifier       TargetProperty="BonusPopulationPrestige"    Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
-		<BinaryModifier TargetProperty="BonusPopulationPrestige"    Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
-	</SimulationDescriptor>
+  <!-- Arphar's Mess -->
+  <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryInfluenceFertile" Type="ClassPopulationPlanet">
+    <Modifier       TargetProperty="BonusPopulationPrestige"    Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestige"    Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
+  </SimulationDescriptor>
 
-	<SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryInfluenceFertile" Type="WithPopulationPlanet">
-		<Modifier TargetProperty="BonusPopulationPrestige"   Operation="Addition"    Value="2"  Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
-		<Modifier TargetProperty="BonusPopulationPrestige"   Operation="Addition"    Value="2"  Path="PopulationGrowthScoreBoosted/./ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTeeming/ClassPopulationPlanetModifiersTraitSecondaryInfluenceFertile" TooltipHidden="true"/>
-	</SimulationDescriptor>
+  <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryInfluenceFertile" Type="WithPopulationPlanet">
+    <Modifier       TargetProperty="BonusPopulationPrestige" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	 Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestige" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
+  </SimulationDescriptor>
 
-	<SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitPrimaryIDS" Type="ClassPopulationPlanet">
-		<Modifier       TargetProperty="BonusPopulationIndustry"  Operation="Addition"    Value="4" Path="ClassPopulation"/>
-		<Modifier       TargetProperty="BonusPopulationDust"      Operation="Addition"    Value="4" Path="ClassPopulation"/>
-		<Modifier       TargetProperty="BonusPopulationScience"   Operation="Addition"    Value="4" Path="ClassPopulation"/>
-	</SimulationDescriptor>
+  <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitPrimaryIDS" Type="ClassPopulationPlanet">
+    <Modifier       TargetProperty="BonusPopulationIndustry"  Operation="Addition"    Value="4" Path="ClassPopulation"/>
+    <Modifier       TargetProperty="BonusPopulationDust"      Operation="Addition"    Value="4" Path="ClassPopulation"/>
+    <Modifier       TargetProperty="BonusPopulationScience"   Operation="Addition"    Value="4" Path="ClassPopulation"/>
+  </SimulationDescriptor>
+  
+  <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitPrimaryIDS" Type="WithPopulationPlanet">
+    <Modifier       TargetProperty="BonusPopulationIndustry"  Operation="Addition"    Value="4"   Path="FAKEFORGUI/./ClassPopulation"/>
+    <Modifier       TargetProperty="BonusPopulationDust"      Operation="Addition"    Value="4"   Path="FAKEFORGUI/./ClassPopulation"/>
+    <Modifier       TargetProperty="BonusPopulationScience"   Operation="Addition"    Value="4"   Path="FAKEFORGUI/./ClassPopulation"/>
+    <BinaryModifier TargetProperty="BonusPopulationIndustry"  Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDust"      Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScience"   Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+  </SimulationDescriptor>
+  
+  <!-- Processing Power -->
+  <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitPrimaryProcessingPower01" Type="ClassPopulationPlanet">
+    <Modifier TargetProperty="BonusPopulationProcessingPower"                           Operation="Addition" Value="1" Path="ClassPopulation"/>
+  </SimulationDescriptor>
+  
+  <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitPrimaryProcessingPower01" Type="WithPopulationPlanet">
+    <Modifier       TargetProperty="BonusPopulationProcessingPower"    Operation="Addition"  Value="1"   Path="FAKEFORGUI/./ClassPopulation"/>
+    <BinaryModifier TargetProperty="BonusPopulationProcessingPower"    Operation="Addition"  Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+  </SimulationDescriptor>
+  
+  <!-- Happiness Defense Hissho -->
+  <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryHappinessSterile" Type="ClassPopulationPlanet">
+    <Modifier   TargetProperty="BonusPopulationHappiness"           Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
+    <Modifier   TargetProperty="BonusPopulationDefenseHissho"       Operation="Addition"    Value="20"  Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
+    <BinaryModifier   TargetProperty="BonusPopulationHappiness"     Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PlanetIsMeager)" TooltipHidden="true"/>
+    <BinaryModifier   TargetProperty="BonusPopulationDefenseHissho" Operation="Addition"    Left="20"   BinaryOperation="Multiplication" Right="$(PlanetIsMeager)" TooltipHidden="true"/>
+  </SimulationDescriptor>
+	
+  <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryHappinessSterile" Type="WithPopulationPlanet">
+    <Modifier       TargetProperty="BonusPopulationHappiness"       Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
+    <Modifier       TargetProperty="BonusPopulationDefenseHissho"   Operation="Addition"    Value="20"  Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"			Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"			Operation="Addition"    Left="20"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationHappiness"       Operation="Addition"    Left="$(PopulationAuxValue1)" BinaryOperation="Multiplication" Right="$(PlanetIsMeager)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDefenseHissho"   Operation="Addition"    Left="$(PopulationAuxValue1)" BinaryOperation="Multiplication" Right="$(PlanetIsMeager)" TooltipHidden="true"/>
+  </SimulationDescriptor>
+	
+	
 </Datatable>


### PR DESCRIPTION
Integration with Community Fixes/patchpreview fix to population boosts not stacking when two populations share the same trait. Not only applies the fix, also with this change ESG will be compatible with prepatchpreview.

Some discoveries and notes to take action:

- For some reason the first traits in most trait files (IE SimulationDescriptors[1_Food].xml) had a hyphen ouside the xml tags and not formatted lines. Fixed that. Also fixes most of the quantities in the comments.

- I added Path="FAKEFORGUI/./SystemLevel": on all the "per system level" boost traits, the problem is they don't add up as "per system level" is a tooltip override, so appears "on system level" for the boost and "per system level" on the original bonus. In the previous version the boost value was hidden. One option is to go with "on System Level" with both FAKE tooltips so they add up, another is to also hide it (removing the FAKFORGUI line), the other, seen in similar variable traits (per hacki door) is to add just a flat value for the boost instead.

- I fixed a few values that where inconsistent IE: 2 per luxury has sometimes 2 more per luxury boost but sometimes 1, so I went with 2 with all of them.

- Added and adjusted missing boost for the riftborn population, in ESG they had +4 IDS, but with vanilla gets +5 extra on boost (boostable only in custom factions).

- Added a Happiness/DefenseHissho trait and the processing power trait. Both are tied to existing population but missing on the files. All the added descriptions are on Simulation\Traits\SimulationDescriptors[9_Vanilla].xml

- These Traits have no UI text (can be seen in pink on custom faction trait droplist), didn't act on it as maybe are obsolete:

PopulationModifiersTraitPrimaryCustomHappinessPrestige00 PopulationModifiersTraitPrimaryCustomHappinessPrestige005 PopulationModifiersTraitSecondaryCustomScienceOnAnomaly000 PopulationModifiersTraitSecondaryCustomHappinessFoodOnMeager01