### PR TITLE
Fix boosted versions of bonus resource population traits

### DIFF
--- a/Endless Space Competitive Mod/Simulation/Traits/SimulationDescriptors[8_Other].xml
+++ b/Endless Space Competitive Mod/Simulation/Traits/SimulationDescriptors[8_Other].xml
@@ -137,9 +137,9 @@
   
   <!-- Luxury Deposit Value -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryLuxuryValue" Type="WithPopulationPlanet">
-    <Modifier       TargetProperty="ResourceBonus"		    Operation="Addition"    Value="0.2" Path="FAKEFORGUI/./ResourceTypeLuxury"/>
-    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="0.2"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
-    <BinaryModifier TargetProperty="ResourceBonus"		    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(LuxuryBoostingPopulation)" TooltipHidden="true"/>
+    <Modifier       TargetProperty="ResourceBonus"        Operation="Addition"    Value="0.2" Path="FAKEFORGUI/./ResourceTypeLuxury"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"  Operation="Addition"    Left="$(PopulationCount)"     BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="ResourceBonus"        Operation="Addition"    Left="$(PopulationAuxValue1)" BinaryOperation="Multiplication" Right="0.2" Path="ClassPopulation/./ClassColonizedPlanet/ResourceTypeLuxury" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryLuxuryValue" Type="ClassPopulationPlanet">
@@ -156,9 +156,9 @@
 
   <!-- Strategic Deposit Value -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryStrategicValue" Type="WithPopulationPlanet">
-    <Modifier       TargetProperty="ResourceBonus"		    Operation="Addition"    Value="0.2" Path="FAKEFORGUI/./ResourceTypeStrategic"/>
-    <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="0.2"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
-    <BinaryModifier TargetProperty="ResourceBonus"		    Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(StrategicBoostingPopulation)" TooltipHidden="true"/>
+    <Modifier       TargetProperty="ResourceBonus"        Operation="Addition"    Value="0.2" Path="FAKEFORGUI/./ResourceTypeStrategic"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"  Operation="Addition"    Left="$(PopulationCount)"     BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="ResourceBonus"        Operation="Addition"    Left="$(PopulationAuxValue1)" BinaryOperation="Multiplication" Right="0.2" Path="ClassPopulation/./ClassColonizedPlanet/ResourceTypeStrategic" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryStrategicValue" Type="ClassPopulationPlanet">


### PR DESCRIPTION
"Boosting" the traits that give extra yields on Luxury and Strategic deposits (that are added to Gnashast and Harmony pops respectively) doesn't work - the tooltip displays a doubled bonus but it isn't actually applied. There were a couple of issues:

1. The `ResourceBonus` modifier needs a `Path` to the deposit (so as not to apply to the population itself)
2. The left and right hand side factors (`PopulationAuxValue1` and `LuxuryBoostingPopulation`) come from different levels (population and deposit respectively) - have to rearrange the formula a little to avoid this