### PR TITLE
Fix Autonomous Admin scaling cost exploit

### DIFF
--- a/Endless Space Competitive Mod/Simulation/ConstructibleElement_Industry[StarSystemImprovement].xml
+++ b/Endless Space Competitive Mod/Simulation/ConstructibleElement_Industry[StarSystemImprovement].xml
@@ -1722,6 +1722,7 @@
   <!--Autonomous Administration-->
   <StarSystemImprovementDefinition Name="StarSystemImprovementOverExpansion1" SubCategory="SubCategoryApproval" ScoreProvider="StarSystemImprovementBuilt">
     <SupervisorGain Name="Approval" />
+    <QueuedSimulationDescriptorReference Name="BuildingStarSystemImprovementOverExpansion1"/>
     <Cost ResourceName="SystemProduction">2240</Cost>
     <CustomCost ResourceName="EmpireEmpirePoint" Instant="true">6000 * (1 + Property(StockLocation,@'../ClassEmpire', AutonomousAdministrationCount))  * Property(StockLocation,@'../ClassEmpire', GameSpeedMultiplier)</CustomCost>
     <PathPrerequisite Flags="Prerequisite,Discard,UnlockAvailability,Faction" Inverted="true">../ClassEmpire,AffinityGameplayUmbralChoir</PathPrerequisite>
@@ -1737,6 +1738,7 @@
 
   <StarSystemImprovementDefinition Name="StarSystemImprovementOverExpansion1Hissho" SubCategory="SubCategoryApproval" ScoreProvider="StarSystemImprovementBuilt">
     <SupervisorGain Name="Approval" />
+    <QueuedSimulationDescriptorReference Name="BuildingStarSystemImprovementOverExpansion1"/>
     <Cost ResourceName="SystemProduction">2240</Cost>
     <CustomCost ResourceName="EmpireEmpirePoint" Instant="true">6000 * (1 + Property(StockLocation,@'../ClassEmpire', AutonomousAdministrationCount))  * Property(StockLocation,@'../ClassEmpire', GameSpeedMultiplier)</CustomCost>
     <PathPrerequisite                           Flags="Prerequisite,Disable,RequiresSystemLevel4">ColonizedStarSystemStateColony,StarSystemImprovementLevel4</PathPrerequisite>

--- a/Endless Space Competitive Mod/Simulation/SimulationDescriptors[StarSystemImprovement].xml
+++ b/Endless Space Competitive Mod/Simulation/SimulationDescriptors[StarSystemImprovement].xml
@@ -667,6 +667,9 @@
     <Modifier TargetProperty="OverColonizationThreshold" Operation="Addition" Value="1" Path="../ClassEmpire" TooltipHidden="false" Priority="999"/>
     <Modifier TargetProperty="AutonomousAdministrationCount" Operation="Addition" Value="1" Path="../ClassEmpire" TooltipHidden="true"/>
   </SimulationDescriptor>
+  <SimulationDescriptor Name="BuildingStarSystemImprovementOverExpansion1" Type="BuildingStarSystemImprovement">
+    <Modifier TargetProperty="AutonomousAdministrationCount" Operation="Addition" Value="1" Path="./ClassEmpire" TooltipHidden="true"/>
+  </SimulationDescriptor>
 
   <!--Arcological Administration-->
   <SimulationDescriptor Name="StarSystemImprovementInfluenceSink" Type="StarSystemImprovement">


### PR DESCRIPTION
Adding to queue increments the empire level counter, so you can't simply dodge the scaling effect by doing more than one system on the same turn.

(There's something similar for Arcological Administration but this one seems to have been missed)