### PR TITLE
Manpower from food various fixes

### DIFF
--- a/Endless Space Competitive Mod/Simulation/Battles/SimulationDescriptors[Garrison].xml
+++ b/Endless Space Competitive Mod/Simulation/Battles/SimulationDescriptors[Garrison].xml
@@ -36,6 +36,7 @@
 
     <!--  ESG -->
     <Property Name="IsntImmuneToSpecialNodes" BaseValue="1"/>
+	<Property Name="NetShipManpower"	 	  BaseValue="0" Composition="Sum"/>
 
     <!-- Repair/Retrofit Anywhere -->
     <Property Name="CanRepairAnywhere"   BaseValue="0" MaxValue="1"/>
@@ -45,6 +46,7 @@
     <Modifier TargetProperty="ExperiencePerTurn" Operation="Addition" Value="$(ExperiencePerTurn)" Path="ClassGarrison/ClassShip"/>
     <Modifier TargetProperty="GarrisonMoneyUpkeep" Operation="Multiplication" Value="$(GarrisonMoneyUpkeepModifierFromPrivateers)"      Priority="100"/>
     <Modifier TargetProperty="MiningProbeLifetime" Operation="Division" Value="$(MiningProbeCount)" Priority="100"/>
+	<Modifier TargetProperty="HasNetManpower" Operation="Addition" Value="$(NetShipManpower)" Path="../ClassEmpire" />
 
 
   </SimulationDescriptor>

--- a/Endless Space Competitive Mod/Simulation/SimulationDescriptors[ColonizedStarSystem].xml
+++ b/Endless Space Competitive Mod/Simulation/SimulationDescriptors[ColonizedStarSystem].xml
@@ -1009,6 +1009,7 @@
     <Modifier TargetProperty="NetSystemManpower" Operation="Addition"       Value="$(NetSystemManpowerHisshos)"         Path="ClassColonizedStarSystem,HasObedience"/>
     <Modifier TargetProperty="NetSystemManpower" Operation="Multiplication" Value="$(NetSystemManpowerPercentHisshos)"  Path="ClassColonizedStarSystem,HasObedience"/>
     <Modifier TargetProperty="MaximumSystemManpowerRefillRate" Operation="Addition" Value="$(MaximumSystemManpower)"/>
+	<Modifier TargetProperty="HasNetManpower" Operation="Addition" Value="$(SystemManpowerRefillRate)" Path="../ClassEmpire" />
 
     <Modifier TargetProperty="EmpireManpowerTotal" Operation="Addition" Value="$(SystemManpowerStock)" Path="./ClassEmpire"/>
 
@@ -1400,6 +1401,7 @@
 
     <Modifier TargetProperty="MaximumSystemManpower"                                    Operation="Addition"    Value="$(RecipeIngredientEffectATier1Luxury7)"                  Path="ClassColonizedStarSystem"/>
     <Modifier TargetProperty="GrowthForManpower"                                        Operation="Addition"    Value="$(RecipeIngredientEffectBTier1Luxury7)"                  Path="ClassColonizedStarSystem"/>
+    <Modifier TargetProperty="MaximumEnrollmentRate"                                    Operation="Addition"    Value="$(RecipeIngredientEffectBTier1Luxury7)"                  Path="ClassColonizedStarSystem"/>
     <Modifier TargetProperty="GroundBattlePopulationToManpowerPermanentConversionRate"  Operation="Addition"    Value="$(RecipeIngredientEffectCTier1Luxury7)"                  Path="ClassColonizedStarSystem"/>
     <Modifier TargetProperty="GroundBattleDefenderManpowerLimitBonus"                   Operation="Addition"    Value="$(RecipeIngredientEffectDTier1Luxury7)"                  Path="ClassColonizedStarSystem"/>
     <Modifier TargetProperty="NetSystemManpower"                  						Operation="Addition"    Value="$(RecipeIngredientEffectETier1Luxury7)"                  Path="ClassColonizedStarSystem"/>
@@ -1426,6 +1428,7 @@
 		<Modifier TargetProperty="GroundBattleDefenderTroopsDamageMultiplier"               Operation="Addition"    Value="$(RecipeIngredientEffectATier2Luxury15)"                  Path="ClassColonizedStarSystem" SearchValueFromPath="true"/>
 		<BinaryModifier TargetProperty="MaximumSystemManpower" Operation="Addition" Left="$(RecipeIngredientEffectBTier2Luxury15)" BinaryOperation="Multiplication" Right="$(Population)" Path="ClassColonizedStarSystem" />
 		<BinaryModifier TargetProperty="GrowthForManpower" 	   Operation="Addition" Left="$(RecipeIngredientEffectCTier2Luxury15)" BinaryOperation="Multiplication" Right="$(Population)" Path="ClassColonizedStarSystem" />
+		<BinaryModifier TargetProperty="MaximumEnrollmentRate" Operation="Addition" Left="$(RecipeIngredientEffectCTier2Luxury15)" BinaryOperation="Multiplication" Right="$(Population)" Path="ClassColonizedStarSystem" />
 		<Modifier TargetProperty="SystemEmpirePoint"                                        Operation="Addition"    Value="$(RecipeIngredientEffectATier2Luxury16)"                  Path="ClassColonizedStarSystem" SearchValueFromPath="true" TooltipHidden="true"/>
 		<Modifier TargetProperty="TradingRouteIncomeModifier"                               Operation="Percent"    Value="$(RecipeIngredientEffectBTier2Luxury16)"                  Path="ClassColonizedStarSystem" SearchValueFromPath="true" TooltipHidden="true"/>
 		<Modifier TargetProperty="SystemMoneyUpkeep"                               			Operation="Percent"    Value="$(RecipeIngredientEffectCTier2Luxury16)"                  Path="ClassColonizedStarSystem" Priority="10" TooltipHidden="true"/>
@@ -1439,6 +1442,7 @@
     <Modifier TargetProperty="SystemFIDSPercent"                                        Operation="Addition"    Value="$(RecipeIngredientEffectTier3Luxury22FIDSHisshos)"       Path="ClassColonizedStarSystem" />
     <Modifier TargetProperty="MaximumSystemManpower"                                    Operation="Percent"     Value="$(RecipeIngredientEffectATier3Luxury23)"                 Path="ClassColonizedStarSystem" />
 		<BinaryModifier TargetProperty="GrowthForManpower" Operation="Percent" Left="$(RecipeIngredientEffectBTier3Luxury23)" BinaryOperation="Multiplication" Right="$(GameSpeedMultiplier)" Path="ClassColonizedStarSystem" />
+		<BinaryModifier TargetProperty="MaximumEnrollmentRate" Operation="Percent" Left="$(RecipeIngredientEffectBTier3Luxury23)" BinaryOperation="Multiplication" Right="$(GameSpeedMultiplier)" Path="ClassColonizedStarSystem" />
 		<Modifier TargetProperty="TradingRouteIncomeModifier"                               Operation="Percent"       Value="$(RecipeIngredientEffectATier3Luxury24)"               Path="ClassColonizedStarSystem" />
 		<Modifier TargetProperty="TaxRateBuyoutMultiplier"                                  Operation="Addition"    Value="$(RecipeIngredientEffectBTier3Luxury24)"                 Path="../ClassEmpire"/>
 		<Modifier TargetProperty="TaxRateSelloutMultiplier"                                 Operation="Addition"    Value="$(RecipeIngredientEffectBTier3Luxury24)"                 Path="../ClassEmpire"/>

--- a/Endless Space Competitive Mod/Simulation/SimulationDescriptors[Empire].xml
+++ b/Endless Space Competitive Mod/Simulation/SimulationDescriptors[Empire].xml
@@ -1055,6 +1055,8 @@
 	<Property Name="EmpireManpowerFromEnrollment" MinValue="0" />
 	<Property Name="EmpireManpowerBalance" MinValue="Negative" />
 	<Property Name="EmpireManpowerPercent" MinValue="0" BaseValue="1" />
+	<Property Name="HasNetManpower" BaseValue="0" MinValue="0" MaxValue="1"/>
+	<Property Name="ShouldGoFullRate" BaseValue="0" MinValue="0" MaxValue="1"/>
 
     <!-- ########################################################## -->
     <!-- ######################## MODIFIER ######################## -->
@@ -1779,12 +1781,16 @@
     <Modifier TargetProperty="RelicSlotsUsed"  Operation="Addition"    Value="$(HasPoliticalRelic)"  />
 
     <!-- Manpower growth management -->	
+	<Modifier       TargetProperty="ShouldGoFullRate"			 Operation="Addition"	 Value="$(HasNetManpower)"    				Path="ClassEmpire" Priority="-2"/>
+	<Modifier       TargetProperty="ShouldGoFullRate"			 Operation="Subtraction" Value="$(EmpireManpowerUpkeep)"			Path="ClassEmpire" Priority="-1"/>
 	<Modifier       TargetProperty="EmpireManpowerBalance"		 Operation="Subtraction" Value="$(EmpireManpowerUpkeep)"    		Path="ClassEmpire" Priority="1"/>
 	<Modifier       TargetProperty="EmpireManpower"				 Operation="Addition"    Value="$(EmpireManpowerFromEnrollment)"    Path="ClassEmpire" Priority="1"/>
 	<BinaryModifier TargetProperty="ManpowerFromGrowthRatio"	 Operation="Addition"    Left="$(MaximumEmpireManpowerStock)"       BinaryOperation="Subtraction" Right="$(EmpireManpowerStock)" Path="ClassEmpire" Priority="2"/>
 	<Modifier       TargetProperty="ManpowerFromGrowthRatio"	 Operation="Subtraction" Value="$(EmpireManpowerBalance)"		    Path="ClassEmpire" Priority="2"/>
 	<BinaryModifier TargetProperty="ManpowerFromGrowthRatio"	 Operation="Division"    Left="$(MaximumEnrollmentRate)"       		BinaryOperation="Multiplication" Right="0.95" Path="ClassEmpire" Priority="2"/>	
+	<Modifier       TargetProperty="ManpowerFromGrowthRatio"	 Operation="Division"    Value="$(EmpireManpowerPercent)"		    Path="ClassEmpire" Priority="2"/>
 	<Modifier       TargetProperty="GrowthForManpowerRatio"		 Operation="Addition"    Value="$(ManpowerFromGrowthRatio)"			Path="ClassEmpire/ClassColonizedStarSystem" Priority="2"/>
+	<Modifier       TargetProperty="GrowthForManpowerRatio"		 Operation="Addition"    Value="$(ShouldGoFullRate)"				Path="ClassEmpire/ClassColonizedStarSystem" Priority="2"/>
 
 	<!-- Records EmpireManpowerFromEnrollment into EnrollmentAppliedToFood when food is updated -->
 	<Modifier TargetProperty="NetEnrollmentApplied"         Operation="Addition"	Value="$(EmpireManpowerFromEnrollment)"	Path="ClassEmpire,EmpireTypeMajor"/>


### PR DESCRIPTION
Added several fixes so the manpower from food calculations are correct, regarding luxuries like virtual artifacts or Microstasis Motors.

Also fixed a bug caused by the manpower upkeep refill calculations, removing the upkeep and refreshing the simulator modifiers...