### PR TITLE
Critical adjustments, Manpower into Food changes and some bugfixes

### DIFF
--- a/Endless Space Competitive Mod/GUI/GuiElements[GameVariables].xml
+++ b/Endless Space Competitive Mod/GUI/GuiElements[GameVariables].xml
@@ -1154,4 +1154,14 @@
     <AltTitle>%GrowthForManpowerAltTitle</AltTitle>
   </ExtendedGuiElement>
 
+  <ExtendedGuiElement Name="EmpireManpowerUpkeep">
+    <Title>%EmpireManpowerUpkeepTitle</Title>
+	<AltTitle>%EmpireManpowerUpkeepAltTitle</AltTitle>
+  </ExtendedGuiElement>
+
+  <ExtendedGuiElement Name="EmpireLifeforceForManpower">
+    <Title>%EmpireLifeforceForManpowerTitle</Title>
+	<AltTitle>%EmpireLifeforceForManpowerAltTitle</AltTitle>
+  </ExtendedGuiElement>
+
 </Datatable>

--- a/Endless Space Competitive Mod/GUI/GuiElements[GameVariables].xml
+++ b/Endless Space Competitive Mod/GUI/GuiElements[GameVariables].xml
@@ -1143,4 +1143,15 @@
   <ExtendedGuiElement Name="SystemLifeforceFromMoneyConversion">
     <Title>%SystemLifeforceFromMoneyConversionTitle</Title>
   </ExtendedGuiElement>
+
+  <ExtendedGuiElement Name="EmpireManpowerFromEnrollment">
+    <Title>%GrowthForManpowerTitle</Title>
+    <Icons>
+      <Icon Size="Medium" Path="EmpireManPowerMedium" />
+      <Icon Size="Large" Path="Bitmaps/Dynamic/GameVariables/EmpireManPowerLarge" />
+    </Icons>
+    <Color Red="255" Green="255" Blue="255" Alpha="255" />
+    <AltTitle>%GrowthForManpowerAltTitle</AltTitle>
+  </ExtendedGuiElement>
+
 </Datatable>

--- a/Endless Space Competitive Mod/GUI/GuiElements[GameVariables].xml
+++ b/Endless Space Competitive Mod/GUI/GuiElements[GameVariables].xml
@@ -8,6 +8,18 @@
     <Color Red="255" Green="255" Blue="255" Alpha="255" />
   </ExtendedGuiElement>
 
+  <ExtendedGuiElement Name="CriticalHitChanceProjectile">
+    <Title>%PanelFeatureModuleEffectsWeaponCriticalHitTitle</Title>
+    <TooltipElement Percent="true"/>
+    <Color Red="255" Green="255" Blue="255" Alpha="255" />
+  </ExtendedGuiElement>
+
+  <ExtendedGuiElement Name="CriticalHitChanceEnergy">
+    <Title>%PanelFeatureModuleEffectsWeaponCriticalHitTitle</Title>
+    <TooltipElement Percent="true"/>
+    <Color Red="255" Green="255" Blue="255" Alpha="255" />
+  </ExtendedGuiElement>
+
   <GuiElement Name="ClassModuleIgnoresArmor">
     <Title>%ClassModuleIgnoresArmorTitle</Title>
   </GuiElement>

--- a/Endless Space Competitive Mod/GUI/Panels/PanelFeatureModuleEffectsDefinition.xml
+++ b/Endless Space Competitive Mod/GUI/Panels/PanelFeatureModuleEffectsDefinition.xml
@@ -144,6 +144,8 @@
       <Item Name="DamageEnergyFleet"                          Title="%PanelFeatureModuleDamageEnergyFleetTitle"                               MinValue="0.01" IsPercentage="true" Format="+{0}"/>
       <Item Name="DamageProjectileFleet"                      Title="%PanelFeatureModuleDamageProjectileFleetTitle"                           MinValue="0.01" IsPercentage="true" Format="+{0}"/>
       <Item Name="CriticalHitChance"                          Title="%PanelFeatureModuleEffectsWeaponCriticalHitTitle"                        MinValue="0.01" IsPercentage="true"/>
+      <Item Name="CriticalHitChanceProjectile"                Title="%PanelFeatureModuleEffectsWeaponCriticalHitTitle"                        MinValue="0.01" IsPercentage="true"/>
+      <Item Name="CriticalHitChanceEnergy"                    Title="%PanelFeatureModuleEffectsWeaponCriticalHitTitle"                        MinValue="0.01" IsPercentage="true"/>
       <Item Name="CriticalHitChanceFleet"                     Title="%PanelFeatureModuleEffectsWeaponCriticalHitFleetTitle"                   MinValue="0.01" IsPercentage="true"/>
       <Item Name="Damage"                                     Title="%FleetDamageTitle"                                                       MinValue="0.01" IsPercentage="true" Format="#C48594#{0}#REVERT#"/>
       <Item Name="FlotillaShipManpowerKillPerHitPercent"      Title="%PanelFeatureModuleEffectFlotillaShipManpowerKillPerHitPercentTitle"     MinValue="0.01" IsPercentage="true"/>

--- a/Endless Space Competitive Mod/Localization/brazilian/ES2_Localization_1-5-2.xml
+++ b/Endless Space Competitive Mod/Localization/brazilian/ES2_Localization_1-5-2.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Datatable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../Schemas/LocalizationPair.xsd">
+
+  <!-- Resource Tooltip -->
+  <LocalizationPair Name="%EmpireLifeforceForManpowerAltTitle">[lifeforceColored] para [ManpowerColored]</LocalizationPair>
+  <LocalizationPair Name="%EmpireManpowerUpkeepAltTitle">[manPowerColored] de Frotas/Sistemas</LocalizationPair>
+
+</Datatable>

--- a/Endless Space Competitive Mod/Localization/english/ES2_Localization_1-5-2.xml
+++ b/Endless Space Competitive Mod/Localization/english/ES2_Localization_1-5-2.xml
@@ -20,6 +20,10 @@
   <LocalizationPair Name="%StarSystemImprovementOnlyOnLevelMaxTooltipEffect">[blue-gray](Can only be built on a System of Level 4)#REVERT#</LocalizationPair>
   <LocalizationPair Name="%OverColonizationThresholdTitleHissho">Overcolonization Threshold</LocalizationPair>
 
+  <!-- Resource Tooltip -->
+  <LocalizationPair Name="%EmpireLifeforceForManpowerAltTitle">[lifeforceColored] to [ManpowerColored]</LocalizationPair>
+  <LocalizationPair Name="%EmpireManpowerUpkeepAltTitle">[manPowerColored] from Fleets/Systems</LocalizationPair>
+  
   <!-- Scavenger Hero Skill -->
   <LocalizationPair Name="%HeroSkill55_Approval_Perpop_Title">Scavenged Surplus</LocalizationPair>
   <LocalizationPair Name="%HeroSkill55_Approval_Perpop_Description">Through careful analysis of waste and the appropriate reclamation and filtration techniques, the hero is able to salvage meaningful quantities of resources seemingly out of thin air.</LocalizationPair>

--- a/Endless Space Competitive Mod/Localization/french/ES2_Localization_1-5-2.xml
+++ b/Endless Space Competitive Mod/Localization/french/ES2_Localization_1-5-2.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Datatable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../Schemas/LocalizationPair.xsd">
+
+  <!-- Resource Tooltip -->
+  <LocalizationPair Name="%EmpireLifeforceForManpowerAltTitle">[lifeforceColored] en [ManpowerColored]</LocalizationPair>
+  <LocalizationPair Name="%EmpireManpowerUpkeepAltTitle">[manPowerColored] venant de Flottes/Systèmes</LocalizationPair>
+
+</Datatable>

--- a/Endless Space Competitive Mod/Localization/german/ES2_Localization_1-5-2.xml
+++ b/Endless Space Competitive Mod/Localization/german/ES2_Localization_1-5-2.xml
@@ -130,6 +130,10 @@ Die Argosy verfügt über die Flotten-Tarnstufe 1 - auch ohne das Modul "Einfach
 	  <LocalizationPair Name="%FailureRequiresMoonDescription">Kann nur in einem System mit Mond gebaut werden</LocalizationPair>
 	  <LocalizationPair Name="%FailureForcedTeamsDescription">Die Spieleinstellungen zwingen Allianzen dauerhaft zu sein</LocalizationPair>
 
+  <!-- Resource Tooltip -->
+  <LocalizationPair Name="%EmpireLifeforceForManpowerAltTitle">[lifeforceColored] in [ManpowerColored]</LocalizationPair>
+  <LocalizationPair Name="%EmpireManpowerUpkeepAltTitle">[manPowerColored] von: Flotten/Systeme</LocalizationPair>
+
 	  <!-- Pre-Teams -->
 	  <LocalizationPair Name="%SettingPreTeamsTitle">Allianzen</LocalizationPair>
 	  <LocalizationPair Name="%SettingPreTeamsDescription">Legt fest, wie Allianzen gehandhabt werden.</LocalizationPair>

--- a/Endless Space Competitive Mod/Localization/polish/ES2_Localization_1-5-2.xml
+++ b/Endless Space Competitive Mod/Localization/polish/ES2_Localization_1-5-2.xml
@@ -50,6 +50,10 @@ Singularities have a fixed duration and can only be placed on a system within th
 Starting Ships: 1x [colonizer], 1x [explorer]
 Faction Pact: +0.67% [industryColored] per [turn] (Max: 20%)</LocalizationPair>
 
+  <!-- Resource Tooltip -->
+  <LocalizationPair Name="%EmpireLifeforceForManpowerAltTitle">[lifeforceColored] na [ManpowerColored]</LocalizationPair>
+  <LocalizationPair Name="%EmpireManpowerUpkeepAltTitle">[manPowerColored] z Floty/Systemy</LocalizationPair>
+
   <!-- Nakalim -->
   <LocalizationPair Name="%LawP00L05TemplarsTooltipOverride">-2 [happinessColored] per [population] on Planets with Temples</LocalizationPair>
   <LocalizationPair Name="%LawP00L05TemplarsTitle">Scrupulous Scientific Examination of Cultural Artifacts</LocalizationPair>

--- a/Endless Space Competitive Mod/Localization/russian/ES2_Localization_1-5-2.xml
+++ b/Endless Space Competitive Mod/Localization/russian/ES2_Localization_1-5-2.xml
@@ -60,6 +60,10 @@
 Стартовый флот: 1x [colonizer], 1x [explorer]
 Пакт наций: +0.67% [industryColored] в [turn] (Макс: 20%)</LocalizationPair>
 
+  <!-- Resource Tooltip -->
+  <LocalizationPair Name="%EmpireLifeforceForManpowerAltTitle">[lifeforceColored] на [ManpowerColored]</LocalizationPair>
+  <LocalizationPair Name="%EmpireManpowerUpkeepAltTitle">[manPowerColored] из Флоты/Системы</LocalizationPair>
+
   <!-- Nakalim -->
   <LocalizationPair Name="%LawP00L05TemplarsTooltipOverride">-2 [happinessColored] за [population] на планетах с Храмом</LocalizationPair>
   <LocalizationPair Name="%LawP00L05TemplarsTitle">Скрупулезное научное исследование культурных артефактов</LocalizationPair>

--- a/Endless Space Competitive Mod/Localization/spanish/ES2_Localization_1-5-2.xml
+++ b/Endless Space Competitive Mod/Localization/spanish/ES2_Localization_1-5-2.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Datatable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../Schemas/LocalizationPair.xsd">
+
+  <!-- Resource Tooltip -->
+  <LocalizationPair Name="%EmpireLifeforceForManpowerAltTitle">[lifeforceColored] para [ManpowerColored]</LocalizationPair>
+  <LocalizationPair Name="%EmpireManpowerUpkeepAltTitle">[manPowerColored] de Flotas/Sistemas</LocalizationPair>
+
+</Datatable>

--- a/Endless Space Competitive Mod/Simulation/Battles/ModuleDefinitions[ModuleFactionQuest].xml
+++ b/Endless Space Competitive Mod/Simulation/Battles/ModuleDefinitions[ModuleFactionQuest].xml
@@ -87,6 +87,19 @@
     <BattleActionReference Name="BattleActionSupportInitialize"/>
   </SupportModule>
 
+  <SupportModule Name="ModuleSupportJuggernautTemplars" Family="FleetEnhancerBase" Level="1">
+    <Cost ResourceName="SystemProduction">200</Cost>
+    <InterpreterPrerequisite Flags="Edition">Path(Context, @'ClassShip,ShipRoleCarrier') or Path(Context, @'ClassShip,ShipRoleBattleship')</InterpreterPrerequisite>
+    <PathPrerequisite Flags="NoMoreThanOneModuleOfThisType,Edition,Disable" Inverted="true">ClassShip/ClassSection/ClassModule,ModuleSupportJuggernautFleetEnhancerTemplars</PathPrerequisite>
+    <PathPrerequisite Flags="UnlockAvailability,Edition,Faction,AffinityGameplayTechnologyTemplars" Inverted="false">../ClassEmpire,AffinityGameplayTemplars</PathPrerequisite>
+    <TechnologyPrerequisite Flags="Edition">TechnologyJuggernautFactionModule</TechnologyPrerequisite>
+    <SimulationDescriptorReference Name="ClassModuleSupport"/>
+    <SimulationDescriptorReference Name="ClassModuleCarrierBattleshipOnly"/>
+    <SimulationDescriptorReference Name="ModuleSupportJuggernautFleetEnhancer"/>
+    <SimulationDescriptorReference Name="ModuleSupportJuggernautFleetEnhancerTemplars"/>
+    <BattleActionReference Name="BattleActionSupportInitialize"/>
+  </SupportModule>
+
   <SupportModule Name="ModuleSupportJuggernautVampirilis" Family="DestructionChargeRateBase" Level="1">
     <Cost ResourceName="SystemProduction">120</Cost>
     <InterpreterPrerequisite Flags="Edition">Path(Context, @'ClassShip,ShipRoleCarrier') or Path(Context, @'ClassShip,ShipRoleJuggernaut') or Path(Context, @'ClassShip,ShipRoleBattleship')</InterpreterPrerequisite>

--- a/Endless Space Competitive Mod/Simulation/Battles/SimulationDescriptors[ModuleFactionJuggernaut].xml
+++ b/Endless Space Competitive Mod/Simulation/Battles/SimulationDescriptors[ModuleFactionJuggernaut].xml
@@ -124,8 +124,8 @@
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ModuleSupportJuggernautFleetEnhancerTemplars" Type="ModuleSupportJuggernautFleetEnhancer">
-    <Modifier TargetProperty="CriticalHitChanceFleet" Operation="Addition" Value="0.15" Path="ModuleSupportJuggernautFleetEnhancer"/>
-    <Modifier TargetProperty="FlotillaMoraleBonusPercent" Operation="Addition" Value="0.15" Path="ClassModuleSupport"/>
+    <Modifier TargetProperty="CriticalHitChanceFleet" Operation="Addition" Value="0.05" Path="ModuleSupportJuggernautFleetEnhancer"/>
+    <Modifier TargetProperty="FlotillaMoraleBonusPercent" Operation="Addition" Value="0.3" Path="ClassModuleSupport"/>
     <Modifier TargetProperty="OffensiveMilitaryPower" Operation="Percent" Value="0.10" Path="../ClassGarrison/ClassShip"/>
     <BinaryModifier TargetProperty="TotalIndustryCost"    Operation="Addition" Left="200" BinaryOperation="Multiplication" Right="$(Multiplier)" Path="../ClassShip" TooltipHidden="true"/>
   </SimulationDescriptor>

--- a/Endless Space Competitive Mod/Simulation/Battles/SimulationDescriptors[ModuleSupport].xml
+++ b/Endless Space Competitive Mod/Simulation/Battles/SimulationDescriptors[ModuleSupport].xml
@@ -513,7 +513,7 @@
 
   <SimulationDescriptor Name="ModuleSupportEMPWeaponDefense1Strategic4" Type="ModuleSupport">
     <Modifier TargetProperty="EMPWeaponDefense" Operation="Addition" Value="0.5" Path="ClassModule" TooltipHidden="true"/>
-    <Modifier TargetProperty="CriticalHitChance" Operation="Addition" Value="0.1" Path="ModuleSupportEMPWeaponDefense"/>
+    <Modifier TargetProperty="CriticalHitChance" Operation="Addition" Value="0.05" Path="ModuleSupportEMPWeaponDefense"/>
     <BinaryModifier TargetProperty="TotalIndustryCost"    Operation="Addition" Left="50" BinaryOperation="Multiplication" Right="$(Multiplier)" Path="../ClassShip" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="TotalStrategic4Cost"    Operation="Addition" Left="1" BinaryOperation="Multiplication" Right="$(Multiplier)" Path="../ClassShip" TooltipHidden="true"/>
   </SimulationDescriptor>
@@ -564,6 +564,13 @@
   <!--  ********************************************  -->
 
   <!--  Energy Enhancers  -->
+  <SimulationDescriptor Name="ModuleSupportEnergyEnhancer"                   Type="ModuleSupportEnergyEnhancer">
+    <Property Name="DamageEnergy"                BaseValue="0"/>
+    <Property Name="CriticalHitChance"                BaseValue="0"/>
+    <Modifier TargetProperty="DamageEnergy"            Operation="Addition" Value="$(DamageEnergy)"       Path="../ClassShip"     Priority="1"/>
+    <Modifier TargetProperty="CriticalHitChanceEnergy" Operation="Addition" Value="$(CriticalHitChance)"       Path="../ClassShip"     Priority="1"/>
+  </SimulationDescriptor>
+
   <SimulationDescriptor Name="ModuleSupportEnergyEnhancer1" Type="ModuleSupportEnergyEnhancer">
     <Modifier TargetProperty="DamageEnergy" Operation="Addition" Value="0.20" Path="ModuleSupportEnergyEnhancer"/>
     <BinaryModifier TargetProperty="TotalIndustryCost"    Operation="Addition" Left="50" BinaryOperation="Multiplication" Right="$(Multiplier)" Path="../ClassShip" TooltipHidden="true"/>
@@ -576,21 +583,28 @@
     <BinaryModifier TargetProperty="TotalStrategic2Cost"    Operation="Addition" Left="1" BinaryOperation="Multiplication" Right="$(Multiplier)" Path="../ClassShip" TooltipHidden="true"/>
   </SimulationDescriptor>
   <SimulationDescriptor Name="ModuleSupportEnergyEnhancer3Strategic4" Type="ModuleSupportEnergyEnhancer">
-    <Modifier TargetProperty="DamageEnergy" Operation="Addition" Value="0.30" Path="ModuleSupportEnergyEnhancer"/>
-    <Modifier TargetProperty="CriticalHitChance" Operation="Addition" Value="0.1" Path="ModuleSupportEnergyEnhancer"/>
+    <Modifier TargetProperty="DamageEnergy" Operation="Addition" Value="0.35" Path="ModuleSupportEnergyEnhancer"/>
+    <Modifier TargetProperty="CriticalHitChance" Operation="Addition" Value="0.08" Path="ModuleSupportEnergyEnhancer"/>
     <Modifier TargetProperty="OffensiveMilitaryPower" Operation="Percent" Value="0.06" Path="../ClassShip"/>
     <BinaryModifier TargetProperty="TotalIndustryCost"    Operation="Addition" Left="70" BinaryOperation="Multiplication" Right="$(Multiplier)" Path="../ClassShip" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="TotalStrategic4Cost"    Operation="Addition" Left="1" BinaryOperation="Multiplication" Right="$(Multiplier)" Path="../ClassShip" TooltipHidden="true"/>
   </SimulationDescriptor>
   <SimulationDescriptor Name="ModuleSupportEnergyEnhancer4Strategic6" Type="ModuleSupportEnergyEnhancer">
-    <Modifier TargetProperty="DamageEnergy" Operation="Addition" Value="0.35" Path="ModuleSupportEnergyEnhancer"/>
-    <Modifier TargetProperty="CriticalHitChance" Operation="Addition" Value="0.15" Path="ModuleSupportEnergyEnhancer"/>
+    <Modifier TargetProperty="DamageEnergy" Operation="Addition" Value="0.45" Path="ModuleSupportEnergyEnhancer"/>
+    <Modifier TargetProperty="CriticalHitChance" Operation="Addition" Value="0.1" Path="ModuleSupportEnergyEnhancer"/>
     <Modifier TargetProperty="OffensiveMilitaryPower" Operation="Percent" Value="0.07" Path="../ClassShip"/>
     <BinaryModifier TargetProperty="TotalIndustryCost"    Operation="Addition" Left="80" BinaryOperation="Multiplication" Right="$(Multiplier)" Path="../ClassShip" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="TotalStrategic6Cost"    Operation="Addition" Left="1" BinaryOperation="Multiplication" Right="$(Multiplier)" Path="../ClassShip" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <!--  Projectile Enhancers  -->
+  <SimulationDescriptor Name="ModuleSupportProjectileEnhancer"                   Type="ModuleSupportProjectileEnhancer">
+    <Property Name="DamageProjectile"                BaseValue="0"/>
+    <Property Name="CriticalHitChance"                BaseValue="0"/>
+    <Modifier TargetProperty="DamageProjectile"            Operation="Addition" Value="$(DamageProjectile)"       Path="../ClassShip"     Priority="1"/>
+    <Modifier TargetProperty="CriticalHitChanceProjectile" Operation="Addition" Value="$(CriticalHitChance)"       Path="../ClassShip"     Priority="1"/>
+  </SimulationDescriptor>
+
   <SimulationDescriptor Name="ModuleSupportProjectileEnhancer1" Type="ModuleSupportProjectileEnhancer">
     <Modifier TargetProperty="DamageProjectile" Operation="Addition" Value="0.20" Path="ModuleSupportProjectileEnhancer"/>
     <BinaryModifier TargetProperty="TotalIndustryCost"    Operation="Addition" Left="50" BinaryOperation="Multiplication" Right="$(Multiplier)" Path="../ClassShip" TooltipHidden="true"/>
@@ -603,15 +617,15 @@
     <BinaryModifier TargetProperty="TotalStrategic1Cost"    Operation="Addition" Left="1" BinaryOperation="Multiplication" Right="$(Multiplier)" Path="../ClassShip" TooltipHidden="true"/>
   </SimulationDescriptor>
   <SimulationDescriptor Name="ModuleSupportProjectileEnhancer3Strategic3" Type="ModuleSupportProjectileEnhancer">
-    <Modifier TargetProperty="DamageProjectile" Operation="Addition" Value="0.30" Path="ModuleSupportProjectileEnhancer"/>
-    <Modifier TargetProperty="CriticalHitChance" Operation="Addition" Value="0.1" Path="ModuleSupportProjectileEnhancer"/>
+    <Modifier TargetProperty="DamageProjectile" Operation="Addition" Value="0.35" Path="ModuleSupportProjectileEnhancer"/>
+    <Modifier TargetProperty="CriticalHitChance" Operation="Addition" Value="0.08" Path="ModuleSupportProjectileEnhancer"/>
     <Modifier TargetProperty="OffensiveMilitaryPower" Operation="Percent" Value="0.06" Path="../ClassShip"/>
     <BinaryModifier TargetProperty="TotalIndustryCost"    Operation="Addition" Left="70" BinaryOperation="Multiplication" Right="$(Multiplier)" Path="../ClassShip" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="TotalStrategic3Cost"    Operation="Addition" Left="1" BinaryOperation="Multiplication" Right="$(Multiplier)" Path="../ClassShip" TooltipHidden="true"/>
   </SimulationDescriptor>
   <SimulationDescriptor Name="ModuleSupportProjectileEnhancer4Strategic5" Type="ModuleSupportProjectileEnhancer">
-    <Modifier TargetProperty="DamageProjectile" Operation="Addition" Value="0.35" Path="ModuleSupportProjectileEnhancer"/>
-    <Modifier TargetProperty="CriticalHitChance" Operation="Addition" Value="0.15" Path="ModuleSupportProjectileEnhancer"/>
+    <Modifier TargetProperty="DamageProjectile" Operation="Addition" Value="0.45" Path="ModuleSupportProjectileEnhancer"/>
+    <Modifier TargetProperty="CriticalHitChance" Operation="Addition" Value="0.1" Path="ModuleSupportProjectileEnhancer"/>
     <Modifier TargetProperty="OffensiveMilitaryPower" Operation="Percent" Value="0.07" Path="../ClassShip"/>
     <BinaryModifier TargetProperty="TotalIndustryCost"    Operation="Addition" Left="80" BinaryOperation="Multiplication" Right="$(Multiplier)" Path="../ClassShip" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="TotalStrategic5Cost"    Operation="Addition" Left="1" BinaryOperation="Multiplication" Right="$(Multiplier)" Path="../ClassShip" TooltipHidden="true"/>

--- a/Endless Space Competitive Mod/Simulation/Battles/SimulationDescriptors[ModuleWeapon].xml
+++ b/Endless Space Competitive Mod/Simulation/Battles/SimulationDescriptors[ModuleWeapon].xml
@@ -319,7 +319,7 @@
 
   <SimulationDescriptor Name="ModuleWeaponKinetic3Strategic3"  Type="ModuleWeapon">
     <Modifier TargetProperty="Damage"                    Operation="Addition"  Value="118"   TooltipHidden="true"/>
-    <Modifier TargetProperty="CriticalHitChance"         Operation="Addition"  Value="0.2"   TooltipHidden="true"/>
+    <Modifier TargetProperty="CriticalHitChance"         Operation="Addition"  Value="0.1"   TooltipHidden="true"/>
     <Modifier TargetProperty="Cooldown"                  Operation="Addition"  Value="-0.1"  TooltipHidden="true"/>
     <BinaryModifier TargetProperty="TotalIndustryCost"    Operation="Addition" Left="$(WeaponIndustryTier2)" BinaryOperation="Multiplication" Right="$(Multiplier)" Path="ClassModuleWeapon" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="TotalStrategic3Cost"       Operation="Addition" Left="1" BinaryOperation="Multiplication" Right="$(Multiplier)" Path="ClassModuleWeapon" TooltipHidden="true"/>
@@ -356,7 +356,7 @@
 
   <SimulationDescriptor Name="ModuleWeaponKinetic4Strategic3"  Type="ModuleWeapon">
     <Modifier TargetProperty="Damage"                    Operation="Addition"  Value="144"   TooltipHidden="true"/>
-    <Modifier TargetProperty="CriticalHitChance"         Operation="Addition"  Value="0.2"   TooltipHidden="true"/>
+    <Modifier TargetProperty="CriticalHitChance"         Operation="Addition"  Value="0.1"   TooltipHidden="true"/>
     <Modifier TargetProperty="Cooldown"                  Operation="Addition"  Value="-0.1"  TooltipHidden="true"/>
     <BinaryModifier TargetProperty="TotalIndustryCost"    Operation="Addition" Left="$(WeaponIndustryTier3)" BinaryOperation="Multiplication" Right="$(Multiplier)" Path="ClassModuleWeapon" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="TotalStrategic3Cost"       Operation="Addition" Left="1" BinaryOperation="Multiplication" Right="$(Multiplier)" Path="ClassModuleWeapon" TooltipHidden="true"/>
@@ -492,7 +492,7 @@
 
   <SimulationDescriptor Name="ModuleWeaponMissile3Strategic3"  Type="ModuleWeapon">
     <Modifier TargetProperty="Damage"                       Operation="Addition" Value="355"    TooltipHidden="true"/>
-    <Modifier TargetProperty="CriticalHitChance"            Operation="Addition" Value="0.2"    TooltipHidden="true"/>
+    <Modifier TargetProperty="CriticalHitChance"            Operation="Addition" Value="0.1"    TooltipHidden="true"/>
     <BinaryModifier TargetProperty="TotalIndustryCost"    Operation="Addition" Left="$(WeaponIndustryTier2)" BinaryOperation="Multiplication" Right="$(Multiplier)" Path="ClassModuleWeapon" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="TotalStrategic3Cost"    Operation="Addition" Left="1" BinaryOperation="Multiplication" Right="$(Multiplier)" Path="ClassModuleWeapon" TooltipHidden="true"/>
 
@@ -511,7 +511,7 @@
 
   <SimulationDescriptor Name="ModuleWeaponMissile4Strategic3"  Type="ModuleWeapon">
     <Modifier TargetProperty="Damage"                       Operation="Addition" Value="430"    TooltipHidden="true"/>
-    <Modifier TargetProperty="CriticalHitChance"            Operation="Addition" Value="0.2"    TooltipHidden="true"/>
+    <Modifier TargetProperty="CriticalHitChance"            Operation="Addition" Value="0.1"    TooltipHidden="true"/>
     <BinaryModifier TargetProperty="TotalIndustryCost"    Operation="Addition" Left="$(WeaponIndustryTier3)" BinaryOperation="Multiplication" Right="$(Multiplier)" Path="ClassModuleWeapon" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="TotalStrategic3Cost"    Operation="Addition" Left="1" BinaryOperation="Multiplication" Right="$(Multiplier)" Path="ClassModuleWeapon" TooltipHidden="true"/>
 
@@ -743,7 +743,7 @@
 
   <SimulationDescriptor Name="ModuleWeaponBeam3Strategic4"     Type="ModuleWeapon">
     <Modifier TargetProperty="Damage"                       Operation="Addition" Value="205"    TooltipHidden="true"/>
-    <Modifier TargetProperty="CriticalHitChance"            Operation="Addition" Value="0.15"   TooltipHidden="true"/>
+    <Modifier TargetProperty="CriticalHitChance"            Operation="Addition" Value="0.1"   TooltipHidden="true"/>
     <BinaryModifier TargetProperty="TotalIndustryCost"    Operation="Addition" Left="$(WeaponIndustryTier2)" BinaryOperation="Multiplication" Right="$(Multiplier)" Path="ClassModuleWeapon" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="TotalStrategic4Cost"    Operation="Addition" Left="1" BinaryOperation="Multiplication" Right="$(Multiplier)" Path="ClassModuleWeapon" TooltipHidden="true"/>
   </SimulationDescriptor>
@@ -756,7 +756,7 @@
 
   <SimulationDescriptor Name="ModuleWeaponBeam4Strategic4"     Type="ModuleWeapon">
     <Modifier TargetProperty="Damage"                       Operation="Addition" Value="235"    TooltipHidden="true"/>
-    <Modifier TargetProperty="CriticalHitChance"            Operation="Addition" Value="0.15"   TooltipHidden="true"/>
+    <Modifier TargetProperty="CriticalHitChance"            Operation="Addition" Value="0.1"   TooltipHidden="true"/>
     <BinaryModifier TargetProperty="TotalIndustryCost"    Operation="Addition" Left="$(WeaponIndustryTier3)" BinaryOperation="Multiplication" Right="$(Multiplier)" Path="ClassModuleWeapon" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="TotalStrategic4Cost"    Operation="Addition" Left="1" BinaryOperation="Multiplication" Right="$(Multiplier)" Path="ClassModuleWeapon" TooltipHidden="true"/>
   </SimulationDescriptor>

--- a/Endless Space Competitive Mod/Simulation/Battles/SimulationDescriptors[Ship].xml
+++ b/Endless Space Competitive Mod/Simulation/Battles/SimulationDescriptors[Ship].xml
@@ -201,6 +201,8 @@
     <Property Name="DamageMedium"                   BaseValue="0" MinValue="-0.95"/>
     <Property Name="DamageLong"                     BaseValue="0" MinValue="-0.95"/>
     <Property Name="CriticalHitChance"              BaseValue="0" MinValue="-0.95"/>
+    <Property Name="CriticalHitChanceProjectile"    BaseValue="0" MinValue="-0.95"/>
+    <Property Name="CriticalHitChanceEnergy"        BaseValue="0" MinValue="-0.95"/>
     <Property Name="ShieldPenetrationFactor"	    BaseValue="0" MinValue="-0.95"/>
     <Property Name="HullPlatingPenetrationFactor"   BaseValue="0" MinValue="-0.95"/>
     <Property Name="DamageShield"                   BaseValue="0" MinValue="-0.95"/>
@@ -355,6 +357,9 @@
     <Modifier TargetProperty="ShipManpowerKillPerHit"   Operation="Percent" Value="$(ShipManpowerKillPerHitPercent)"  Path="ClassShip/ClassSection/ClassModuleWeapon" />
 
     <Modifier TargetProperty="CriticalHitChance"        Operation="Addition" Value="$(CriticalHitChance)"           Path="ClassShip/ClassSection/ClassModuleWeapon" />
+	<Modifier TargetProperty="CriticalHitChance"        Operation="Addition" Value="$(CriticalHitChanceProjectile)" Path="ClassShip/ClassSection/ClassModuleWeapon,!ClassModuleWeaponLaser,!ClassModuleWeaponBeam" Priority="1" />
+	<Modifier TargetProperty="CriticalHitChance"        Operation="Addition" Value="$(CriticalHitChanceEnergy)"     Path="ClassShip/ClassSection/ClassModuleWeapon,ClassModuleWeaponLaser" Priority="1" />
+	<Modifier TargetProperty="CriticalHitChance"        Operation="Addition" Value="$(CriticalHitChanceEnergy)"     Path="ClassShip/ClassSection/ClassModuleWeapon,ClassModuleWeaponBeam" Priority="1" />
     <Modifier TargetProperty="ShieldPenetrationFactor"			Operation="Addition" Value="$(ShieldPenetrationFactor)"				Path="ClassShip/ClassSection/ClassModuleWeapon" />
     <Modifier TargetProperty="HullPlatingPenetrationFactor"     Operation="Addition" Value="$(HullPlatingPenetrationFactor)"        Path="ClassShip/ClassSection/ClassModuleWeapon" />
     <Modifier TargetProperty="DamageShield"             Operation="Addition" Value="$(DamageShield)"                Path="ClassShip/ClassSection/ClassModuleWeapon" />

--- a/Endless Space Competitive Mod/Simulation/EntityActions.xml
+++ b/Endless Space Competitive Mod/Simulation/EntityActions.xml
@@ -585,7 +585,7 @@
   </OutpostActionFinishDefinition>
 
   <!--  War  -->
-  <EmpireDiplomaticAction Name="StartWarEmpireAction" ResultingDiplomaticRelationState="DiplomaticRelationStateMinorAdvancedWar" RefreshRelationPoint="true">
+  <EmpireDiplomaticActionDynamicCost Name="StartWarEmpireAction" ResultingDiplomaticRelationState="DiplomaticRelationStateMinorAdvancedWar" RefreshRelationPoint="true">
     <CustomCost ResourceName="EmpireEmpirePoint" Instant="true">Property(StockLocation,@ClassEmpire,DiplomacyCostReduction) * (2 * Property(Relation,RelationPoint)) * Property(StockLocation,@ClassEmpire,FreeWarDeclaration) * Property(StockLocation,@ClassEmpire,AggressiveTreatyCostReduction)</CustomCost>
     <CancelActions Flags="CancelOnWar" SameContext="true" SameInitiator="true" SameNodeAndOnAllEmpires="false"/>
     <StatePrerequisite Inverted="true" Flags="Prerequisite,Discard" Hidden="true" State="DiplomaticRelationStateMinorUnknown"/>
@@ -593,7 +593,7 @@
     <StatePrerequisite Inverted="true" Flags="Prerequisite,Discard" Hidden="true" State="DiplomaticRelationStateMinorAdvancedWar"/>
     <PopulationEventOnSelf>PopulationPoliticalEventMinorWarDeclared</PopulationEventOnSelf>
     <ScoreProviderEventOnSelf>MinorEmpireWarDeclared</ScoreProviderEventOnSelf>
-  </EmpireDiplomaticAction>
+  </EmpireDiplomaticActionDynamicCost>
 
   <!-- Diplomacy -->
   <!-- DEPRECATED DONT DELETE -->

--- a/Endless Space Competitive Mod/Simulation/ResourceDefinitions.xml
+++ b/Endless Space Competitive Mod/Simulation/ResourceDefinitions.xml
@@ -1,5 +1,21 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Datatable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xsi:noNamespaceSchemaLocation="../Schemas/ResourceDefinition.xsd">
+
+    <ResourceDefinition Name="EmpireManpower" Type="LateCollect">
+        <ResourceLocation Name="EmpireManpower" LocationPath="ClassEmpire">
+            <NetPropertyName>TrueNetEmpireManpower</NetPropertyName>
+        </ResourceLocation>
+    </ResourceDefinition>
+
+	<!-- Resource just to track Enrollment from Manpower -->
+    <ResourceDefinition Name="EnrollmentApplied" Type="Common">
+        <ResourceLocation Name="EnrollmentApplied" LocationPath="ClassEmpire,EmpireTypeMajor">
+            <MaximumStockPropertyName>MaximumEnrollmentApplied</MaximumStockPropertyName>
+            <NetPropertyName>NetEnrollmentApplied</NetPropertyName>
+            <StockPropertyName>EnrollmentAppliedToFood</StockPropertyName>
+        </ResourceLocation>
+    </ResourceDefinition>
+
     <!-- System resources -->
     <ResourceDefinition Name="WarningProgression" Type="Common">
         <ResourceLocation Name="WarningProgression" LocationPath="ClassEmpire/ClassDiplomacy/ClassDiplomaticEmpire">

--- a/Endless Space Competitive Mod/Simulation/SimulationDescriptors[ColonizedStarSystem].xml
+++ b/Endless Space Competitive Mod/Simulation/SimulationDescriptors[ColonizedStarSystem].xml
@@ -451,14 +451,15 @@
     <Property Name="GroundBattleOwnerShipRatePercentage"	BaseValue="0" />
     <Property Name="GroundBattleManpowerRecoveredAfterLoot"	BaseValue="0" />
 
-    <!-- For final ground battle-->
+    <!-- For food into manpower conversion -->
     <Property Name="PassiveEnrollmentRate"          BaseValue="0" MaxValue="1"/>
     <Property Name="PassiveEnrollmentRateHissho"    BaseValue="0" MaxValue="1"/>
-    <Property Name="ShouldTakeGrowthForManpower"    MaxValue="1"/>
+    <Property Name="GrowthForManpowerRatio"         MinValue="0"  MaxValue="1"/>
     <Property Name="GrowthForManpower"              BaseValue="0"/>
     <Property Name="GSModifiedGrowth"               BaseValue="0"/>
     <Property Name="GrowthForManpowerForUpkeep"     BaseValue="0"/>
     <Property Name="GrowthForOutpost"               BaseValue="0"/>
+	<Property Name="MaximumEnrollmentRate"          BaseValue="0"/>
 
 
     <Property Name="SystemDefense"          BaseValue="0"   />
@@ -1097,7 +1098,7 @@
 
 
     <Modifier       TargetProperty="ShouldUseGrowth"                 Operation="Multiplication"       Value="$(PopulationUsingGrowth)"  Priority="2"   />
-    <Modifier       TargetProperty="ShouldTakeGrowthForManpower"     Operation="Multiplication"       Value="$(ShouldUseGrowth)"  Priority="2"   />
+    <Modifier       TargetProperty="GrowthForManpowerRatio"			 Operation="Multiplication"       Value="$(ShouldUseGrowth)"		Priority="2"   />
 
     <Modifier TargetProperty="PopulationCountedTowardsUpkeep" Operation="Addition" Value="$(Population)" Path="ClassColonizedStarSystem,!ClassExploitedStarSystem"/>
     <Modifier TargetProperty="PopulationCountedTowardsUpkeep" Operation="Subtraction" Value="$(PopulationNotUsingGrowth)" Path="ClassColonizedStarSystem,!ClassExploitedStarSystem"/>
@@ -1118,11 +1119,12 @@
     <Modifier       TargetProperty="PassiveEnrollmentRate"              Operation="Addition"             Value="$(PassiveEnrollmentRateHissho)"  />
     <BinaryModifier TargetProperty="GSModifiedGrowth"                   Operation="Addition"             Left="$(SystemGrowth)"                  BinaryOperation="Multiplication" Right="$(GameSpeedTimeMultiplier)"    />
     <BinaryModifier TargetProperty="GrowthForManpower"                  Operation="Addition"             Left="$(GSModifiedGrowth)"              BinaryOperation="Multiplication" Right="$(PassiveEnrollmentRate)"    />
+	<BinaryModifier TargetProperty="MaximumEnrollmentRate"              Operation="Addition"             Left="$(GSModifiedGrowth)"              BinaryOperation="Multiplication" Right="$(PassiveEnrollmentRate)"    />	
     <BinaryModifier TargetProperty="GrowthForManpowerForUpkeep"         Operation="Addition"             Left="$(SystemGrowth)"                  BinaryOperation="Multiplication" Right="$(PassiveEnrollmentRate)"    />
-    <Modifier       TargetProperty="GrowthForManpower"                  Operation="Multiplication"       Value="$(ShouldTakeGrowthForManpower)"  Priority="2"   />
-    <Modifier       TargetProperty="GrowthForManpowerForUpkeep"         Operation="Multiplication"       Value="$(ShouldTakeGrowthForManpower)"  Priority="2"   />
+    <Modifier       TargetProperty="GrowthForManpower"                  Operation="Multiplication"       Value="$(GrowthForManpowerRatio)"		 Priority="2"   />
+    <Modifier       TargetProperty="GrowthForManpowerForUpkeep"         Operation="Multiplication"       Value="$(GrowthForManpowerRatio)"		 Priority="2"   />
 
-    <Modifier       TargetProperty="EmpireManpower"  Operation="Addition"             Value="$(GrowthForManpower)"            Path="../ClassEmpire"/>
+    <Modifier       TargetProperty="EmpireManpowerFromEnrollment"		Operation="Addition"             Value="$(GrowthForManpower)"            Path="../ClassEmpire"/>
 
 
 
@@ -2079,9 +2081,10 @@
 		<BinaryModifier     TargetProperty="SystemProductionUpkeep"             Operation="Addition"        Left="$(BlockadeOrbitingMilitaryPower)" BinaryOperation="Multiplication"    Right="$(NetSystemProductionImpactFactor)" Path="!BesiegedColonizedStarSystem,ColonizedStarSystemStateOutpost" Priority="100000" />
 
 		<!-- Colony defense maluses -->
+		<Modifier TargetProperty="MaximumEnrollmentRate"                    Operation="Force"       Value="0"   Priority="1"	Path="ClassColonizedStarSystem" TooltipHidden="true"/>
 		<Modifier TargetProperty="SystemDefenseRecovery"                    Operation="Force"       Value="0"   Priority="1000" Path="ClassColonizedStarSystem" TooltipHidden="true"/>
 		<Modifier TargetProperty="MaximumSystemManpowerRefillRate"          Operation="Force"       Value="0"   Priority="1000" Path="ClassColonizedStarSystem" TooltipHidden="true"/>
-		<Modifier TargetProperty="ShouldTakeGrowthForManpower"              Operation="Force"       Value="0"   Priority="1000" Path="ClassColonizedStarSystem" TooltipHidden="true"/>
+		<Modifier TargetProperty="GrowthForManpowerRatio"					Operation="Force"       Value="0"   Priority="1000" Path="ClassColonizedStarSystem" TooltipHidden="true"/>
 		<Modifier TargetProperty="NetSystemMigrationGrowth"                 Operation="Force"       Value="0"   Priority="1000" Path="ClassColonizedStarSystem" TooltipHidden="true"/>
 
 		<!-- dust/science/influence & resources loss are calculated with "raw" net. -->
@@ -2225,9 +2228,10 @@
 		<!--  Colony defense maluses  -->
 		<BinaryModifier TargetProperty="SystemManpowerLoss" Operation="Subtraction" Left="$(OrbitingSiegePower)" BinaryOperation="Division" Right="1" Path="!GroundBattleInProgress" Priority="0" />
 		<BinaryModifier TargetProperty="NetSystemManpower" Operation="Force" Left="$(SystemManpowerLoss)" BinaryOperation="Multiplication" Right="1" />
+		<Modifier TargetProperty="MaximumEnrollmentRate" Operation="Force" Value="0" Priority="1" Path="ClassColonizedStarSystem" TooltipHidden="true"/>
 		<Modifier TargetProperty="SystemDefenseRecovery" Operation="Force" Value="0" Priority="1000" Path="ClassColonizedStarSystem" TooltipHidden="true" />
 		<Modifier TargetProperty="MaximumSystemManpowerRefillRate" Operation="Force" Value="0" Priority="1000" Path="ClassColonizedStarSystem" TooltipHidden="true" />
-		<Modifier TargetProperty="ShouldTakeGrowthForManpower" Operation="Force" Value="0" Priority="1000" Path="ClassColonizedStarSystem" TooltipHidden="true" />
+		<Modifier TargetProperty="GrowthForManpowerRatio" Operation="Force" Value="0" Priority="1000" Path="ClassColonizedStarSystem" TooltipHidden="true" />
 		<Modifier TargetProperty="NetSystemMigrationGrowth" Operation="Force" Value="0" Priority="1000" Path="ClassColonizedStarSystem" TooltipHidden="true" />
 		<Modifier TargetProperty="SystemInfluenceRadius" Operation="Force" Value="0.1" Path="ClassColonizedStarSystem" TooltipHidden="true" Priority="10000"/>
 

--- a/Endless Space Competitive Mod/Simulation/SimulationDescriptors[EmpireImprovements].xml
+++ b/Endless Space Competitive Mod/Simulation/SimulationDescriptors[EmpireImprovements].xml
@@ -722,4 +722,10 @@
     <Modifier TargetProperty="Multiplier" Value="0.25"  Operation="Addition" Priority="2" Path="ClassEmpire//ClassGarrison/ClassShip,ShipRoleHero//ClassModule" TooltipHidden="true"/>
     <Modifier TargetProperty="MaximumHealth" Value="500"  Operation="Addition" Path="ClassEmpire//ClassGarrison/ClassShip,ShipRoleHero/ClassSectionCore" TooltipHidden="true"/>
   </SimulationDescriptor>
+  
+  <!--Metaplot Quest Reward-->
+  <SimulationDescriptor Name="EmpireImprovementQuestMetaplot2" Type="EmpireImprovement">
+    <Modifier TargetProperty="CriticalHitChance"	Operation="Addition"	Value="0.1"		Path="ClassEmpire/ClassGarrisonFleet/ClassShip"/>
+    <Modifier TargetProperty="ShipDamage"			Operation="Addition"	Value="0.1"		Path="ClassEmpire/ClassGarrisonFleet"/>
+  </SimulationDescriptor>
 </Datatable>

--- a/Endless Space Competitive Mod/Simulation/SimulationDescriptors[EmpireImprovements].xml
+++ b/Endless Space Competitive Mod/Simulation/SimulationDescriptors[EmpireImprovements].xml
@@ -73,7 +73,9 @@
 
   <!-- Combine Vodyani modest MP gen reward with worthless MP cap reward and buff both -->
   <SimulationDescriptor Name="EmpireImprovementQuestVampirilis04" Type="EmpireImprovement">
-    <Modifier TargetProperty="EmpireManpower" Operation="Percent" Value="0.3" Path="ClassEmpire"/>
+    <Modifier TargetProperty="EmpireManpower" Operation="Percent" Value="0.3" Path="ClassEmpire" Priority="1"/>
+    <Modifier TargetProperty="EmpireManpowerBalance" Operation="Percent" Value="0.3" Path="ClassEmpire" TooltipHidden="true"/>
+    <Modifier TargetProperty="EmpireManpowerPercent" Operation="Addition" Value="0.3" Path="ClassEmpire" TooltipHidden="true"/>
     <Modifier TargetProperty="MaximumEmpireManpowerStock" Operation="Addition" Value="1000" Path="ClassEmpire"/>
   </SimulationDescriptor>
 
@@ -108,6 +110,7 @@
   <!-- Umbral Choir Quest: BW to MP -->
   <SimulationDescriptor Name="EmpireImprovementMPfromProcessingPower" Type="EmpireImprovement">
     <BinaryModifier TargetProperty="EmpireManpower" Operation="Addition" Left="$(MaximumEmpireProcessingPowerStock)" BinaryOperation="Multiplication" Right="4" Path="ClassEmpire" SearchValueFromPath="true"/>
+    <BinaryModifier TargetProperty="EmpireManpowerBalance" Operation="Addition" Left="$(MaximumEmpireProcessingPowerStock)" BinaryOperation="Multiplication" Right="4" Path="ClassEmpire" SearchValueFromPath="true" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <!-- Umbral Choir Quest: Happy Sleepers -->
@@ -639,7 +642,10 @@
 
   <SimulationDescriptor Name="EmpireImprovementQuestVaultersManpowerFromScience" Type="EmpireImprovement">
     <BinaryModifier TargetProperty="EmpireManpower" Operation="Addition" Left="50" BinaryOperation="Multiplication" Right="$(ScienceBuildingCount)" Path="ClassEmpire" SearchValueFromPath="true"/>
-    <BinaryModifier TargetProperty="EmpireManpower" Operation="Percent" Left="0.01" BinaryOperation="Multiplication" Right="$(ScienceBuildingCount)" Path="ClassEmpire" SearchValueFromPath="true"/>
+    <BinaryModifier TargetProperty="EmpireManpowerBalance" Operation="Addition" Left="50" BinaryOperation="Multiplication" Right="$(ScienceBuildingCount)" Path="ClassEmpire" SearchValueFromPath="true" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="EmpireManpower" Operation="Percent" Left="0.01" BinaryOperation="Multiplication" Right="$(ScienceBuildingCount)" Path="ClassEmpire" SearchValueFromPath="true" Priority="1"/>
+    <BinaryModifier TargetProperty="EmpireManpowerBalance" Operation="Percent" Left="0.01" BinaryOperation="Multiplication" Right="$(ScienceBuildingCount)" Path="ClassEmpire" SearchValueFromPath="true" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="EmpireManpowerPercent" Operation="Addition" Left="0.01" BinaryOperation="Multiplication" Right="$(ScienceBuildingCount)" Path="ClassEmpire" SearchValueFromPath="true" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <!-- Curio Exploration -->

--- a/Endless Space Competitive Mod/Simulation/SimulationDescriptors[Empire].xml
+++ b/Endless Space Competitive Mod/Simulation/SimulationDescriptors[Empire].xml
@@ -345,6 +345,8 @@
     <Property Name="FakeEmpireRelicStock" BaseValue="1" MinValue="1" IsSealed="true"/>
     <Property Name="FakeNetEmpireRelics" BaseValue="0" MinValue="0"/>
     <Property Name="NetRelicsResearch" BaseValue="0"/>
+	<!-- Replaces NetEmpireManpower for EmpireManpower resource calculation -->
+    <Property Name="TrueNetEmpireManpower"      MinValue="Negative"/>
 
 		<Property Name="EmpireLifeforceFromHuntingGrounds" BaseValue="0" MinValue="0" />
 		<Property Name="EmpireMoneyFromHuntingGrounds" BaseValue="0" MinValue="0" />
@@ -368,6 +370,11 @@
 		<Property Name="EmpireTemplePointsStock" IsSealed="true"/>
 		<Property Name="EmpireHonorStock" IsSealed="true"/>
 		<Property Name="LowestEmpireHonorStock" IsSealed="true" BaseValue="100"/>
+
+	<!-- New resource to record the Empire Manpower from Enrollment at the food update pass -->
+    <Property Name="MaximumEnrollmentApplied" BaseValue="0"/>
+    <Property Name="NetEnrollmentApplied"     BaseValue="0" MinValue="Negative"/>
+    <Property Name="EnrollmentAppliedToFood"  IsSealed="true"/>
 
 		<Property Name="FleetsCount" BaseValue="0" MinValue="0"/>
 
@@ -1041,6 +1048,14 @@
     <Property Name="ActualPoliticalRelicEcologistLuxuryBoost"/>
     <Property Name="ActualPoliticalRelicReligiousHeroPointBoost" MinValue="Negative"/>
     <Property Name="ActualPoliticalRelicMilitaristRetrofitBoost" MinValue="Negative"/>
+
+	<!-- Aux properties for all the growth into manpower calculations -->
+	<Property Name="MaximumEnrollmentRate" MinValue="1"  Composition="Sum" />
+	<Property Name="ManpowerFromGrowthRatio" MinValue="0" />
+	<Property Name="EmpireManpowerFromEnrollment" MinValue="0" />
+	<Property Name="EmpireManpowerBalance" MinValue="Negative" />
+	<Property Name="EmpireManpowerPercent" MinValue="0" BaseValue="1" />
+
     <!-- ########################################################## -->
     <!-- ######################## MODIFIER ######################## -->
     <!-- ########################################################## -->
@@ -1117,6 +1132,7 @@
 		<Modifier TargetProperty="MaximumEmpireProcessingPowerStock" Operation="Percent" Value="$(MaximumEmpireProcessingPowerStockOvercolonizationMultiplier)" Priority="100"/>
 		<BinaryModifier TargetProperty="ProcessingPowerForManpower" Operation="Addition" Left="$(EmpireProcessingPowerStock)" BinaryOperation="Multiplication" Right="$(PassiveProcessingPowerEnrollmentRate)"/>
 		<Modifier TargetProperty="EmpireManpower" Operation="Addition" Value="$(ProcessingPowerForManpower)" Path="../ClassEmpire"/>
+		<Modifier TargetProperty="EmpireManpowerBalance" Operation="Addition" Value="$(ProcessingPowerForManpower)" Path="../ClassEmpire" TooltipHidden="true"/>
 
     <BinaryModifier TargetProperty="EmpireProcessingPowerAllocated" Operation="Addition" Left="$(MaximumEmpireProcessingPowerStock)" BinaryOperation="Subtraction" Right="$(EmpireProcessingPowerStock)" />
     <Modifier TargetProperty="EmpireProcessingPowerAllocated" Operation="Addition" Value="$(EmpireProcessingPowerAllocated)" Path="ClassEmpire/ClassColonizedStarSystem,HomeSystem" />
@@ -1232,9 +1248,6 @@
 		<BinaryModifier TargetProperty="PlanePopulationDestructionCountBonus" Operation="Addition" Left="$(PlanePopulationDestructionProbabilityBonus)" BinaryOperation="Multiplication" Right="50"/>
 
 
-    <!-- Manpower management -->
-		<BinaryModifier TargetProperty="ShouldTakeGrowthForManpower" Operation="Addition" Left="$(MaximumEmpireManpowerStock)" BinaryOperation="Subtraction" Right="$(EmpireManpowerStock)" Path="ClassEmpire/ClassColonizedStarSystem"/>
-
     <Modifier TargetProperty="EmpireInfantryHP" Operation="Addition" Value="$(InfantryMaxHealth)" Path="ClassEmpire//ClassShip" TooltipHidden="true"/>
     <Modifier TargetProperty="EmpireInfantryMinDamage" Operation="Addition" Value="$(InfantryMinDamages)" Path="ClassEmpire//ClassShip" TooltipHidden="true"/>
 
@@ -1269,6 +1282,7 @@
 
 		<BinaryModifier TargetProperty="EmpireLifeforceForManpower" Operation="Addition" Left="$(EmpireLifeforce)" BinaryOperation="Multiplication" Right="$(PassiveLifeforceEnrollmentRate)" Path="ClassEmpire"/>
 		<Modifier TargetProperty="EmpireManpower" Operation="Addition" Value="$(EmpireLifeforceForManpower)" Path="ClassEmpire"/>
+		<Modifier TargetProperty="EmpireManpowerBalance" Operation="Addition" Value="$(EmpireLifeforceForManpower)" Path="ClassEmpire" TooltipHidden="true"/>
 		<BinaryModifier TargetProperty="EmpireLifeforceUpkeep" Operation="Addition" Left="$(EmpireLifeforceForManpower)" BinaryOperation="Multiplication" Right="0.5" Path="ClassEmpire"/>
 
 		<!-- Vodyani Essence GUI Explication -->
@@ -1738,6 +1752,7 @@
     <BinaryModifier TargetProperty="EmpireMoney" Operation="Addition" Left="$(ActualPoliticalRelicScientistRelicDustBoost)" BinaryOperation="Multiplication" Right="$(ResultingResearchRelics)" Path="ClassEmpire/ClassSenate/ClassSenator,Politics02/../ClassEmpire"/>
     <BinaryModifier TargetProperty="EmpireEmpirePoint" Operation="Addition" Left="$(ActualPoliticalRelicScientistRelicInfluenceBoost)" BinaryOperation="Multiplication" Right="$(ResultingResearchRelics)" Path="ClassEmpire/ClassSenate/ClassSenator,Politics02/../ClassEmpire"/>
     <BinaryModifier TargetProperty="EmpireManpower" Operation="Addition" Left="$(ActualPoliticalRelicScientistRelicManpowerBoost)" BinaryOperation="Multiplication" Right="$(ResultingResearchRelics)" Path="ClassEmpire/ClassSenate/ClassSenator,Politics02/../ClassEmpire"/>
+    <BinaryModifier TargetProperty="EmpireManpowerBalance" Operation="Addition" Left="$(ActualPoliticalRelicScientistRelicManpowerBoost)" BinaryOperation="Multiplication" Right="$(ResultingResearchRelics)" Path="ClassEmpire/ClassSenate/ClassSenator,Politics02/../ClassEmpire" TooltipHidden="true"/>
 
     <Modifier TargetProperty="TradingRouteIncomeModifier" Operation="Percent" Value="$(ActualPoliticalRelicPacifistTradeValueBoost)" Path="ClassEmpire/ClassSenate/ClassSenator,Politics03/../ClassEmpire/ClassColonizedStarSystem/ClassColonizedStarSystem,StarSystemImprovementUniqueTemplars/./ClassColonizedStarSystem"/>
     <Modifier TargetProperty="TroopHealthPerTemple" Operation="Addition" Value="$(ActualPoliticalRelicPacifistTroopHealthBoost)" Path="ClassEmpire/ClassSenate/ClassSenator,Politics03/../ClassEmpire/ClassColonizedStarSystem/ClassColonizedStarSystem"/>
@@ -1762,6 +1777,26 @@
     <Modifier TargetProperty="RelicSlotsUsed"  Operation="Addition"    Value="$(HasExpansionRelic)"  />
     <Modifier TargetProperty="RelicSlotsUsed"  Operation="Addition"    Value="$(HasDiplomacyRelic)"  />
     <Modifier TargetProperty="RelicSlotsUsed"  Operation="Addition"    Value="$(HasPoliticalRelic)"  />
+
+    <!-- Manpower growth management -->	
+	<Modifier       TargetProperty="EmpireManpowerBalance"		 Operation="Subtraction" Value="$(EmpireManpowerUpkeep)"    		Path="ClassEmpire" Priority="1"/>
+	<Modifier       TargetProperty="EmpireManpower"				 Operation="Addition"    Value="$(EmpireManpowerFromEnrollment)"    Path="ClassEmpire" Priority="1"/>
+	<BinaryModifier TargetProperty="ManpowerFromGrowthRatio"	 Operation="Addition"    Left="$(MaximumEmpireManpowerStock)"       BinaryOperation="Subtraction" Right="$(EmpireManpowerStock)" Path="ClassEmpire" Priority="2"/>
+	<Modifier       TargetProperty="ManpowerFromGrowthRatio"	 Operation="Subtraction" Value="$(EmpireManpowerBalance)"		    Path="ClassEmpire" Priority="2"/>
+	<BinaryModifier TargetProperty="ManpowerFromGrowthRatio"	 Operation="Division"    Left="$(MaximumEnrollmentRate)"       		BinaryOperation="Multiplication" Right="0.95" Path="ClassEmpire" Priority="2"/>	
+	<Modifier       TargetProperty="GrowthForManpowerRatio"		 Operation="Addition"    Value="$(ManpowerFromGrowthRatio)"			Path="ClassEmpire/ClassColonizedStarSystem" Priority="2"/>
+
+	<!-- Records EmpireManpowerFromEnrollment into EnrollmentAppliedToFood when food is updated -->
+	<Modifier TargetProperty="NetEnrollmentApplied"         Operation="Addition"	Value="$(EmpireManpowerFromEnrollment)"	Path="ClassEmpire"/>
+	<Modifier TargetProperty="NetEnrollmentApplied"         Operation="Subtraction"	Value="$(EnrollmentAppliedToFood)"		Path="ClassEmpire"/>
+	<Modifier TargetProperty="MaximumEnrollmentApplied"     Operation="Addition"	Value="$(NetEnrollmentApplied)"			Path="ClassEmpire"/>
+	<Modifier TargetProperty="MaximumEnrollmentApplied"     Operation="Addition"	Value="$(EnrollmentAppliedToFood)"		Path="ClassEmpire"/>
+	
+	<!-- We remove the EmpireManpowerFromEnrollment and use EnrollmentAppliedToFood instead -->
+	<Modifier TargetProperty="TrueNetEmpireManpower"         Operation="Addition"	 Value="$(NetEmpireManpower)"				Path="ClassEmpire"/>
+	<BinaryModifier TargetProperty="TrueNetEmpireManpower"	 Operation="Subtraction" Left="$(EmpireManpowerFromEnrollment)" BinaryOperation="Multiplication" Right="$(EmpireManpowerPercent)"	Path="ClassEmpire"/>
+	<BinaryModifier TargetProperty="TrueNetEmpireManpower"	 Operation="Addition"	 Left="$(EnrollmentAppliedToFood)"		BinaryOperation="Multiplication" Right="$(EmpireManpowerPercent)"	Path="ClassEmpire"/>
+
   </SimulationDescriptor>
 
   <!--Used for Craver Influence and Science ESG-->

--- a/Endless Space Competitive Mod/Simulation/SimulationDescriptors[Empire].xml
+++ b/Endless Space Competitive Mod/Simulation/SimulationDescriptors[Empire].xml
@@ -1787,15 +1787,15 @@
 	<Modifier       TargetProperty="GrowthForManpowerRatio"		 Operation="Addition"    Value="$(ManpowerFromGrowthRatio)"			Path="ClassEmpire/ClassColonizedStarSystem" Priority="2"/>
 
 	<!-- Records EmpireManpowerFromEnrollment into EnrollmentAppliedToFood when food is updated -->
-	<Modifier TargetProperty="NetEnrollmentApplied"         Operation="Addition"	Value="$(EmpireManpowerFromEnrollment)"	Path="ClassEmpire"/>
-	<Modifier TargetProperty="NetEnrollmentApplied"         Operation="Subtraction"	Value="$(EnrollmentAppliedToFood)"		Path="ClassEmpire"/>
-	<Modifier TargetProperty="MaximumEnrollmentApplied"     Operation="Addition"	Value="$(NetEnrollmentApplied)"			Path="ClassEmpire"/>
-	<Modifier TargetProperty="MaximumEnrollmentApplied"     Operation="Addition"	Value="$(EnrollmentAppliedToFood)"		Path="ClassEmpire"/>
+	<Modifier TargetProperty="NetEnrollmentApplied"         Operation="Addition"	Value="$(EmpireManpowerFromEnrollment)"	Path="ClassEmpire,EmpireTypeMajor"/>
+	<Modifier TargetProperty="NetEnrollmentApplied"         Operation="Subtraction"	Value="$(EnrollmentAppliedToFood)"		Path="ClassEmpire,EmpireTypeMajor"/>
+	<Modifier TargetProperty="MaximumEnrollmentApplied"     Operation="Addition"	Value="$(NetEnrollmentApplied)"			Path="ClassEmpire,EmpireTypeMajor"/>
+	<Modifier TargetProperty="MaximumEnrollmentApplied"     Operation="Addition"	Value="$(EnrollmentAppliedToFood)"		Path="ClassEmpire,EmpireTypeMajor"/>
 	
 	<!-- We remove the EmpireManpowerFromEnrollment and use EnrollmentAppliedToFood instead -->
 	<Modifier TargetProperty="TrueNetEmpireManpower"         Operation="Addition"	 Value="$(NetEmpireManpower)"				Path="ClassEmpire"/>
-	<BinaryModifier TargetProperty="TrueNetEmpireManpower"	 Operation="Subtraction" Left="$(EmpireManpowerFromEnrollment)" BinaryOperation="Multiplication" Right="$(EmpireManpowerPercent)"	Path="ClassEmpire"/>
-	<BinaryModifier TargetProperty="TrueNetEmpireManpower"	 Operation="Addition"	 Left="$(EnrollmentAppliedToFood)"		BinaryOperation="Multiplication" Right="$(EmpireManpowerPercent)"	Path="ClassEmpire"/>
+	<BinaryModifier TargetProperty="TrueNetEmpireManpower"	 Operation="Subtraction" Left="$(EmpireManpowerFromEnrollment)" BinaryOperation="Multiplication" Right="$(EmpireManpowerPercent)"	Path="ClassEmpire,EmpireTypeMajor"/>
+	<BinaryModifier TargetProperty="TrueNetEmpireManpower"	 Operation="Addition"	 Left="$(EnrollmentAppliedToFood)"		BinaryOperation="Multiplication" Right="$(EmpireManpowerPercent)"	Path="ClassEmpire,EmpireTypeMajor"/>
 
   </SimulationDescriptor>
 

--- a/Endless Space Competitive Mod/Simulation/SimulationDescriptors[FactionTrait].xml
+++ b/Endless Space Competitive Mod/Simulation/SimulationDescriptors[FactionTrait].xml
@@ -256,6 +256,7 @@
   </SimulationDescriptor>
   <SimulationDescriptor Name="FactionTraitMinorSwarm02" Type="FactionTraitMinor">
     <BinaryModifier TargetProperty="EmpireManpower" Operation="Addition" Left="30" BinaryOperation="Multiplication" Right="$(SystemCount)" Path="ClassEmpire"/>
+    <BinaryModifier TargetProperty="EmpireManpowerBalance" Operation="Addition" Left="30" BinaryOperation="Multiplication" Right="$(SystemCount)" Path="ClassEmpire" TooltipHidden="true"/>
     <Modifier TargetProperty="MinorTraitsAssimilated" Operation="Addition" Value="1" Path="ClassEmpire" TooltipHidden="true"/>
   </SimulationDescriptor>
 
@@ -483,6 +484,7 @@
   <SimulationDescriptor Name="FactionTraitProcessingPowerFromTraitors"    Type="FactionTrait">
     <BinaryModifier TargetProperty="MaximumEmpireProcessingPowerStock" Operation="Addition" Left="$(TraitorsCount)" BinaryOperation="Multiplication" Right="1" Path="../ClassEmpire"/>
     <BinaryModifier TargetProperty="EmpireManpower" Operation="Addition" Left="$(TraitorsCount)" BinaryOperation="Multiplication" Right="3" Path="../ClassEmpire"/>
+    <BinaryModifier TargetProperty="EmpireManpowerBalance" Operation="Addition" Left="$(TraitorsCount)" BinaryOperation="Multiplication" Right="3" Path="../ClassEmpire" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="FactionTraitAntiExpansionists" Type="FactionTrait">
@@ -536,6 +538,7 @@
     <Modifier TargetProperty="Happiness" Operation="Addition" Value="10" Path="ClassColonizedStarSystem" SearchValueFromPath="true" EnforceContext="true"/>
     <Modifier TargetProperty="Happiness" Operation="Addition" Value="10" Path="../ClassEmpire/ClassColonizedStarSystem" SearchValueFromPath="true" EnforceContext="true"/>
     <Modifier TargetProperty="EmpireManpower" Operation="Addition" Value="25" Path="../ClassEmpire" SearchValueFromPath="true" EnforceContext="true"/>
+    <Modifier TargetProperty="EmpireManpowerBalance" Operation="Addition" Value="25" Path="../ClassEmpire" SearchValueFromPath="true" EnforceContext="true" TooltipHidden="true"/>
     <Modifier TargetProperty="InfluenceConversionRateModifier" Operation="Percent" Value="-0.5" Path="ClassColonizedStarSystem"/>
   </SimulationDescriptor>
 

--- a/Endless Space Competitive Mod/Simulation/SimulationDescriptors[GameDifficulty].xml
+++ b/Endless Space Competitive Mod/Simulation/SimulationDescriptors[GameDifficulty].xml
@@ -147,6 +147,7 @@
     <Modifier TargetProperty="MaximumShipManpower"                        Operation="Addition"    Value="120"     Path="ClassEmpire//ClassShip"/>
     <Modifier TargetProperty="AdditionalGroundBattleManpowerLimit"  Operation="Addition"    Value="60"      Path="ClassEmpire//ClassShip"/>
 	  <Modifier TargetProperty="EmpireManpower"            Operation="Addition"    Value="300"  Priority="-1"   Path="ClassEmpire"/>
+	<Modifier TargetProperty="EmpireManpowerBalance"                        Operation="Addition"    Value="300"  Priority="-1"   Path="ClassEmpire,EmpireTypeMajor" TooltipHidden="true"/>
 
 	<!--Better AI Empires Hissho Tweak MINING PROBE COMPENSATION-->
 	  <BinaryModifier TargetProperty="SystemFIDSPercent"            Operation="Addition"     Left="$(BetterHisshoTweak)"  BinaryOperation="Multiplication"    Right="$(OwnedSystems)"   Priority="-1"   Path="ClassEmpire/ClassColonizedStarSystem"/>
@@ -223,6 +224,7 @@
     <Modifier TargetProperty="MaximumShipManpower"                          Operation="Addition"    Value="150"     Path="ClassEmpire//ClassShip"/>
     <Modifier TargetProperty="AdditionalGroundBattleManpowerLimit"          Operation="Addition"    Value="75"      Path="ClassEmpire//ClassShip"/>
 	<Modifier TargetProperty="EmpireManpower"                               Operation="Addition"    Value="400"  Priority="-1"   Path="ClassEmpire,EmpireTypeMajor"/>
+	<Modifier TargetProperty="EmpireManpowerBalance"                        Operation="Addition"    Value="400"  Priority="-1"   Path="ClassEmpire,EmpireTypeMajor" TooltipHidden="true"/>
 
 	<!--Better AI Empires Hissho Tweak MINING PROBE COMPENSATION-->
 	<BinaryModifier TargetProperty="SystemFIDSPercent"            Operation="Addition"     Left="$(BetterHisshoTweak)"  BinaryOperation="Multiplication"    Right="$(OwnedSystems)"   Priority="-1"   Path="ClassEmpire/ClassColonizedStarSystem"/>
@@ -300,6 +302,7 @@
     <Modifier TargetProperty="MaximumShipManpower"                          Operation="Addition"    Value="150"     Path="ClassEmpire//ClassShip"/>
     <Modifier TargetProperty="AdditionalGroundBattleManpowerLimit"          Operation="Addition"    Value="75"      Path="ClassEmpire//ClassShip"/>
 	<Modifier TargetProperty="EmpireManpower"                               Operation="Addition"    Value="400"  Priority="-1"   Path="ClassEmpire,EmpireTypeMajor"/>
+	<Modifier TargetProperty="EmpireManpowerBalance"                        Operation="Addition"    Value="400"  Priority="-1"   Path="ClassEmpire,EmpireTypeMajor" TooltipHidden="true"/>
 
 	<!--Better AI Empires Hissho Tweak MINING PROBE COMPENSATION-->
 	<BinaryModifier TargetProperty="SystemFIDSPercent"            Operation="Addition"     Left="$(BetterHisshoTweak)"  BinaryOperation="Multiplication"    Right="$(OwnedSystems)"   Priority="-1"   Path="ClassEmpire/ClassColonizedStarSystem"/>

--- a/Endless Space Competitive Mod/Simulation/SimulationDescriptors[GameDifficulty].xml
+++ b/Endless Space Competitive Mod/Simulation/SimulationDescriptors[GameDifficulty].xml
@@ -146,7 +146,7 @@
 	<!--Better AI Empires General SEIGE FIX-->
     <Modifier TargetProperty="MaximumShipManpower"                        Operation="Addition"    Value="120"     Path="ClassEmpire//ClassShip"/>
     <Modifier TargetProperty="AdditionalGroundBattleManpowerLimit"  Operation="Addition"    Value="60"      Path="ClassEmpire//ClassShip"/>
-	  <Modifier TargetProperty="EmpireManpower"            Operation="Addition"    Value="300"  Priority="-1"   Path="ClassEmpire"/>
+	  <Modifier TargetProperty="EmpireManpower"            Operation="Addition"    Value="300"  Priority="-1"   Path="ClassEmpire,EmpireTypeMajor"/>
 	<Modifier TargetProperty="EmpireManpowerBalance"                        Operation="Addition"    Value="300"  Priority="-1"   Path="ClassEmpire,EmpireTypeMajor" TooltipHidden="true"/>
 
 	<!--Better AI Empires Hissho Tweak MINING PROBE COMPENSATION-->

--- a/Endless Space Competitive Mod/Simulation/SimulationDescriptors[Garrison].xml
+++ b/Endless Space Competitive Mod/Simulation/SimulationDescriptors[Garrison].xml
@@ -267,4 +267,10 @@
         <BinaryModifier TargetProperty="MaximumShipManpowerRefillRate" Operation="Addition" Left="$(MaximumShipManpower)" BinaryOperation="Multiplication" Right="1" Path="ClassGarrisonFleet/ClassShip" SearchValueFromPath="true" TooltipHidden="true"/>
 				<Modifier TargetProperty="AdmiralsInFriendlyTerritory" Operation="Addition" Value="$(AdmiralsInFriendlyTerritory)" Path="../ClassEmpire" TooltipHidden="true"/>
     </SimulationDescriptor>
+
+    <SimulationDescriptor Name="NodeFleetEffectMetaplotSystemDestroyed" Type="NodeFleetEffect">
+		<BinaryModifier TargetProperty="EmpireManpower" Operation="Addition" Left="$(ShipCount)" BinaryOperation="Multiplication" Right="2" Path="../ClassEmpire" ForceFrom="true" />
+		<BinaryModifier TargetProperty="EmpireManpowerBalance" Operation="Addition" Left="$(ShipCount)" BinaryOperation="Multiplication" Right="2" Path="../ClassEmpire" ForceFrom="true" TooltipHidden="true" />
+    </SimulationDescriptor>
+
 </Datatable>

--- a/Endless Space Competitive Mod/Simulation/SimulationDescriptors[MinorRelation].xml
+++ b/Endless Space Competitive Mod/Simulation/SimulationDescriptors[MinorRelation].xml
@@ -44,6 +44,7 @@
 		<Modifier TargetProperty="EmpireMoney" 			Operation="Addition"   Value="$(EmpireMoney)" 		Path="./ClassEmpire,EmpireTypeMajor" />
 		<Modifier TargetProperty="EmpireResearch" 		Operation="Addition"   Value="$(EmpireResearch)" 	Path="./ClassEmpire,EmpireTypeMajor" />
 		<Modifier TargetProperty="EmpireManpower" 		Operation="Addition"   Value="$(EmpireManpower)" 	Path="./ClassEmpire,EmpireTypeMajor" />
+		<Modifier TargetProperty="EmpireManpowerBalance" Operation="Addition"   Value="$(EmpireManpower)" 	Path="./ClassEmpire,EmpireTypeMajor" TooltipHidden="true" />
 		<Modifier TargetProperty="EmpireLifeforce" 		Operation="Addition"   Value="$(NetEmpireLifeforce)" 	Path="./ClassEmpire,AffinityGameplayVampirilis" />
 		
 		<!-- Luxs & Strats are transfered to the empire via its Composition Sum -->

--- a/Endless Space Competitive Mod/Simulation/SimulationDescriptors[Population].xml
+++ b/Endless Space Competitive Mod/Simulation/SimulationDescriptors[Population].xml
@@ -230,6 +230,7 @@
     <BinaryModifier   TargetProperty="MaximumSystemManpower"    Operation="Addition"     Left="$(BonusPopulationDefense)"        BinaryOperation="Multiplication" Right="$(PopulationCount)"     Priority="-2" Path="../ClassStarSystem" />
     <BinaryModifier   TargetProperty="NetSystemManpower"        Operation="Addition"     Left="$(BonusPopulationSystemManpower)" BinaryOperation="Multiplication" Right="$(PopulationCount)"     Priority="-2" Path="../ClassStarSystem" />
     <BinaryModifier   TargetProperty="EmpireManpower"           Operation="Addition"     Left="$(BonusPopulationEmpireManpower)" BinaryOperation="Multiplication" Right="$(PopulationCount)"     Priority="-2" Path="../ClassEmpire" />
+    <BinaryModifier   TargetProperty="EmpireManpowerBalance"    Operation="Addition"     Left="$(BonusPopulationEmpireManpower)" BinaryOperation="Multiplication" Right="$(PopulationCount)"     Priority="-2" Path="../ClassEmpire" TooltipHidden="true" />
 
     <BinaryModifier		TargetProperty="GroundBattleBombardmentAttackerDamagesMin"	Operation="Addition" Left="$(BonusPopulationGroundBattleBombardmentAttackerDamagesMin)" BinaryOperation="Multiplication" Right="$(PopulationCount)"  Priority="-2" Path="../ClassColonizedStarSystem" />
     <BinaryModifier		TargetProperty="GroundBattleBombardmentAttackerDamagesMax"	Operation="Addition" Left="$(BonusPopulationGroundBattleBombardmentAttackerDamagesMax)" BinaryOperation="Multiplication" Right="$(PopulationCount)"  Priority="-2" Path="../ClassColonizedStarSystem" />

--- a/Endless Space Competitive Mod/Simulation/SimulationDescriptors[StarSystemImprovement].xml
+++ b/Endless Space Competitive Mod/Simulation/SimulationDescriptors[StarSystemImprovement].xml
@@ -49,6 +49,13 @@
     <Modifier TargetProperty="ExperienceAtShipCreation" Operation="Addition" Value="20" Path="./ColonizedStarSystemStateColony,ClassColonizedStarSystem/ClassGarrison" TooltipOverride="%StarSystemImprovementQuestVampirilis07EffectOverride"/>
   </SimulationDescriptor>
 
+  <SimulationDescriptor Name="StarSystemImprovementPopulationSlot2Vampirilis" Type="StarSystemImprovement">
+    <BinaryModifier TargetProperty="PlanetFood" Operation="Addition" Left="2" BinaryOperation="Multiplication" Right="$(Population)" Path="./ClassColonizedStarSystem/ClassPlanet" SearchValueFromPath="true"/>
+    <Modifier TargetProperty="EmpireManpower" Operation="Percent" Value="0.2" Path="./ClassColonizedStarSystem/./ClassEmpire" Priority="1"/>
+    <Modifier TargetProperty="EmpireManpowerBalance" Operation="Percent" Value="0.2" Path="./ClassColonizedStarSystem/./ClassEmpire" TooltipHidden="true"/>
+    <Modifier TargetProperty="EmpireManpowerPercent" Operation="Addition" Value="0.2" Path="./ClassColonizedStarSystem/./ClassEmpire" TooltipHidden="true"/>
+  </SimulationDescriptor>
+
   <!-- Vodyani T4 Empire Unique Building  -->
   <SimulationDescriptor Name="BuildingStarSystemImprovementUniqueVampirilis" Type="BuildingStarSystemImprovement"/>
   <SimulationDescriptor Name="StarSystemImprovementUniqueVampirilis" Type="StarSystemImprovement">
@@ -197,18 +204,21 @@
     <Property Name="ManpowerConversionLocal" BaseValue="0.5"/>
     <Modifier TargetProperty="ManpowerConversionLocal" Operation="Multiplication" Value="$(GameSpeedTimeMultiplier)" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="EmpireManpower" Operation="Addition" Left="$(ManpowerConversionLocal)" BinaryOperation="Multiplication" Right="$(SystemProduction)" Path="../ClassEmpire" TooltipHidden="true" />
+    <BinaryModifier TargetProperty="EmpireManpowerBalance" Operation="Addition" Left="$(ManpowerConversionLocal)" BinaryOperation="Multiplication" Right="$(SystemProduction)" Path="../ClassEmpire" TooltipHidden="true" />
     <BinaryModifier TargetProperty="SystemProductionFromProductionConversion" Operation="Addition" Left="-1" BinaryOperation="Multiplication" Right="$(SystemProduction)" Path="ClassColonizedStarSystem" TooltipHidden="true" />
   </SimulationDescriptor>
   <SimulationDescriptor Name="StarSystemImprovementQuestTimeLords06Effect" Type="StarSystemImprovement">
     <Property Name="ManpowerConversionLocal" BaseValue="0.75"/>
     <Modifier TargetProperty="ManpowerConversionLocal" Operation="Multiplication" Value="$(GameSpeedTimeMultiplier)" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="EmpireManpower" Operation="Addition" Left="$(ManpowerConversionLocal)" BinaryOperation="Multiplication" Right="$(SystemProduction)" Path="../ClassEmpire" TooltipHidden="true" />
+    <BinaryModifier TargetProperty="EmpireManpowerBalance" Operation="Addition" Left="$(ManpowerConversionLocal)" BinaryOperation="Multiplication" Right="$(SystemProduction)" Path="../ClassEmpire" TooltipHidden="true" />
     <BinaryModifier TargetProperty="SystemProductionFromProductionConversion" Operation="Addition" Left="-1" BinaryOperation="Multiplication" Right="$(SystemProduction)" Path="ClassColonizedStarSystem" TooltipHidden="true" />
   </SimulationDescriptor>
   <SimulationDescriptor Name="StarSystemImprovementQuestTimeLords08Effect" Type="StarSystemImprovement">
     <Property Name="ManpowerConversionLocal" BaseValue="0.63"/>
     <Modifier TargetProperty="ManpowerConversionLocal" Operation="Multiplication" Value="$(GameSpeedTimeMultiplier)" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="EmpireManpower" Operation="Addition" Left="$(ManpowerConversionLocal)" BinaryOperation="Multiplication" Right="$(SystemProduction)" Path="../ClassEmpire" TooltipHidden="true" />
+    <BinaryModifier TargetProperty="EmpireManpowerBalance" Operation="Addition" Left="$(ManpowerConversionLocal)" BinaryOperation="Multiplication" Right="$(SystemProduction)" Path="../ClassEmpire" TooltipHidden="true" />
     <BinaryModifier TargetProperty="SystemProductionFromProductionConversion" Operation="Addition" Left="-1" BinaryOperation="Multiplication" Right="$(SystemProduction)" Path="ClassColonizedStarSystem" TooltipHidden="true" />
   </SimulationDescriptor>
 

--- a/Endless Space Competitive Mod/Simulation/SimulationDescriptors[TimeBubble].xml
+++ b/Endless Space Competitive Mod/Simulation/SimulationDescriptors[TimeBubble].xml
@@ -31,6 +31,7 @@
         <BinaryModifier TargetProperty="NetSystemProduction" Operation="Multiplication" Left="1" BinaryOperation="Subtraction" Right="$(CanBeSlowed)" Path="ClassStarSystem" SearchValueFromPath="true" Priority="1000" TooltipHidden="true"/>
         <BinaryModifier TargetProperty="NetSystemResearch" Operation="Multiplication" Left="1" BinaryOperation="Subtraction" Right="$(CanBeSlowed)" Path="ClassStarSystem" SearchValueFromPath="true" Priority="1000" TooltipHidden="true"/>
         <BinaryModifier TargetProperty="NetSystemProduction" Operation="Multiplication" Left="1" BinaryOperation="Subtraction" Right="$(CanBeSlowed)" Path="ClassStarSystem" SearchValueFromPath="true" Priority="1000" TooltipHidden="true"/>
+        <BinaryModifier TargetProperty="MaximumEnrollmentRate" Operation="Multiplication" Left="1" BinaryOperation="Subtraction" Right="$(CanBeSlowed)" Path="ClassStarSystem" SearchValueFromPath="true" Priority="1" TooltipHidden="true"/>
         <BinaryModifier TargetProperty="GrowthForManpowerRatio" Operation="Multiplication" Left="1" BinaryOperation="Subtraction" Right="$(CanBeSlowed)" Path="ClassStarSystem" SearchValueFromPath="true" Priority="1000" TooltipHidden="true"/>
         <Modifier TargetProperty="PlanetDepletionPerTurn" Operation="Force" Value="0" Path="ClassStarSystem/ClassPlanet" Priority="2" TooltipHidden="true"/>
         <Modifier TargetProperty="NetDustOverTime" Operation="Force" Value="0" Path="ClassStarSystem/StarSystemImprovementUniqueTimeLords" TooltipHidden="true"/>

--- a/Endless Space Competitive Mod/Simulation/SimulationDescriptors[TimeBubble].xml
+++ b/Endless Space Competitive Mod/Simulation/SimulationDescriptors[TimeBubble].xml
@@ -31,7 +31,7 @@
         <BinaryModifier TargetProperty="NetSystemProduction" Operation="Multiplication" Left="1" BinaryOperation="Subtraction" Right="$(CanBeSlowed)" Path="ClassStarSystem" SearchValueFromPath="true" Priority="1000" TooltipHidden="true"/>
         <BinaryModifier TargetProperty="NetSystemResearch" Operation="Multiplication" Left="1" BinaryOperation="Subtraction" Right="$(CanBeSlowed)" Path="ClassStarSystem" SearchValueFromPath="true" Priority="1000" TooltipHidden="true"/>
         <BinaryModifier TargetProperty="NetSystemProduction" Operation="Multiplication" Left="1" BinaryOperation="Subtraction" Right="$(CanBeSlowed)" Path="ClassStarSystem" SearchValueFromPath="true" Priority="1000" TooltipHidden="true"/>
-        <BinaryModifier TargetProperty="ShouldTakeGrowthForManpower" Operation="Multiplication" Left="1" BinaryOperation="Subtraction" Right="$(CanBeSlowed)" Path="ClassStarSystem" SearchValueFromPath="true" Priority="1000" TooltipHidden="true"/>
+        <BinaryModifier TargetProperty="GrowthForManpowerRatio" Operation="Multiplication" Left="1" BinaryOperation="Subtraction" Right="$(CanBeSlowed)" Path="ClassStarSystem" SearchValueFromPath="true" Priority="1000" TooltipHidden="true"/>
         <Modifier TargetProperty="PlanetDepletionPerTurn" Operation="Force" Value="0" Path="ClassStarSystem/ClassPlanet" Priority="2" TooltipHidden="true"/>
         <Modifier TargetProperty="NetDustOverTime" Operation="Force" Value="0" Path="ClassStarSystem/StarSystemImprovementUniqueTimeLords" TooltipHidden="true"/>
         <BinaryModifier TargetProperty="NetStrategic1" Operation="Multiplication" Left="1" BinaryOperation="Subtraction" Right="$(CanBeSlowed)" Path="ClassColonizedStarSystem" SearchValueFromPath="true" Priority="1000" TooltipHidden="true"/>


### PR DESCRIPTION
Lowers crit chance in some outliers.
Energy/Projectile enhancers. crit chance is now for energy/projectile weapon types.
Fixed Nakalim Fleet Enhancer not restricted to only one of that type. For Cravers version I didn't need to update the restriction.

As agreed in Issue: #1584 