### PR TITLE
Fix mastery for endless skill 7

### DIFF
--- a/Endless Space Competitive Mod/Simulation/HeroSkillDefinitions.xml
+++ b/Endless Space Competitive Mod/Simulation/HeroSkillDefinitions.xml
@@ -370,7 +370,7 @@
     <SkillLevel Name="HeroSkill07BranchEndless_01">
       <HeroSimulationDescriptorReference Name="HeroSkillComplete"/>
       <SystemSimulationDescriptorReference Name="HeroSkillEndlessSDCost_1"/>
-      <MasteryLevel Class="HeroMasteryLabor" Levels="1"/>
+      <MasteryLevel Class="HeroMasteryLabour" Levels="1"/>
     </SkillLevel>
   </HeroSkillDefinition>
 


### PR DESCRIPTION
Minor fix, the labour mastery is spelled with a "u". Affects the mastery count but not much else.