### PR TITLE
Fixes on squadron stances and population traits

### DIFF
--- a/Endless Space Competitive Mod/GUI/GUIElements[PopulationModifiersTraits].xml
+++ b/Endless Space Competitive Mod/GUI/GUIElements[PopulationModifiersTraits].xml
@@ -1026,6 +1026,15 @@
     <Title>%PopulationModifiersTraitSecondaryCustomScienceOnLuxury00Title</Title>
   </GuiElement>
 
+  <!-- +3 ScienceOnAnomaly -->
+  <GuiElement Name="PopulationModifiersTraitSecondaryCustomScienceOnAnomaly000">
+    <Title>%PopulationModifiersTraitSecondaryCustomScienceOnAnomaly000Title</Title>
+  </GuiElement>
+
+  <GuiElement Name="ClassPopulationPlanetModifiersTraitSecondaryCustomScienceOnAnomaly000">
+    <Title>%PopulationModifiersTraitSecondaryCustomScienceOnAnomaly000Title</Title>
+  </GuiElement>
+  
   <!-- +5 ScienceOnAnomaly -->
   <GuiElement Name="PopulationModifiersTraitSecondaryCustomScienceOnAnomaly00">
     <Title>%PopulationModifiersTraitSecondaryCustomScienceOnAnomaly00Title</Title>
@@ -3030,9 +3039,6 @@
 
   <ExtendedGuiElement Name="ClassPopulationPlanetModifiersTraitPrimaryCustomHappinessLevel00">
     <Title>%ClassPopulationPlanetModifiersTraitPrimaryCustomHappinessLevel00Title</Title>
-    <TooltipElement>
-      <EffectOverride>%PopulationModifiersTraitSecondaryCustomHappinessLevel00TooltipOverride</EffectOverride>
-    </TooltipElement>
   </ExtendedGuiElement>
 
   <!-- FIDSI -->

--- a/Endless Space Competitive Mod/Localization/brazilian/ES2_Localization_Population_Modifiers.xml
+++ b/Endless Space Competitive Mod/Localization/brazilian/ES2_Localization_Population_Modifiers.xml
@@ -119,7 +119,8 @@
   <LocalizationPair Name="%PopulationModifiersTraitSecondaryCustomScienceOnHappy04Title">Ciência Jovial 5</LocalizationPair>
   <LocalizationPair Name="%PopulationModifiersTraitSecondaryCustomScienceOnStrategic00Title">Ciência Estratégica</LocalizationPair>
   <LocalizationPair Name="%PopulationModifiersTraitSecondaryCustomScienceOnLuxury00Title">Ciência de Luxo</LocalizationPair>
-  <LocalizationPair Name="%PopulationModifiersTraitSecondaryCustomScienceOnAnomaly00Title">Ciência Anômala</LocalizationPair>
+  <LocalizationPair Name="%PopulationModifiersTraitSecondaryCustomScienceOnAnomaly000Title">Ciência Anômala 1</LocalizationPair>
+  <LocalizationPair Name="%PopulationModifiersTraitSecondaryCustomScienceOnAnomaly00Title">Ciência Anômala 2</LocalizationPair>
   <LocalizationPair Name="%PopulationModifiersTraitSecondaryCustomSciencePerMinorFaction00Title">Ciência Federal</LocalizationPair>
   <LocalizationPair Name="%PopulationModifiersTraitSecondaryCustomSciencePerMinorFaction00TooltipOverride">+1 [sciencecolored] por Facção Secundária Assimilada</LocalizationPair>
   <LocalizationPair Name="%PopulationModifiersTraitSecondaryCustomSciencePerBackdoor00Title">Ciência duplicada</LocalizationPair>

--- a/Endless Space Competitive Mod/Localization/english/ES2_Localization_Population_Modifiers.xml
+++ b/Endless Space Competitive Mod/Localization/english/ES2_Localization_Population_Modifiers.xml
@@ -119,7 +119,8 @@
   <LocalizationPair Name="%PopulationModifiersTraitSecondaryCustomScienceOnHappy04Title">Jovial Science 5</LocalizationPair>
   <LocalizationPair Name="%PopulationModifiersTraitSecondaryCustomScienceOnStrategic00Title">Strategic Science</LocalizationPair>
   <LocalizationPair Name="%PopulationModifiersTraitSecondaryCustomScienceOnLuxury00Title">Luxury Science</LocalizationPair>
-  <LocalizationPair Name="%PopulationModifiersTraitSecondaryCustomScienceOnAnomaly00Title">Anomalous Science</LocalizationPair>
+  <LocalizationPair Name="%PopulationModifiersTraitSecondaryCustomScienceOnAnomaly000Title">Anomalous Science 1</LocalizationPair>
+  <LocalizationPair Name="%PopulationModifiersTraitSecondaryCustomScienceOnAnomaly00Title">Anomalous Science 2</LocalizationPair>
   <LocalizationPair Name="%PopulationModifiersTraitSecondaryCustomSciencePerMinorFaction00Title">Federal Science</LocalizationPair>
   <LocalizationPair Name="%PopulationModifiersTraitSecondaryCustomSciencePerMinorFaction00TooltipOverride">+1 [sciencecolored] per Minor Faction Assimilated</LocalizationPair>
   <LocalizationPair Name="%PopulationModifiersTraitSecondaryCustomSciencePerBackdoor00Title">Duplicitous Science</LocalizationPair>

--- a/Endless Space Competitive Mod/Localization/german/ES2_Localization_Population_Modifiers.xml
+++ b/Endless Space Competitive Mod/Localization/german/ES2_Localization_Population_Modifiers.xml
@@ -119,7 +119,8 @@
   <LocalizationPair Name="%PopulationModifiersTraitSecondaryCustomScienceOnHappy04Title">Gute Laune Wissenschaft 5</LocalizationPair>
   <LocalizationPair Name="%PopulationModifiersTraitSecondaryCustomScienceOnStrategic00Title">Strategische Wissenschaft</LocalizationPair>
   <LocalizationPair Name="%PopulationModifiersTraitSecondaryCustomScienceOnLuxury00Title">Luxus-Wissenschaft</LocalizationPair>
-  <LocalizationPair Name="%PopulationModifiersTraitSecondaryCustomScienceOnAnomaly00Title">Anomalie-Wissenschaft</LocalizationPair>
+  <LocalizationPair Name="%PopulationModifiersTraitSecondaryCustomScienceOnAnomaly000Title">Anomalie-Wissenschaft 1</LocalizationPair>
+  <LocalizationPair Name="%PopulationModifiersTraitSecondaryCustomScienceOnAnomaly00Title">Anomalie-Wissenschaft 2</LocalizationPair>
   <LocalizationPair Name="%PopulationModifiersTraitSecondaryCustomSciencePerMinorFaction00Title">Föderale Wissenschaft</LocalizationPair>
   <LocalizationPair Name="%PopulationModifiersTraitSecondaryCustomSciencePerMinorFaction00TooltipOverride">+1 [Wissenschaftcolored] je assimilierter Nebenfraktion</LocalizationPair>
   <LocalizationPair Name="%PopulationModifiersTraitSecondaryCustomSciencePerBackdoor00Title">Falsche Wissenschaft</LocalizationPair>

--- a/Endless Space Competitive Mod/Localization/polish/ES2_Localization_Population_Modifiers.xml
+++ b/Endless Space Competitive Mod/Localization/polish/ES2_Localization_Population_Modifiers.xml
@@ -119,7 +119,8 @@
   <LocalizationPair Name="%PopulationModifiersTraitSecondaryCustomScienceOnHappy04Title">[scienceColored] na Szczęście 5</LocalizationPair>
   <LocalizationPair Name="%PopulationModifiersTraitSecondaryCustomScienceOnStrategic00Title">[scienceColored] dla Strategów</LocalizationPair>
   <LocalizationPair Name="%PopulationModifiersTraitSecondaryCustomScienceOnLuxury00Title">[scienceColored] i Luksusy</LocalizationPair>
-  <LocalizationPair Name="%PopulationModifiersTraitSecondaryCustomScienceOnAnomaly00Title">[scienceColored] na Anomalię</LocalizationPair>
+  <LocalizationPair Name="%PopulationModifiersTraitSecondaryCustomScienceOnAnomaly000Title">[scienceColored] na Anomalię 1</LocalizationPair>
+  <LocalizationPair Name="%PopulationModifiersTraitSecondaryCustomScienceOnAnomaly00Title">[scienceColored] na Anomalię 2</LocalizationPair>
   <LocalizationPair Name="%PopulationModifiersTraitSecondaryCustomSciencePerMinorFaction00Title">[scienceColored] na Frakcję</LocalizationPair>
   <LocalizationPair Name="%PopulationModifiersTraitSecondaryCustomSciencePerMinorFaction00TooltipOverride">+1 [sciencecolored] za zasymilowaną Frakcję Poboczną</LocalizationPair>
   <LocalizationPair Name="%PopulationModifiersTraitSecondaryCustomSciencePerBackdoor00Title">[scienceColored] dla Hakerów</LocalizationPair>

--- a/Endless Space Competitive Mod/Localization/russian/ES2_Localization_Population_Modifiers.xml
+++ b/Endless Space Competitive Mod/Localization/russian/ES2_Localization_Population_Modifiers.xml
@@ -119,7 +119,8 @@
   <LocalizationPair Name="%PopulationModifiersTraitSecondaryCustomScienceOnHappy04Title">Веселая Наука 5</LocalizationPair>
   <LocalizationPair Name="%PopulationModifiersTraitSecondaryCustomScienceOnStrategic00Title">Стратегическая Наука</LocalizationPair>
   <LocalizationPair Name="%PopulationModifiersTraitSecondaryCustomScienceOnLuxury00Title">Роскошная Наука</LocalizationPair>
-  <LocalizationPair Name="%PopulationModifiersTraitSecondaryCustomScienceOnAnomaly00Title">Аномальная Наука</LocalizationPair>
+  <LocalizationPair Name="%PopulationModifiersTraitSecondaryCustomScienceOnAnomaly000Title">Аномальная Наука 1</LocalizationPair>
+  <LocalizationPair Name="%PopulationModifiersTraitSecondaryCustomScienceOnAnomaly00Title">Аномальная Наука 2</LocalizationPair>
   <LocalizationPair Name="%PopulationModifiersTraitSecondaryCustomSciencePerMinorFaction00Title">Федеральная Наука</LocalizationPair>
   <LocalizationPair Name="%PopulationModifiersTraitSecondaryCustomSciencePerMinorFaction00TooltipOverride">+1 [sciencecolored] за ассимилированную Малую Фракцию</LocalizationPair>
   <LocalizationPair Name="%PopulationModifiersTraitSecondaryCustomSciencePerBackdoor00Title">Коварная Наука</LocalizationPair>

--- a/Endless Space Competitive Mod/Localization/spanish/ES2_Localization_Population_Modifiers.xml
+++ b/Endless Space Competitive Mod/Localization/spanish/ES2_Localization_Population_Modifiers.xml
@@ -119,7 +119,8 @@
   <LocalizationPair Name="%PopulationModifiersTraitSecondaryCustomScienceOnHappy04Title">Jovial Science 5</LocalizationPair>
   <LocalizationPair Name="%PopulationModifiersTraitSecondaryCustomScienceOnStrategic00Title">Strategic Science</LocalizationPair>
   <LocalizationPair Name="%PopulationModifiersTraitSecondaryCustomScienceOnLuxury00Title">Luxury Science</LocalizationPair>
-  <LocalizationPair Name="%PopulationModifiersTraitSecondaryCustomScienceOnAnomaly00Title">Anomalous Science</LocalizationPair>
+  <LocalizationPair Name="%PopulationModifiersTraitSecondaryCustomScienceOnAnomaly000Title">Anomalous Science 1</LocalizationPair>
+  <LocalizationPair Name="%PopulationModifiersTraitSecondaryCustomScienceOnAnomaly00Title">Anomalous Science 2</LocalizationPair>
   <LocalizationPair Name="%PopulationModifiersTraitSecondaryCustomSciencePerMinorFaction00Title">Federal Science</LocalizationPair>
   <LocalizationPair Name="%PopulationModifiersTraitSecondaryCustomSciencePerMinorFaction00TooltipOverride">+1 [sciencecolored] per Minor Faction Assimilated</LocalizationPair>
   <LocalizationPair Name="%PopulationModifiersTraitSecondaryCustomSciencePerBackdoor00Title">Duplicitous Science</LocalizationPair>

--- a/Endless Space Competitive Mod/Simulation/Battles/SimulationDescriptors[BattleEffect].xml
+++ b/Endless Space Competitive Mod/Simulation/Battles/SimulationDescriptors[BattleEffect].xml
@@ -23,36 +23,26 @@
     <Modifier TargetProperty="Damage"     Operation="Percent" Value="$(MoraleBonusDamageEffective)" Path="ClassGroup/ClassFlotilla/ClassShip/ClassSection/ClassModuleSquadron" TooltipHidden="true" />
   </SimulationDescriptor>
 
-  <!-- Shield Wall - Unused -->
+  <!-- Shield Wall -->
   <SimulationDescriptor Name="PlayEffectShortRangeDefense"   Type="PlayEffect">
     <Modifier TargetProperty="DefenseBonusAtShortRange"    Operation="Addition"   Value="0.25"  Path="ClassGroup//ClassShip"/>
 
-    <!--CARRIER AIR SUPPORT - CAS %-->
-    <Modifier TargetProperty="FightersWithOffensiveStanceRatio" Operation="Addition" Value="1" Path="ClassGroup" TooltipHidden="true"/>
+    <Modifier TargetProperty="FightersWithOffensiveStanceRatio" Operation="Addition" Value="0.3" Path="ClassGroup" TooltipHidden="true"/>
+    <Modifier TargetProperty="FightersWithDefensiveStanceRatio" Operation="Addition" Value="0.7" Path="ClassGroup" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <!-- Hard Target - Unused -->
   <SimulationDescriptor Name="PlayEffectLongRangeDefense"   Type="PlayEffect">
     <Modifier TargetProperty="DefenseBonusAtLongRange"    Operation="Addition"   Value="0.25"  Path="ClassGroup//ClassShip"/>
 
-    <!--CARRIER AIR SUPPORT - CAS %-->
-    <Modifier TargetProperty="FightersWithOffensiveStanceRatio" Operation="Addition" Value="1" Path="ClassGroup" TooltipHidden="true"/>
-  </SimulationDescriptor>
-
-  <!-- Gravity Distortion 2 - Unused -->
-  <SimulationDescriptor Name="PlayEffectHullPlatingPenetrationIncreaseAll2"   Type="PlayEffect">
-    <Modifier TargetProperty="HullPlatingPenetrationFactor"                Operation="Addition"   Value="0.7" Path="ClassGroup//ClassModuleWeapon"/>
-    <!-- Temp: The "both side" indication is add with an ExtendedGuiElement (until we have a real feedback)-->
-
-    <!--CARRIER AIR SUPPORT - CAS %-->
-    <Modifier TargetProperty="FightersWithOffensiveStanceRatio" Operation="Addition" Value="1" Path="ClassGroup" TooltipHidden="true"/>
+    <Modifier TargetProperty="FightersWithOffensiveStanceRatio" Operation="Addition" Value="0.3" Path="ClassGroup" TooltipHidden="true"/>
+    <Modifier TargetProperty="FightersWithDefensiveStanceRatio" Operation="Addition" Value="0.7" Path="ClassGroup" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <!-- Bigger is Better -->
   <SimulationDescriptor Name="PlayEffectDamageIncreasePerTargetCommandPoints"   Type="PlayEffect">
     <Modifier TargetProperty="DamageBonusPerTargetCommandPoints"            Operation="Addition"   Value="0.04"  Path="ClassGroup//ClassShip"/>
 
-    <!--CARRIER AIR SUPPORT - CAS %-->
     <Modifier TargetProperty="FightersWithOffensiveStanceRatio" Operation="Addition" Value="1" Path="ClassGroup" TooltipHidden="true"/>
   </SimulationDescriptor>
 
@@ -60,7 +50,6 @@
   <SimulationDescriptor Name="PlayEffectDamageIncreasePerShipAtLongRange"   Type="PlayEffect">
     <Modifier TargetProperty="DamageBonusPerOpponentShipAtLongRange"      Operation="Addition"   Value="0.03"  Path="ClassGroup//ClassShip"/>
 
-    <!--CARRIER AIR SUPPORT - CAS %-->
     <Modifier TargetProperty="FightersWithOffensiveStanceRatio" Operation="Addition" Value="1" Path="ClassGroup" TooltipHidden="true"/>
   </SimulationDescriptor>
 
@@ -75,32 +64,32 @@
   <SimulationDescriptor Name="PlayEffectWeakestTargetingOther"   Type="PlayEffect">
     <Modifier TargetProperty="IsWeakestTargeting"      Operation="Addition"   Value="1"  Path="ClassGroup//ClassShip" TooltipOverride="%PlayEffectWeakestTargetingOtherTooltip"/>
 
-    <!--CARRIER AIR SUPPORT - CAS %-->
-    <Modifier TargetProperty="FightersWithOffensiveStanceRatio" Operation="Addition" Value="1" Path="ClassGroup" TooltipHidden="true"/>
+    <Modifier TargetProperty="FightersWithOffensiveStanceRatio" Operation="Addition" Value="0.7" Path="ClassGroup" TooltipHidden="true"/>
+    <Modifier TargetProperty="FightersWithDefensiveStanceRatio" Operation="Addition" Value="0.3" Path="ClassGroup" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <!-- Revive and Rebuild -->
   <SimulationDescriptor Name="PlayEffectPlayerRecycling"   Type="PlayEffect">
     <Modifier TargetProperty="PlayerRecyclingDustPerCP"      Operation="Addition"   Value="15"  Path="ClassGroup"/>
 
-    <!--CARRIER AIR SUPPORT - CAS %-->
-    <Modifier TargetProperty="FightersWithOffensiveStanceRatio" Operation="Addition" Value="1" Path="ClassGroup" TooltipHidden="true"/>
+    <Modifier TargetProperty="FightersWithOffensiveStanceRatio" Operation="Addition" Value="0.5" Path="ClassGroup" TooltipHidden="true"/>
+    <Modifier TargetProperty="FightersWithDefensiveStanceRatio" Operation="Addition" Value="0.5" Path="ClassGroup" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <!-- Repair and Recover -->
   <SimulationDescriptor Name="PlayEffectCoreRepairGroup"   Type="PlayEffect">
     <Modifier TargetProperty="CoreHealthRepair" Operation="Addition" Value="0.3" Path="ClassGroup//ClassShip"/>
 
-    <!--CARRIER AIR SUPPORT - CAS %-->
-    <Modifier TargetProperty="FightersWithOffensiveStanceRatio" Operation="Addition" Value="1" Path="ClassGroup" TooltipHidden="true"/>
+    <Modifier TargetProperty="FightersWithOffensiveStanceRatio" Operation="Addition" Value="0.5" Path="ClassGroup" TooltipHidden="true"/>
+    <Modifier TargetProperty="FightersWithDefensiveStanceRatio" Operation="Addition" Value="0.5" Path="ClassGroup" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <!-- Post-Op Analysis -->
   <SimulationDescriptor Name="PlayEffectXPEnhancedGroup"   Type="PlayEffect">
     <Modifier TargetProperty="ExperienceBonusPercent"   Operation="Addition"   Value="0.5"  Path="ClassGroup"/>
 
-    <!--CARRIER AIR SUPPORT - CAS %-->
-    <Modifier TargetProperty="FightersWithOffensiveStanceRatio" Operation="Addition" Value="1" Path="ClassGroup" TooltipHidden="true"/>
+    <Modifier TargetProperty="FightersWithOffensiveStanceRatio" Operation="Addition" Value="0.5" Path="ClassGroup" TooltipHidden="true"/>
+    <Modifier TargetProperty="FightersWithDefensiveStanceRatio" Operation="Addition" Value="0.5" Path="ClassGroup" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <!-- Unlucky Arms -->
@@ -109,8 +98,7 @@
     <Modifier TargetProperty="CriticalHitChance"            Operation="Force"   Value="0"  Path="ClassGroup//ClassShip" TooltipHidden="true"/>
     <Modifier TargetProperty="CriticalAttackChance"            Operation="Force"   Value="0"  Path="ClassGroup//ClassModuleSquadron"/>
 
-    <!--CARRIER AIR SUPPORT - CAS %-->
-    <Modifier TargetProperty="FightersWithOffensiveStanceRatio" Operation="Addition" Value="1" Path="ClassGroup" TooltipHidden="true"/>
+    <Modifier TargetProperty="FightersWithDefensiveStanceRatio" Operation="Addition" Value="1" Path="ClassGroup" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <!-- Get Lucky -->
@@ -118,7 +106,6 @@
     <Modifier TargetProperty="CriticalHitDamageBonus"       Operation="Addition"   Value="0.7" Path="ClassGroup//ClassSalvo"/>
     <Modifier TargetProperty="SquadronCriticalDamageBonus"       Operation="Addition"   Value="0.5" Path="ClassGroup//ClassModuleSquadron"/>
 
-    <!--CARRIER AIR SUPPORT - CAS %-->
     <Modifier TargetProperty="FightersWithOffensiveStanceRatio" Operation="Addition" Value="1" Path="ClassGroup" TooltipHidden="true"/>
   </SimulationDescriptor>
 
@@ -127,14 +114,14 @@
     <Modifier TargetProperty="ManpowerLostTransferPercent" Operation="Addition" Value="0.75" Path="ClassGroup"/>
     <Modifier TargetProperty="Evasion"                   Operation="Percent"   Value="-0.25" Path="ClassGroup//ClassShip"/>
 
-    <Modifier TargetProperty="FightersWithOffensiveStanceRatio" Operation="Addition" Value="1" Path="ClassGroup" TooltipHidden="true"/>
+    <Modifier TargetProperty="FightersWithDefensiveStanceRatio" Operation="Addition" Value="1" Path="ClassGroup" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <!-- Hopeless -->
   <SimulationDescriptor Name="PlayEffectMoralePenalty"   Type="PlayEffect">
     <Modifier TargetProperty="MoraleBonus"            Operation="Multiplication"   Value="-0.5"  Path="ClassGroup" TooltipHidden="true"/>
 
-    <Modifier TargetProperty="FightersWithOffensiveStanceRatio" Operation="Addition" Value="1" Path="ClassGroup" TooltipHidden="true"/>
+    <Modifier TargetProperty="FightersWithDefensiveStanceRatio" Operation="Addition" Value="1" Path="ClassGroup" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <!-- Temporal Drag -->
@@ -157,14 +144,13 @@
   <SimulationDescriptor Name="PlayEffectHullPlatingIncrease"   Type="PlayEffect">
     <Modifier TargetProperty="HullPlatingAbsorptionPercent"  Operation="Addition"   Value="0.15"  Path="ClassGroup//ClassShip"/>
 
-    <Modifier TargetProperty="FightersWithOffensiveStanceRatio" Operation="Addition" Value="1" Path="ClassGroup" TooltipHidden="true"/>
+    <Modifier TargetProperty="FightersWithDefensiveStanceRatio" Operation="Addition" Value="1" Path="ClassGroup" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <!-- Sheredyn Slugs -->
   <SimulationDescriptor Name="PlayEffectProjectileHullPlatingPenetrationIncrease"   Type="PlayEffect">
     <Modifier TargetProperty="ProjectileHullPlatingPenetrationFactor"      Operation="Addition"   Value="0.5"  Path="ClassGroup//ClassShip"/>
 
-    <!--CARRIER AIR SUPPORT - CAS %-->
     <Modifier TargetProperty="FightersWithOffensiveStanceRatio" Operation="Addition" Value="1" Path="ClassGroup" TooltipHidden="true"/>
   </SimulationDescriptor>
 
@@ -172,38 +158,58 @@
   <SimulationDescriptor Name="PlayEffectUnarmedDefenseIncrease"   Type="PlayEffect">
     <Modifier TargetProperty="DefenseAbsorptionBonusOnCivilians"            Operation="Addition"   Value="1"  Path="ClassGroup//ClassShip"/>
 
-    <!--CARRIER AIR SUPPORT - CAS %-->
-    <Modifier TargetProperty="FightersWithOffensiveStanceRatio" Operation="Addition" Value="1" Path="ClassGroup" TooltipHidden="true"/>
+    <Modifier TargetProperty="FightersWithOffensiveStanceRatio" Operation="Addition" Value="0.3" Path="ClassGroup" TooltipHidden="true"/>
+    <Modifier TargetProperty="FightersWithDefensiveStanceRatio" Operation="Addition" Value="0.7" Path="ClassGroup" TooltipHidden="true"/>
+  </SimulationDescriptor>
+
+  <!-- Plasma Distortion (Both) -->
+  <SimulationDescriptor Name="PlayEffectShieldPenetrationIncreaseAll"   Type="PlayEffect">
+    <Modifier TargetProperty="ShieldPenetrationFactor"                Operation="Addition"   Value="0.15" Path="ClassGroup//ClassShip"/>
   </SimulationDescriptor>
 
   <!-- Plasma Distortion -->
-  <SimulationDescriptor Name="PlayEffectShieldPenetrationIncreaseAll"   Type="PlayEffect">
-    <Modifier TargetProperty="ShieldPenetrationFactor"                Operation="Addition"   Value="0.15" Path="ClassGroup//ClassModuleWeapon"/>
+  <SimulationDescriptor Name="PlayEffectShieldPenetrationIncrease"   Type="PlayEffect">
+    <Modifier TargetProperty="ShieldPenetrationFactor"                Operation="Addition"   Value="0.1" Path="ClassGroup//ClassModuleWeapon"/>
+    <Modifier TargetProperty="ShieldPenetrationFactor"                Operation="Addition"   Value="0.1" Path="ClassGroup//ClassModuleSquadron" TooltipHidden="true"/>
 
     <Modifier TargetProperty="FightersWithOffensiveStanceRatio" Operation="Addition" Value="1" Path="ClassGroup" TooltipHidden="true"/>
   </SimulationDescriptor>
+  
+  <!-- Plasma Distortion ++ -->
+  <SimulationDescriptor Name="PlayEffectShieldPenetrationIncrease2"   Type="PlayEffect">
+    <Modifier TargetProperty="ShieldPenetrationFactor"                Operation="Addition"   Value="0.2" Path="ClassGroup//ClassModuleWeapon"/>
+    <Modifier TargetProperty="ShieldPenetrationFactor"                Operation="Addition"   Value="0.2" Path="ClassGroup//ClassModuleSquadron" TooltipHidden="true"/>
 
-  <SimulationDescriptor Name="PlayEffectShieldPenetrationIncrease"   Type="PlayEffect">
-    <Modifier TargetProperty="ShieldPenetrationFactor"                Operation="Addition"   Value="0.1" Path="ClassGroup//ClassShip"/>
-  </SimulationDescriptor>
+    <Modifier TargetProperty="FightersWithOffensiveStanceRatio" Operation="Addition" Value="1" Path="ClassGroup" TooltipHidden="true"/>
+  </SimulationDescriptor>  
 
   <!-- Smart Survivors -->
   <SimulationDescriptor Name="PlayEffectLostShipXPIncrease"   Type="PlayEffect">
     <Modifier TargetProperty="ExperiencePerLostCP"      Operation="Addition"   Value="5"  Path="ClassGroup"/>
 
-    <!--CARRIER AIR SUPPORT - CAS %-->
-    <Modifier TargetProperty="FightersWithOffensiveStanceRatio" Operation="Addition" Value="1" Path="ClassGroup" TooltipHidden="true"/>
+    <Modifier TargetProperty="FightersWithOffensiveStanceRatio" Operation="Addition" Value="0.5" Path="ClassGroup" TooltipHidden="true"/>
+    <Modifier TargetProperty="FightersWithDefensiveStanceRatio" Operation="Addition" Value="0.5" Path="ClassGroup" TooltipHidden="true"/>
+  </SimulationDescriptor>
+
+  <!-- Gravity Distortion (Common) -->
+  <SimulationDescriptor Name="PlayEffectHullPlatingPenetrationIncreaseAll"   Type="PlayEffect">
+    <Modifier TargetProperty="HullPlatingPenetrationFactor"                Operation="Addition"   Value="0.15" Path="ClassGroup//ClassShip"/>
   </SimulationDescriptor>
 
   <!-- Gravity Distortion -->
-  <SimulationDescriptor Name="PlayEffectHullPlatingPenetrationIncreaseAll"   Type="PlayEffect">
-    <Modifier TargetProperty="HullPlatingPenetrationFactor"                Operation="Addition"   Value="0.15" Path="ClassGroup//ClassModuleWeapon"/>
+  <SimulationDescriptor Name="PlayEffectHullPlatingPenetrationIncrease"   Type="PlayEffect">
+    <Modifier TargetProperty="HullPlatingPenetrationFactor"                Operation="Addition"   Value="0.1" Path="ClassGroup//ClassModuleWeapon"/>
+    <Modifier TargetProperty="HullPlatingPenetrationFactor"                Operation="Addition"   Value="0.1" Path="ClassGroup//ClassModuleSquadron" TooltipHidden="true"/>	
 
     <Modifier TargetProperty="FightersWithOffensiveStanceRatio" Operation="Addition" Value="1" Path="ClassGroup" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <SimulationDescriptor Name="PlayEffectHullPlatingPenetrationIncrease"   Type="PlayEffect">
-    <Modifier TargetProperty="HullPlatingPenetrationFactor"                Operation="Addition"   Value="0.1" Path="ClassGroup//ClassShip"/>
+  <!-- Gravity Distortion++ -->
+  <SimulationDescriptor Name="PlayEffectHullPlatingPenetrationIncreaseAll2"   Type="PlayEffect">
+    <Modifier TargetProperty="HullPlatingPenetrationFactor"                Operation="Addition"   Value="0.2" Path="ClassGroup//ClassModuleWeapon"/>
+    <Modifier TargetProperty="HullPlatingPenetrationFactor"                Operation="Addition"   Value="0.2" Path="ClassGroup//ClassModuleSquadron" TooltipHidden="true"/>	
+
+    <Modifier TargetProperty="FightersWithOffensiveStanceRatio" Operation="Addition" Value="1" Path="ClassGroup" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <!-- Power to Shields -->
@@ -211,10 +217,10 @@
     <Modifier TargetProperty="ShieldAbsorptionPercent"  Operation="Addition"   Value="1"  Path="ClassGroup//ClassShip"/>
     <Modifier TargetProperty="MaximumShield"  Operation="Percent"   Value="0.1"  Path="ClassGroup//ClassShip"/>
 
-    <Modifier TargetProperty="FightersWithOffensiveStanceRatio" Operation="Addition" Value="1" Path="ClassGroup" TooltipHidden="true"/>
+    <Modifier TargetProperty="FightersWithDefensiveStanceRatio" Operation="Addition" Value="1" Path="ClassGroup" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- Collect Bounty -->
+  <!-- Take Trophies -->
   <SimulationDescriptor Name="PlayEffectOpponentRecycling"   Type="PlayEffect">
     <!--UI only doesn't work-->
     <Modifier TargetProperty="OpponentRecyclingDustPerCP"      Operation="Addition"   Value="10"  Path="ClassGroup//ClassShip"/>
@@ -231,16 +237,16 @@
   <SimulationDescriptor Name="PlayEffectInfluenceGain"   Type="PlayEffect">
     <Modifier TargetProperty="OpponentRecyclingEmpirePointPerCP"      Operation="Addition"   Value="3"  Path="ClassGroup"/>
 
-    <!--CARRIER AIR SUPPORT - CAS %-->
-    <Modifier TargetProperty="FightersWithOffensiveStanceRatio" Operation="Addition" Value="1" Path="ClassGroup" TooltipHidden="true"/>
+    <Modifier TargetProperty="FightersWithOffensiveStanceRatio" Operation="Addition" Value="0.5" Path="ClassGroup" TooltipHidden="true"/>
+    <Modifier TargetProperty="FightersWithDefensiveStanceRatio" Operation="Addition" Value="0.5" Path="ClassGroup" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <!-- Irradiation -->
   <SimulationDescriptor Name="PlayEffectEnergyManpowerKillIncrease"   Type="PlayEffect">
     <Modifier TargetProperty="AdditionalShipManpowerKillPerHitEnergy"      Operation="Addition"   Value="2"  Path="ClassGroup//ClassShip"/>
 
-    <!--CARRIER AIR SUPPORT - CAS %-->
-    <Modifier TargetProperty="FightersWithOffensiveStanceRatio" Operation="Addition" Value="1" Path="ClassGroup" TooltipHidden="true"/>
+    <Modifier TargetProperty="FightersWithOffensiveStanceRatio" Operation="Addition" Value="0.7" Path="ClassGroup" TooltipHidden="true"/>
+    <Modifier TargetProperty="FightersWithDefensiveStanceRatio" Operation="Addition" Value="0.3" Path="ClassGroup" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <!-- Emergency Battery-->
@@ -250,7 +256,8 @@
     <Modifier TargetProperty="Damage"                   Operation="Percent"   Value="-0.15" Path="ClassGroup//ClassModuleWeapon" TooltipHidden="true"/>
     <Modifier TargetProperty="Evasion"                   Operation="Percent"   Value="-0.15" Path="ClassGroup//ClassShip" TooltipHidden="true"/>
 
-    <Modifier TargetProperty="FightersWithOffensiveStanceRatio" Operation="Addition" Value="1" Path="ClassGroup" TooltipHidden="true"/>
+    <Modifier TargetProperty="FightersWithOffensiveStanceRatio" Operation="Addition" Value="0.3" Path="ClassGroup" TooltipHidden="true"/>
+    <Modifier TargetProperty="FightersWithDefensiveStanceRatio" Operation="Addition" Value="0.7" Path="ClassGroup" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <!-- By Any Means -->
@@ -258,7 +265,8 @@
     <Modifier TargetProperty="EmpirePointGainPerCP" Operation="Addition" Value="-100" Path="ClassGroup"/>
     <Modifier TargetProperty="Damage"                   Operation="Percent"   Value="0.3" Path="ClassGroup//ClassModuleWeapon"/>
 
-    <Modifier TargetProperty="FightersWithOffensiveStanceRatio" Operation="Addition" Value="1" Path="ClassGroup" TooltipHidden="true"/>
+    <Modifier TargetProperty="FightersWithOffensiveStanceRatio" Operation="Addition" Value="0.7" Path="ClassGroup" TooltipHidden="true"/>
+    <Modifier TargetProperty="FightersWithDefensiveStanceRatio" Operation="Addition" Value="0.3" Path="ClassGroup" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <!-- Crew Defense Protocol -->
@@ -270,7 +278,8 @@
     <Modifier TargetProperty="DefenseBonusAtLongRange"            Operation="Addition"   Value="-0.25"  Path="ClassGroup//ClassShip" TooltipHidden="true"/>
     <Modifier TargetProperty="DefenseBonusAtMediumRange"            Operation="Addition"   Value="-0.25"  Path="ClassGroup//ClassShip" TooltipHidden="true"/>
 
-    <Modifier TargetProperty="FightersWithOffensiveStanceRatio" Operation="Addition" Value="1" Path="ClassGroup" TooltipHidden="true"/>
+    <Modifier TargetProperty="FightersWithOffensiveStanceRatio" Operation="Addition" Value="0.3" Path="ClassGroup" TooltipHidden="true"/>
+    <Modifier TargetProperty="FightersWithDefensiveStanceRatio" Operation="Addition" Value="0.7" Path="ClassGroup" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <!-- Science for Scrap -->
@@ -281,14 +290,15 @@
     <!--Actual effect-->
     <BinaryModifier TargetProperty="OpponentRecyclingSciencePerCP"     Operation="Addition" Left="10" BinaryOperation="Multiplication" Right="$(InitialShipsCount)" Path="ClassGroup" TooltipHidden="true" />
 
-    <Modifier TargetProperty="FightersWithOffensiveStanceRatio" Operation="Addition" Value="1" Path="ClassGroup" TooltipHidden="true"/>
+    <Modifier TargetProperty="FightersWithOffensiveStanceRatio" Operation="Addition" Value="0.5" Path="ClassGroup" TooltipHidden="true"/>
+    <Modifier TargetProperty="FightersWithDefensiveStanceRatio" Operation="Addition" Value="0.5" Path="ClassGroup" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <!-- Prudent Positions -->
   <SimulationDescriptor Name="PlayEffectDamageReductionAll"   Type="PlayEffect">
     <Modifier TargetProperty="Damage"                   Operation="Percent"   Value="-0.25" Path="ClassGroup//ClassModuleWeapon"/>
 
-    <Modifier TargetProperty="FightersWithOffensiveStanceRatio" Operation="Addition" Value="1" Path="ClassGroup" TooltipHidden="true"/>
+    <Modifier TargetProperty="FightersWithDefensiveStanceRatio" Operation="Addition" Value="1" Path="ClassGroup" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <!--Collateral Damage-->
@@ -296,7 +306,6 @@
     <Modifier TargetProperty="SplashFlotillaDamagePercent"      Operation="Addition"   Value="0.15"  Path="ClassGroup//ClassSalvo"/>
     <Modifier TargetProperty="Damage"                   Operation="Percent"   Value="-0.25" Path="ClassGroup//ClassModuleWeapon"/>
 
-    <!--CARRIER AIR SUPPORT - CAS %-->
     <Modifier TargetProperty="FightersWithOffensiveStanceRatio" Operation="Addition" Value="1" Path="ClassGroup" TooltipHidden="true"/>
   </SimulationDescriptor>
 
@@ -304,31 +313,30 @@
   <SimulationDescriptor Name="PlayEffectDefenseReductionPerCP"   Type="PlayEffect">
     <Modifier TargetProperty="DefenseGainPerCP"      Operation="Addition"   Value="-0.1"  Path="ClassGroup//ClassShip"/>
 
-    <!--CARRIER AIR SUPPORT - CAS %-->
-    <Modifier TargetProperty="FightersWithOffensiveStanceRatio" Operation="Addition" Value="1" Path="ClassGroup" TooltipHidden="true"/>
+    <Modifier TargetProperty="FightersWithOffensiveStanceRatio" Operation="Addition" Value="0.7" Path="ClassGroup" TooltipHidden="true"/>
+    <Modifier TargetProperty="FightersWithDefensiveStanceRatio" Operation="Addition" Value="0.3" Path="ClassGroup" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <!-- Full Reserves -->
   <SimulationDescriptor Name="PlayEffectActionGain"   Type="PlayEffect">
     <Modifier TargetProperty="BattleActionGain"      Operation="Addition"   Value="2"  Path="ClassGroup//ClassShip"/>
 
-    <!--CARRIER AIR SUPPORT - CAS %-->
-    <Modifier TargetProperty="FightersWithOffensiveStanceRatio" Operation="Addition" Value="1" Path="ClassGroup" TooltipHidden="true"/>
+    <Modifier TargetProperty="FightersWithOffensiveStanceRatio" Operation="Addition" Value="0.5" Path="ClassGroup" TooltipHidden="true"/>
+    <Modifier TargetProperty="FightersWithDefensiveStanceRatio" Operation="Addition" Value="0.5" Path="ClassGroup" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <!-- En Passant -->
   <SimulationDescriptor Name="PlayEffectMovementGain"   Type="PlayEffect">
     <Modifier TargetProperty="BattleMovementGain"      Operation="Addition"   Value="$(MaximumMovement)"  Path="ClassGroup//ClassShip" SearchValueFromPath="true" TooltipOverride="%PlayEffectMovementGainTooltipOverride"/>
 
-    <!--CARRIER AIR SUPPORT - CAS %-->
-    <Modifier TargetProperty="FightersWithOffensiveStanceRatio" Operation="Addition" Value="1" Path="ClassGroup" TooltipHidden="true"/>
+    <Modifier TargetProperty="FightersWithOffensiveStanceRatio" Operation="Addition" Value="0.5" Path="ClassGroup" TooltipHidden="true"/>
+    <Modifier TargetProperty="FightersWithDefensiveStanceRatio" Operation="Addition" Value="0.5" Path="ClassGroup" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <!-- The Fewer the Proud -->
   <SimulationDescriptor Name="PlayEffectLostShipDamageIncrease"   Type="PlayEffect">
     <Modifier TargetProperty="TemporaryDamageIncreaseIfLostShip"      Operation="Addition"   Value="0.3"  Path="ClassGroup//ClassShip"/>
 
-    <!--CARRIER AIR SUPPORT - CAS %-->
     <Modifier TargetProperty="FightersWithOffensiveStanceRatio" Operation="Addition" Value="1" Path="ClassGroup" TooltipHidden="true"/>
   </SimulationDescriptor>
 
@@ -336,32 +344,31 @@
   <SimulationDescriptor Name="PlayEffectLostShipDefenseBoost"   Type="PlayEffect">
     <Modifier TargetProperty="TemporaryDefenseIncreaseIfLostShip"      Operation="Addition"   Value="0.3"  Path="ClassGroup//ClassShip"/>
 
-    <!--CARRIER AIR SUPPORT - CAS %-->
-    <Modifier TargetProperty="FightersWithOffensiveStanceRatio" Operation="Addition" Value="1" Path="ClassGroup" TooltipHidden="true"/>
+    <Modifier TargetProperty="FightersWithDefensiveStanceRatio" Operation="Addition" Value="1" Path="ClassGroup" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <!-- Unused -->
   <SimulationDescriptor Name="PlayEffectLostShipRepair"   Type="PlayEffect">
     <Modifier TargetProperty="RepairAfterBattlePerLostShip"      Operation="Addition"   Value="0.05"  Path="ClassGroup"/>
 
-    <!--CARRIER AIR SUPPORT - CAS %-->
-    <Modifier TargetProperty="FightersWithOffensiveStanceRatio" Operation="Addition" Value="1" Path="ClassGroup" TooltipHidden="true"/>
+    <Modifier TargetProperty="FightersWithOffensiveStanceRatio" Operation="Addition" Value="0.3" Path="ClassGroup" TooltipHidden="true"/>
+    <Modifier TargetProperty="FightersWithDefensiveStanceRatio" Operation="Addition" Value="0.7" Path="ClassGroup" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <!-- Anti-Shrapnel Hull -->
   <SimulationDescriptor Name="PlayEffectProjectileManpowerAbsorptionIncrease"   Type="PlayEffect">
     <Modifier TargetProperty="ProjectileManpowerAbsorption"         Operation="Addition"   Value="0.5"  Path="ClassGroup//ClassShip"/>
 
-    <!--CARRIER AIR SUPPORT - CAS %-->
-    <Modifier TargetProperty="FightersWithOffensiveStanceRatio" Operation="Addition" Value="1" Path="ClassGroup" TooltipHidden="true"/>
+    <Modifier TargetProperty="FightersWithOffensiveStanceRatio" Operation="Addition" Value="0.3" Path="ClassGroup" TooltipHidden="true"/>
+    <Modifier TargetProperty="FightersWithDefensiveStanceRatio" Operation="Addition" Value="0.7" Path="ClassGroup" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <!-- Radiation Shield -->
   <SimulationDescriptor Name="PlayEffectEnergyManpowerAbsorptionIncrease"   Type="PlayEffect">
     <Modifier TargetProperty="EnergyManpowerAbsorption"            Operation="Addition"   Value="0.5"  Path="ClassGroup//ClassShip"/>
 
-    <!--CARRIER AIR SUPPORT - CAS %-->
-    <Modifier TargetProperty="FightersWithOffensiveStanceRatio" Operation="Addition" Value="1" Path="ClassGroup" TooltipHidden="true"/>
+    <Modifier TargetProperty="FightersWithOffensiveStanceRatio" Operation="Addition" Value="0.3" Path="ClassGroup" TooltipHidden="true"/>
+    <Modifier TargetProperty="FightersWithDefensiveStanceRatio" Operation="Addition" Value="0.7" Path="ClassGroup" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <!-- Needs of the Many -->
@@ -375,6 +382,8 @@
   <!-- Reworked Diplomatic Immunity -->
   <SimulationDescriptor Name="PlayEffectNoDamage"   Type="PlayEffect">
     <Modifier TargetProperty="Damage"            Operation="Force"   Value="0"  Path="ClassGroup//ClassModuleWeapon"/>
+
+    <Modifier TargetProperty="FightersWithDefensiveStanceRatio" Operation="Addition" Value="1" Path="ClassGroup" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="PlayEffectImmunityEmpirePointCost"   Type="PlayEffect">
@@ -384,9 +393,7 @@
   <!-- Berserker -->
   <SimulationDescriptor Name="PlayEffectDamageIncreaseIfAlone"   Type="PlayEffect">
     <Modifier TargetProperty="DamageBonusIfOneShip"                   Operation="Addition"   Value="0.25" Path="ClassGroup//ClassShip" TooltipOverride="%DamageBonusIfOneShipTitle"/>
-    <!-- Temp: The "both side" indication is add with an ExtendedGuiElement (until we have a real feedback)-->
 
-    <!--CARRIER AIR SUPPORT - CAS %-->
     <Modifier TargetProperty="FightersWithOffensiveStanceRatio" Operation="Addition" Value="1" Path="ClassGroup" TooltipHidden="true"/>
   </SimulationDescriptor>
 
@@ -395,8 +402,7 @@
     <Modifier TargetProperty="DefenseBonusIfOneShip"                  Operation="Addition"   Value="0.50" Path="ClassGroup//ClassShip" TooltipOverride="%DefenseBonusIfOneShipTitle"/>
     <!-- Temp: The "both side" indication is add with an ExtendedGuiElement (until we have a real feedback)-->
 
-    <!--CARRIER AIR SUPPORT - CAS %-->
-    <Modifier TargetProperty="FightersWithOffensiveStanceRatio" Operation="Addition" Value="1" Path="ClassGroup" TooltipHidden="true"/>
+    <Modifier TargetProperty="FightersWithDefensiveStanceRatio" Operation="Addition" Value="1" Path="ClassGroup" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <!-- Coilgun Armor Destruction -->

--- a/Endless Space Competitive Mod/Simulation/PopulationDefinitions.xml
+++ b/Endless Space Competitive Mod/Simulation/PopulationDefinitions.xml
@@ -545,7 +545,7 @@
     <Trait Name="PopulationModifiersTraitTemplars"/>
 
     <!--+2 Approval / +1 Influence-->
-    <Trait Name="PopulationModifiersTraitPrimaryCustomHappinessPrestige00" />
+    <Trait Name="PopulationModifiersTraitPrimaryCustomHappiness00" />
     <!--+2 FIDSI (vanilla trait)-->
     <Trait Name="PopulationModifiersTraitSecondaryFIDSIHappy"/>
 

--- a/Endless Space Competitive Mod/Simulation/Traits/PopulationModifiersTraits[6_Happiness].xml
+++ b/Endless Space Competitive Mod/Simulation/Traits/PopulationModifiersTraits[6_Happiness].xml
@@ -2,7 +2,7 @@
 <Datatable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xsi:noNamespaceSchemaLocation="../../Schemas/PopulationModifiersTrait.xsd">
   <!-- Primary -->
   <!-- Happiness -->
-  <!-- +2 Happiness / +30 System manpower capacity-->
+  <!-- +2 Happiness / +1 influence-->
   <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryCustomHappiness00" SubCategory="Primary" ShowInCustom="true" Cost="5">
     <Modifiers>
       <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
@@ -25,7 +25,7 @@
   </PopulationModifiersTrait>
 
   <!-- +2 Happiness / +1 Influence-->
-  <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryCustomHappinessPrestige00" SubCategory="Primary" Cost="5">
+  <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryCustomHappinessPrestige00" SubCategory="Primary" Cost="5" ShowInCustom="false">
     <Modifiers>
       <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomHappinessPrestige00"/>
@@ -47,7 +47,7 @@
   </PopulationModifiersTrait>
 
 <!-- +3 Happiness / +3 Science-->
-  <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryCustomHappinessPrestige005" SubCategory="Primary" Cost="5">
+  <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryCustomHappinessPrestige005" SubCategory="Primary" ShowInCustom="false" Cost="5">
     <Modifiers>
       <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomHappinessPrestige005"/>
@@ -625,7 +625,7 @@
   </PopulationModifiersTrait>
 
   <!-- +2 HappinessOnMeager /food-->
-  <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomHappinessFoodOnMeager01" SubCategory="Secondary" Cost="5">
+  <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomHappinessFoodOnMeager01" SubCategory="Secondary" ShowInCustom="false" Cost="5">
     <Tags>PlanetGameplayTypeMeager,BonusPopulationHappiness</Tags>
     <Modifiers>
       <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">

--- a/Endless Space Competitive Mod/Simulation/Traits/PopulationModifiersTraits[7_Military].xml
+++ b/Endless Space Competitive Mod/Simulation/Traits/PopulationModifiersTraits[7_Military].xml
@@ -204,7 +204,7 @@
   <!-- Secondary -->
   <!-- Empire Manpower -->
   <!-- +1 EmpireManpower -->
-  <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpower00" SubCategory="Secondary" ShowInCustom="true" Cost="5">
+  <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpower00" SubCategory="Secondary" ShowInCustom="false" Cost="5">
     <Modifiers>
       <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomEmpireManpower00"/>
@@ -3116,7 +3116,7 @@
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefensePerMinorFaction00" SubCategory="Secondary" ShowInCustom="true" Cost="20">
     <Modifiers>
       <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
-        <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerPerMinorFaction00"/>
+        <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomDefensePerMinorFaction00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
         <!-- +25 DefensePerMinorFaction per Population-->

--- a/Endless Space Competitive Mod/Simulation/Traits/SimulationDescriptors[6_Happiness].xml
+++ b/Endless Space Competitive Mod/Simulation/Traits/SimulationDescriptors[6_Happiness].xml
@@ -2,24 +2,24 @@
 <Datatable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xsi:noNamespaceSchemaLocation="../../Schemas/Amplitude.Unity.Simulation.SimulationDescriptor.xsd">
 <!-- Primary -->
 <!-- Happiness -->
-<!-- +2 Happiness / +30 System manpower capacity-->
+<!-- +2 Approval / +1 Influence Hissho-->
   <SimulationDescriptor Type="WithPopulationPlanet" Name="WithPopulationPlanetModifiersTraitPrimaryCustomHappiness00">
 	<Modifier       TargetProperty="BonusPopulationHappiness"        Operation="Addition"    Value="2"   Path="FAKEFORGUI/./ClassPopulation"/>
 	<BinaryModifier TargetProperty="BonusPopulationHappiness"        Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
-	<Modifier       TargetProperty="BonusPopulationDefenseHissho"    Operation="Addition"    Value="30"  Path="FAKEFORGUI/./ClassPopulation"/>
-	<BinaryModifier TargetProperty="BonusPopulationDefenseHissho"    Operation="Addition"    Left="30"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+	<Modifier       TargetProperty="BonusPopulationPrestigeHissho"   Operation="Addition"    Value="1"   Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationPrestigeHissho"   Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Type="ClassPopulationPlanet" Name="ClassPopulationPlanetModifiersTraitPrimaryCustomHappiness00">
     <Modifier Path="ClassPopulation" Value="2" Operation="Addition" TargetProperty="BonusPopulationHappiness"/>
-    <Modifier Path="ClassPopulation" Value="30" Operation="Addition" TargetProperty="BonusPopulationDefenseHissho"/>
+    <Modifier Path="ClassPopulation" Value="1" Operation="Addition" TargetProperty="BonusPopulationPrestigeHissho"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Type="ClassPopulationAssimilated" Name="ClassPopulationAssimilatedPrimaryCustomHappiness00">
     <Modifier Path="ClassPopulation" Value="2" Operation="Addition" TargetProperty="BonusPopulationHappiness"/>
   </SimulationDescriptor>
 
-<!-- +2 Happiness / +1 Influence-->
+<!-- DEPRECATED: +2 Approval / +1 Influence-->
   <SimulationDescriptor Type="WithPopulationPlanet" Name="WithPopulationPlanetModifiersTraitPrimaryCustomHappinessPrestige00">
 	<Modifier       TargetProperty="BonusPopulationHappiness"        Operation="Addition"    Value="2"   Path="FAKEFORGUI/./ClassPopulation"/>
 	<BinaryModifier TargetProperty="BonusPopulationHappiness"        Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
@@ -36,7 +36,7 @@
     <Modifier Path="ClassPopulation" Value="2" Operation="Addition" TargetProperty="BonusPopulationHappiness"/>
   </SimulationDescriptor>
 
-<!-- +3 Happiness / +3 Science-->
+<!-- DEPRECATED: +3 Approval / +3 Science-->
   <SimulationDescriptor Type="WithPopulationPlanet" Name="WithPopulationPlanetModifiersTraitPrimaryCustomHappinessPrestige005">
 	<Modifier       TargetProperty="BonusPopulationHappiness"        Operation="Addition"    Value="3"   Path="FAKEFORGUI/./ClassPopulation"/>
 	<BinaryModifier TargetProperty="BonusPopulationHappiness"        Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
@@ -53,24 +53,30 @@
     <Modifier Path="ClassPopulation" Value="3" Operation="Addition" TargetProperty="BonusPopulationHappiness"/>
 </SimulationDescriptor>
 
-<!-- +4 Happiness -->
+<!-- +4 Approval / +2 Influence Hishho -->
   <SimulationDescriptor Type="WithPopulationPlanet" Name="WithPopulationPlanetModifiersTraitPrimaryCustomHappiness01">
 	<Modifier       TargetProperty="BonusPopulationHappiness"        Operation="Addition"    Value="4"   Path="FAKEFORGUI/./ClassPopulation"/>
 	<BinaryModifier TargetProperty="BonusPopulationHappiness"        Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+	<Modifier       TargetProperty="BonusPopulationPrestigeHissho"   Operation="Addition"    Value="2"   Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationPrestigeHissho"   Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
   </SimulationDescriptor>
-
+  
   <SimulationDescriptor Type="ClassPopulationPlanet" Name="ClassPopulationPlanetModifiersTraitPrimaryCustomHappiness01">
     <Modifier Path="ClassPopulation" Value="4" Operation="Addition" TargetProperty="BonusPopulationHappiness"/>
+	<Modifier Path="ClassPopulation" Value="2" Operation="Addition" TargetProperty="BonusPopulationPrestigeHissho"/>
   </SimulationDescriptor>
 
-<!-- +6 Happiness -->
+<!-- +6 Approval / +3 Influence Hishho  -->
   <SimulationDescriptor Type="WithPopulationPlanet" Name="WithPopulationPlanetModifiersTraitPrimaryCustomHappiness02">
 	<Modifier       TargetProperty="BonusPopulationHappiness"        Operation="Addition"    Value="6"   Path="FAKEFORGUI/./ClassPopulation"/>
 	<BinaryModifier TargetProperty="BonusPopulationHappiness"        Operation="Addition"    Left="6"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+	<Modifier       TargetProperty="BonusPopulationPrestigeHissho"   Operation="Addition"    Value="3"   Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationPrestigeHissho"   Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Type="ClassPopulationPlanet" Name="ClassPopulationPlanetModifiersTraitPrimaryCustomHappiness02">
     <Modifier Path="ClassPopulation" Value="6" Operation="Addition" TargetProperty="BonusPopulationHappiness"/>
+	<Modifier Path="ClassPopulation" Value="3" Operation="Addition" TargetProperty="BonusPopulationPrestigeHissho"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Type="ClassPopulationAssimilated" Name="ClassPopulationAssimilatedPrimaryCustomHappiness02">
@@ -78,73 +84,98 @@
   </SimulationDescriptor>
 
   <!-- Secondary -->
-  <!-- Happiness on Cold -->
-  <!-- +1 HappinessOnCold -->
+  <!-- Approval on Cold -->
+  <!-- +1 Approval on Cold / +1 Science on Cold Hissho -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnCold00" Type="WithPopulationPlanet">
     <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="1"   Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
     <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsCold)" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScienceHissho" Operation="Addition"    Value="1"   Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue2"	  Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScienceHissho" Operation="Addition"    Left="$(PopulationAuxValue2)"    BinaryOperation="Multiplication" Right="$(PlanetIsCold)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnCold00" Type="ClassPopulationPlanet">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="1" BinaryOperation="Multiplication" Right="$(PlanetIsCold)" TooltipHidden="true"/>
+    <Modifier TargetProperty="BonusPopulationScienceHissho" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
+    <BinaryModifier TargetProperty="BonusPopulationScienceHissho" Operation="Addition" Left="1" BinaryOperation="Multiplication" Right="$(PlanetIsCold)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationAssimilatedSecondaryCustomHappinessOnCold00" Type="ClassPopulationAssimilated">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="1" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +2 HappinessOnCold -->
+  <!-- +2 Approval on Cold / +2 Science on Cold Hissho -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnCold01" Type="WithPopulationPlanet">
     <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
     <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsCold)" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScienceHissho" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue2"	  Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScienceHissho" Operation="Addition"    Left="$(PopulationAuxValue2)"    BinaryOperation="Multiplication" Right="$(PlanetIsCold)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnCold01" Type="ClassPopulationPlanet">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="2" BinaryOperation="Multiplication" Right="$(PlanetIsCold)" TooltipHidden="true"/>
+    <Modifier TargetProperty="BonusPopulationScienceHissho" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
+    <BinaryModifier TargetProperty="BonusPopulationScienceHissho" Operation="Addition" Left="2" BinaryOperation="Multiplication" Right="$(PlanetIsCold)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +3 HappinessOnCold -->
+   <!-- +3 Approval on Cold / +3 Science on Cold Hissho -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnCold02" Type="WithPopulationPlanet">
     <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
     <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsCold)" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScienceHissho" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue2"	  Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScienceHissho" Operation="Addition"    Left="$(PopulationAuxValue2)"    BinaryOperation="Multiplication" Right="$(PlanetIsCold)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnCold02" Type="ClassPopulationPlanet">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="3" BinaryOperation="Multiplication" Right="$(PlanetIsCold)" TooltipHidden="true"/>
+    <Modifier TargetProperty="BonusPopulationScienceHissho" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
+    <BinaryModifier TargetProperty="BonusPopulationScienceHissho" Operation="Addition" Left="3" BinaryOperation="Multiplication" Right="$(PlanetIsCold)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationAssimilatedSecondaryCustomHappinessOnCold02" Type="ClassPopulationAssimilated">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="2" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +4 HappinessOnCold -->
+   <!-- +4 Approval on Cold / +4 Science on Cold Hissho -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnCold03" Type="WithPopulationPlanet">
     <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="4"   Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
     <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsCold)" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScienceHissho" Operation="Addition"    Value="4"   Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue2"	  Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScienceHissho" Operation="Addition"    Left="$(PopulationAuxValue2)"    BinaryOperation="Multiplication" Right="$(PlanetIsCold)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnCold03" Type="ClassPopulationPlanet">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="4" Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="4" BinaryOperation="Multiplication" Right="$(PlanetIsCold)" TooltipHidden="true"/>
+    <Modifier TargetProperty="BonusPopulationScienceHissho" Operation="Addition" Value="4" Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
+    <BinaryModifier TargetProperty="BonusPopulationScienceHissho" Operation="Addition" Left="4" BinaryOperation="Multiplication" Right="$(PlanetIsCold)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +5 HappinessOnCold -->
+   <!-- +5 Approval on Cold / +5 Science on Cold Hissho -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnCold04" Type="WithPopulationPlanet">
     <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="5"   Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
     <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsCold)" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScienceHissho" Operation="Addition"    Value="5"   Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue2"	  Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScienceHissho" Operation="Addition"    Left="$(PopulationAuxValue2)"    BinaryOperation="Multiplication" Right="$(PlanetIsCold)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnCold04" Type="ClassPopulationPlanet">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="5" BinaryOperation="Multiplication" Right="$(PlanetIsCold)" TooltipHidden="true"/>
+    <Modifier TargetProperty="BonusPopulationScienceHissho" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetGameplayTypeCold"/>
+    <BinaryModifier TargetProperty="BonusPopulationScienceHissho" Operation="Addition" Left="5" BinaryOperation="Multiplication" Right="$(PlanetIsCold)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationAssimilatedSecondaryCustomHappinessOnCold04" Type="ClassPopulationAssimilated">
@@ -152,72 +183,97 @@
   </SimulationDescriptor>
 
   <!-- Happiness on Temperate -->
-  <!-- +1 HappinessOnTemperate -->
+  <!-- +1 Approval on Temperate / +1 Influence on Temperate Hishho -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTemperate00" Type="WithPopulationPlanet">
     <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="1"   Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
     <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTemperate)" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationPrestigeHissho" Operation="Addition"    Value="1"   Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue2"	  Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestigeHissho" Operation="Addition"    Left="$(PopulationAuxValue2)"    BinaryOperation="Multiplication" Right="$(PlanetIsTemperate)" TooltipHidden="true"/>	
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTemperate00" Type="ClassPopulationPlanet">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="1" BinaryOperation="Multiplication" Right="$(PlanetIsTemperate)" TooltipHidden="true"/>
+    <Modifier TargetProperty="BonusPopulationPrestigeHissho" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestigeHissho" Operation="Addition" Left="1" BinaryOperation="Multiplication" Right="$(PlanetIsTemperate)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationAssimilatedSecondaryCustomHappinessOnTemperate00" Type="ClassPopulationAssimilated">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="1" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +2 HappinessOnTemperate -->
+  <!-- +2 Approval on Temperate / +1 Influence on Temperate Hishho -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTemperate01" Type="WithPopulationPlanet">
     <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
     <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTemperate)" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationPrestigeHissho" Operation="Addition"    Value="1"   Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue2"	  Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestigeHissho" Operation="Addition"    Left="$(PopulationAuxValue2)"    BinaryOperation="Multiplication" Right="$(PlanetIsTemperate)" TooltipHidden="true"/>	
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTemperate01" Type="ClassPopulationPlanet">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="2" BinaryOperation="Multiplication" Right="$(PlanetIsTemperate)" TooltipHidden="true"/>
+    <Modifier TargetProperty="BonusPopulationPrestigeHissho" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestigeHissho" Operation="Addition" Left="1" BinaryOperation="Multiplication" Right="$(PlanetIsTemperate)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +3 HappinessOnTemperate -->
+  <!-- +3 Approval on Temperate / +2 Influence on Temperate Hishho -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTemperate02" Type="WithPopulationPlanet">
     <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
     <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTemperate)" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationPrestigeHissho" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue2"	  Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestigeHissho" Operation="Addition"    Left="$(PopulationAuxValue2)"    BinaryOperation="Multiplication" Right="$(PlanetIsTemperate)" TooltipHidden="true"/>	
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTemperate02" Type="ClassPopulationPlanet">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="3" BinaryOperation="Multiplication" Right="$(PlanetIsTemperate)" TooltipHidden="true"/>
+    <Modifier TargetProperty="BonusPopulationPrestigeHissho" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestigeHissho" Operation="Addition" Left="2" BinaryOperation="Multiplication" Right="$(PlanetIsTemperate)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationAssimilatedSecondaryCustomHappinessOnTemperate02" Type="ClassPopulationAssimilated">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="2" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +4 HappinessOnTemperate -->
+  <!-- +4 Approval on Temperate / +2 Influence on Temperate Hishho -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTemperate03" Type="WithPopulationPlanet">
     <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="4"   Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
     <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTemperate)" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationPrestigeHissho" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue2"	  Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestigeHissho" Operation="Addition"    Left="$(PopulationAuxValue2)"    BinaryOperation="Multiplication" Right="$(PlanetIsTemperate)" TooltipHidden="true"/>	
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTemperate03" Type="ClassPopulationPlanet">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="4" Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="4" BinaryOperation="Multiplication" Right="$(PlanetIsTemperate)" TooltipHidden="true"/>
+    <Modifier TargetProperty="BonusPopulationPrestigeHissho" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestigeHissho" Operation="Addition" Left="2" BinaryOperation="Multiplication" Right="$(PlanetIsTemperate)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +5 HappinessOnTemperate -->
+  <!-- +5 Approval on Temperate / +3 Influence on Temperate Hishho -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTemperate04" Type="WithPopulationPlanet">
     <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="5"   Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
     <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTemperate)" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationPrestigeHissho" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue2"	  Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestigeHissho" Operation="Addition"    Left="$(PopulationAuxValue2)"    BinaryOperation="Multiplication" Right="$(PlanetIsTemperate)" TooltipHidden="true"/>	
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTemperate04" Type="ClassPopulationPlanet">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="5" BinaryOperation="Multiplication" Right="$(PlanetIsTemperate)" TooltipHidden="true"/>
+    <Modifier TargetProperty="BonusPopulationPrestigeHissho" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetGameplayTypeTemperate"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestigeHissho" Operation="Addition" Left="3" BinaryOperation="Multiplication" Right="$(PlanetIsTemperate)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationAssimilatedSecondaryCustomHappinessOnTemperate04" Type="ClassPopulationAssimilated">
@@ -225,77 +281,97 @@
   </SimulationDescriptor>
 
   <!-- Happiness on Hot -->
-  <!-- +1 HappinessOnHot -->
+  <!-- +1 Approval on Hot / +15 Defense on Hot Hishho -->  
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHot00" Type="WithPopulationPlanet">
     <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="1"   Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
     <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHot)" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDefenseHissho" Operation="Addition"    Value="15"   Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue2"	  Operation="Addition"    Left="15"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDefenseHissho" Operation="Addition"    Left="$(PopulationAuxValue2)"    BinaryOperation="Multiplication" Right="$(PlanetIsHot)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHot00" Type="ClassPopulationPlanet">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="1" BinaryOperation="Multiplication" Right="$(PlanetIsHot)" TooltipHidden="true"/>
+    <Modifier TargetProperty="BonusPopulationDefenseHissho" Operation="Addition" Value="15" Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
+    <BinaryModifier TargetProperty="BonusPopulationDefenseHissho" Operation="Addition" Left="15" BinaryOperation="Multiplication" Right="$(PlanetIsHot)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationAssimilatedSecondaryCustomHappinessOnHot00" Type="ClassPopulationAssimilated">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="1" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +2 HappinessOnHot / +2 Influence on hot-->
+ <!-- +2 Approval on Hot / +30 Defense on Hot Hishho -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHot01" Type="WithPopulationPlanet">
-    <Modifier       TargetProperty="BonusPopulationHappiness"       Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
-    <BinaryModifier TargetProperty="PopulationAuxValue1"			Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
-    <Modifier       TargetProperty="BonusPopulationPrestigeHissho"  Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
-    <BinaryModifier TargetProperty="PopulationAuxValue2"			Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
-    <BinaryModifier TargetProperty="BonusPopulationHappiness"       Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHot)" TooltipHidden="true"/>
-    <BinaryModifier TargetProperty="BonusPopulationPrestigeHissho"  Operation="Addition"    Left="$(PopulationAuxValue2)"    BinaryOperation="Multiplication" Right="$(PlanetIsHot)" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHot)" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDefenseHissho" Operation="Addition"    Value="30"   Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue2"	  Operation="Addition"    Left="30"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDefenseHissho" Operation="Addition"    Left="$(PopulationAuxValue2)"    BinaryOperation="Multiplication" Right="$(PlanetIsHot)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHot01" Type="ClassPopulationPlanet">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="2" BinaryOperation="Multiplication" Right="$(PlanetIsHot)" TooltipHidden="true"/>
-    <Modifier TargetProperty="BonusPopulationPrestigeHissho" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
-    <BinaryModifier TargetProperty="BonusPopulationPrestigeHissho" Operation="Addition" Left="2" BinaryOperation="Multiplication" Right="$(PlanetIsHot)" TooltipHidden="true"/>
+    <Modifier TargetProperty="BonusPopulationDefenseHissho" Operation="Addition" Value="30" Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
+    <BinaryModifier TargetProperty="BonusPopulationDefenseHissho" Operation="Addition" Left="30" BinaryOperation="Multiplication" Right="$(PlanetIsHot)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +3 HappinessOnHot -->
+  <!-- +3 Approval on Hot / +45 Defense on Hot Hishho -->  
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHot02" Type="WithPopulationPlanet">
     <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
     <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHot)" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDefenseHissho" Operation="Addition"    Value="45"   Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue2"	  Operation="Addition"    Left="45"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDefenseHissho" Operation="Addition"    Left="$(PopulationAuxValue2)"    BinaryOperation="Multiplication" Right="$(PlanetIsHot)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHot02" Type="ClassPopulationPlanet">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="3" BinaryOperation="Multiplication" Right="$(PlanetIsHot)" TooltipHidden="true"/>
+    <Modifier TargetProperty="BonusPopulationDefenseHissho" Operation="Addition" Value="45" Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
+    <BinaryModifier TargetProperty="BonusPopulationDefenseHissho" Operation="Addition" Left="45" BinaryOperation="Multiplication" Right="$(PlanetIsHot)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationAssimilatedSecondaryCustomHappinessOnHot02" Type="ClassPopulationAssimilated">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="2" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +4 HappinessOnHot -->
+  <!-- +4 Approval on Hot / +60 Defense on Hot Hishho -->  
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHot03" Type="WithPopulationPlanet">
     <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="4"   Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
     <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHot)" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDefenseHissho" Operation="Addition"    Value="60"   Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue2"	  Operation="Addition"    Left="60"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDefenseHissho" Operation="Addition"    Left="$(PopulationAuxValue2)"    BinaryOperation="Multiplication" Right="$(PlanetIsHot)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHot03" Type="ClassPopulationPlanet">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="4" Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="4" BinaryOperation="Multiplication" Right="$(PlanetIsHot)" TooltipHidden="true"/>
+    <Modifier TargetProperty="BonusPopulationDefenseHissho" Operation="Addition" Value="60" Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
+    <BinaryModifier TargetProperty="BonusPopulationDefenseHissho" Operation="Addition" Left="60" BinaryOperation="Multiplication" Right="$(PlanetIsHot)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +5 HappinessOnHot -->
+  <!-- +5 Approval on Hot / +75 Defense on Hot Hishho -->  
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHot04" Type="WithPopulationPlanet">
     <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="5"   Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
     <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHot)" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDefenseHissho" Operation="Addition"    Value="75"   Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue2"	  Operation="Addition"    Left="75"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDefenseHissho" Operation="Addition"    Left="$(PopulationAuxValue2)"    BinaryOperation="Multiplication" Right="$(PlanetIsHot)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHot04" Type="ClassPopulationPlanet">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="5" BinaryOperation="Multiplication" Right="$(PlanetIsHot)" TooltipHidden="true"/>
+    <Modifier TargetProperty="BonusPopulationDefenseHissho" Operation="Addition" Value="75" Path="FAKEFORGUI/./PlanetGameplayTypeHot"/>
+    <BinaryModifier TargetProperty="BonusPopulationDefenseHissho" Operation="Addition" Left="75" BinaryOperation="Multiplication" Right="$(PlanetIsHot)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationAssimilatedSecondaryCustomHappinessOnHot04" Type="ClassPopulationAssimilated">
@@ -303,81 +379,101 @@
   </SimulationDescriptor>
 
   <!-- Happiness on Teeming -->
-  <!-- +1 HappinessOnTeeming -->
+  <!-- +1 Approval on Fertile / +1 Food on Fertile Hishho -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTeeming00" Type="WithPopulationPlanet">
     <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="1"   Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
     <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationFoodHissho" Operation="Addition"    Value="1"   Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue2"	  Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFoodHissho" Operation="Addition"    Left="$(PopulationAuxValue2)"    BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTeeming00" Type="ClassPopulationPlanet">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="1" BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
+    <Modifier TargetProperty="BonusPopulationFoodHissho" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
+    <BinaryModifier TargetProperty="BonusPopulationFoodHissho" Operation="Addition" Left="1" BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationAssimilatedSecondaryCustomHappinessOnTeeming00" Type="ClassPopulationAssimilated">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="1" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +2 HappinessOnTeeming -->
+  <!-- +2 Approval on Fertile / +2 Food on Fertile Hishho -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTeeming01" Type="WithPopulationPlanet">
     <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
     <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationFoodHissho" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue2"	  Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFoodHissho" Operation="Addition"    Left="$(PopulationAuxValue2)"    BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTeeming01" Type="ClassPopulationPlanet">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="2" BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
+    <Modifier TargetProperty="BonusPopulationFoodHissho" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
+    <BinaryModifier TargetProperty="BonusPopulationFoodHissho" Operation="Addition" Left="2" BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>	
   </SimulationDescriptor>
 
-  <!-- +3 HappinessOnTeeming -->
+  <!-- +3 Approval on Fertile / +3 Food on Fertile Hishho -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTeeming02" Type="WithPopulationPlanet">
     <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
     <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationFoodHissho" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue2"	  Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFoodHissho" Operation="Addition"    Left="$(PopulationAuxValue2)"    BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTeeming02" Type="ClassPopulationPlanet">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="3" BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
+    <Modifier TargetProperty="BonusPopulationFoodHissho" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
+    <BinaryModifier TargetProperty="BonusPopulationFoodHissho" Operation="Addition" Left="3" BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationAssimilatedSecondaryCustomHappinessOnTeeming02" Type="ClassPopulationAssimilated">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="2" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +4 HappinessOnTeeming / +60 System manpower capacity on fertile-->
+  <!-- +4 Approval on Fertile / +4 Food on Fertile Hishho -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTeeming03" Type="WithPopulationPlanet">
-    <Modifier       TargetProperty="BonusPopulationHappiness"       Operation="Addition"    Value="4"   Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
-    <Modifier       TargetProperty="BonusPopulationDefenseHissho"   Operation="Addition"    Value="60"  Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
-    <BinaryModifier TargetProperty="PopulationAuxValue1"			Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
-    <BinaryModifier TargetProperty="PopulationAuxValue2"			Operation="Addition"    Left="60"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
-    <BinaryModifier TargetProperty="BonusPopulationHappiness"       Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
-    <BinaryModifier TargetProperty="BonusPopulationDefenseHissho"   Operation="Addition"    Left="$(PopulationAuxValue2)"   BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="4"   Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationFoodHissho" Operation="Addition"    Value="4"   Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue2"	  Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFoodHissho" Operation="Addition"    Left="$(PopulationAuxValue2)"    BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTeeming03" Type="ClassPopulationPlanet">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="4" Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="4" BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
-    <Modifier TargetProperty="BonusPopulationDefenseHissho" Operation="Addition" Value="60" Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
-    <BinaryModifier TargetProperty="BonusPopulationDefenseHissho" Operation="Addition" Left="60" BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
+    <Modifier TargetProperty="BonusPopulationFoodHissho" Operation="Addition" Value="4" Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
+    <BinaryModifier TargetProperty="BonusPopulationFoodHissho" Operation="Addition" Left="4" BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationAssimilatedSecondaryCustomHappinessOnTeeming03" Type="ClassPopulationAssimilated">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="3" Path="ClassPopulation"/>
   </SimulationDescriptor>
   
-  <!-- +5 HappinessOnTeeming -->
+  <!-- +5 Approval on Fertile / +5 Food on Fertile Hishho -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTeeming04" Type="WithPopulationPlanet">
     <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="5"   Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
     <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationFoodHissho" Operation="Addition"    Value="5"   Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue2"	  Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFoodHissho" Operation="Addition"    Left="$(PopulationAuxValue2)"    BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTeeming04" Type="ClassPopulationPlanet">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="5" BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
+    <Modifier TargetProperty="BonusPopulationFoodHissho" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
+    <BinaryModifier TargetProperty="BonusPopulationFoodHissho" Operation="Addition" Left="5" BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationAssimilatedSecondaryCustomHappinessOnTeeming04" Type="ClassPopulationAssimilated">
@@ -385,44 +481,49 @@
   </SimulationDescriptor>
 
   <!-- Happiness on Meager -->
-  <!-- +1 HappinessOnMeager -->
+  <!-- +1 Approval on Sterile / +1 Dust on Sterile Hishho -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnMeager00" Type="WithPopulationPlanet">
     <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="1"   Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
     <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMeager)" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDustHissho" Operation="Addition"    Value="1"   Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue2"	  Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDustHissho" Operation="Addition"    Left="$(PopulationAuxValue2)"    BinaryOperation="Multiplication" Right="$(PlanetIsMeager)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnMeager00" Type="ClassPopulationPlanet">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="1" BinaryOperation="Multiplication" Right="$(PlanetIsMeager)" TooltipHidden="true"/>
+    <Modifier TargetProperty="BonusPopulationDustHissho" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
+    <BinaryModifier TargetProperty="BonusPopulationDustHissho" Operation="Addition" Left="1" BinaryOperation="Multiplication" Right="$(PlanetIsMeager)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationAssimilatedSecondaryCustomHappinessOnMeager00" Type="ClassPopulationAssimilated">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="1" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +2 HappinessOnMeager / +30 System manpower capacity-->
+  <!-- +2 Approval on Sterile / +2 Dust on Sterile Hishho -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnMeager01" Type="WithPopulationPlanet">
-    <Modifier       TargetProperty="BonusPopulationHappiness"       Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
-    <Modifier       TargetProperty="BonusPopulationDefenseHissho"   Operation="Addition"    Value="30"  Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
-    <BinaryModifier TargetProperty="PopulationAuxValue1"			Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
-    <BinaryModifier TargetProperty="PopulationAuxValue2"			Operation="Addition"    Left="30"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
-    <BinaryModifier TargetProperty="BonusPopulationHappiness"       Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
-    <BinaryModifier TargetProperty="BonusPopulationDefenseHissho"   Operation="Addition"    Left="$(PopulationAuxValue2)"   BinaryOperation="Multiplication" Right="$(PlanetIsTeeming)" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMeager)" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDustHissho" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue2"	  Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDustHissho" Operation="Addition"    Left="$(PopulationAuxValue2)"    BinaryOperation="Multiplication" Right="$(PlanetIsMeager)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnMeager01" Type="ClassPopulationPlanet">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="2" BinaryOperation="Multiplication" Right="$(PlanetIsMeager)" TooltipHidden="true"/>
-    <Modifier TargetProperty="BonusPopulationDefenseHissho" Operation="Addition" Value="30" Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
-    <BinaryModifier TargetProperty="BonusPopulationDefenseHissho" Operation="Addition" Left="30" BinaryOperation="Multiplication" Right="$(PlanetIsMeager)" TooltipHidden="true"/>
+    <Modifier TargetProperty="BonusPopulationDustHissho" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
+    <BinaryModifier TargetProperty="BonusPopulationDustHissho" Operation="Addition" Left="2" BinaryOperation="Multiplication" Right="$(PlanetIsMeager)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationAssimilatedPlanetSecondaryCustomHappinessOnMeager00" Type="ClassPopulationAssimilated">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="1" Path="ClassPopulation"/>
   </SimulationDescriptor>
   
-  <!-- +2 HappinessOnMeager / +2 food-->
+  <!-- DEPRECATED: +2 Approval on Sterile / +2 Food on Sterile Hishho -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessFoodOnMeager01" Type="WithPopulationPlanet">
     <Modifier       TargetProperty="BonusPopulationHappiness"       Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
     <Modifier       TargetProperty="BonusPopulationFoodHissho"      Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetGameplayTypeTeeming"/>
@@ -443,44 +544,59 @@
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="1" Path="ClassPopulation"/>
   </SimulationDescriptor>
   
-  <!-- +3 HappinessOnMeager -->
+  <!-- +3 Approval on Sterile / +3 Dust on Sterile Hishho -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnMeager02" Type="WithPopulationPlanet">
     <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
     <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMeager)" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDustHissho" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue2"	  Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDustHissho" Operation="Addition"    Left="$(PopulationAuxValue2)"    BinaryOperation="Multiplication" Right="$(PlanetIsMeager)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnMeager02" Type="ClassPopulationPlanet">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="3" BinaryOperation="Multiplication" Right="$(PlanetIsMeager)" TooltipHidden="true"/>
+    <Modifier TargetProperty="BonusPopulationDustHissho" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
+    <BinaryModifier TargetProperty="BonusPopulationDustHissho" Operation="Addition" Left="3" BinaryOperation="Multiplication" Right="$(PlanetIsMeager)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationAssimilatedSecondaryCustomHappinessOnMeager02" Type="ClassPopulationAssimilated">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="2" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +4 HappinessOnMeager -->
+  <!-- +4 Approval on Sterile / +4 Dust on Sterile Hishho -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnMeager03" Type="WithPopulationPlanet">
     <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="4"   Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
     <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMeager)" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDustHissho" Operation="Addition"    Value="4"   Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue2"	  Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDustHissho" Operation="Addition"    Left="$(PopulationAuxValue2)"    BinaryOperation="Multiplication" Right="$(PlanetIsMeager)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnMeager03" Type="ClassPopulationPlanet">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="4" Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="4" BinaryOperation="Multiplication" Right="$(PlanetIsMeager)" TooltipHidden="true"/>
+    <Modifier TargetProperty="BonusPopulationDustHissho" Operation="Addition" Value="4" Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
+    <BinaryModifier TargetProperty="BonusPopulationDustHissho" Operation="Addition" Left="4" BinaryOperation="Multiplication" Right="$(PlanetIsMeager)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +5 HappinessOnMeager -->
+  <!-- +5 Approval on Sterile / +5 Dust on Sterile Hishho -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnMeager04" Type="WithPopulationPlanet">
     <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="5"   Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
     <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMeager)" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDustHissho" Operation="Addition"    Value="5"   Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue2"	  Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDustHissho" Operation="Addition"    Left="$(PopulationAuxValue2)"    BinaryOperation="Multiplication" Right="$(PlanetIsMeager)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnMeager04" Type="ClassPopulationPlanet">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="5" BinaryOperation="Multiplication" Right="$(PlanetIsMeager)" TooltipHidden="true"/>
+    <Modifier TargetProperty="BonusPopulationDustHissho" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetGameplayTypeMeager"/>
+    <BinaryModifier TargetProperty="BonusPopulationDustHissho" Operation="Addition" Left="5" BinaryOperation="Multiplication" Right="$(PlanetIsMeager)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationAssimilatedSecondaryCustomHappinessOnMeager04" Type="ClassPopulationAssimilated">
@@ -488,72 +604,97 @@
   </SimulationDescriptor>
 
   <!-- Happiness on Gas -->
-  <!-- +3 HappinessOnGas -->
+  <!-- +3 Approval on Gas / +3 Science on Gas Hishho -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnGas00" Type="WithPopulationPlanet">
     <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
     <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsGas)" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScienceHissho" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue2"	  Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScienceHissho" Operation="Addition"    Left="$(PopulationAuxValue2)"    BinaryOperation="Multiplication" Right="$(PlanetIsGas)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnGas00" Type="ClassPopulationPlanet">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="3" BinaryOperation="Multiplication" Right="$(PlanetIsGas)" TooltipHidden="true"/>
+    <Modifier TargetProperty="BonusPopulationScienceHissho" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
+    <BinaryModifier TargetProperty="BonusPopulationScienceHissho" Operation="Addition" Left="3" BinaryOperation="Multiplication" Right="$(PlanetIsGas)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationAssimilatedSecondaryCustomHappinessOnGas00" Type="ClassPopulationAssimilated">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="1" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +5 HappinessOnGas -->
+  <!-- +5 Approval on Gas / +5 Science on Gas Hishho -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnGas01" Type="WithPopulationPlanet">
     <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="5"   Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
     <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsGas)" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScienceHissho" Operation="Addition"    Value="5"   Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue2"	  Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScienceHissho" Operation="Addition"    Left="$(PopulationAuxValue2)"    BinaryOperation="Multiplication" Right="$(PlanetIsGas)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnGas01" Type="ClassPopulationPlanet">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="5" BinaryOperation="Multiplication" Right="$(PlanetIsGas)" TooltipHidden="true"/>
+    <Modifier TargetProperty="BonusPopulationScienceHissho" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
+    <BinaryModifier TargetProperty="BonusPopulationScienceHissho" Operation="Addition" Left="5" BinaryOperation="Multiplication" Right="$(PlanetIsGas)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +10 HappinessOnGas -->
+  <!-- +10 Approval on Gas / +10 Science on Gas Hishho -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnGas02" Type="WithPopulationPlanet">
     <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="10"  Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
     <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="10"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsGas)" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScienceHissho" Operation="Addition"    Value="10"   Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue2"	  Operation="Addition"    Left="10"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScienceHissho" Operation="Addition"    Left="$(PopulationAuxValue2)"    BinaryOperation="Multiplication" Right="$(PlanetIsGas)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnGas02" Type="ClassPopulationPlanet">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="10" Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="10" BinaryOperation="Multiplication" Right="$(PlanetIsGas)" TooltipHidden="true"/>
+    <Modifier TargetProperty="BonusPopulationScienceHissho" Operation="Addition" Value="10" Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
+    <BinaryModifier TargetProperty="BonusPopulationScienceHissho" Operation="Addition" Left="10" BinaryOperation="Multiplication" Right="$(PlanetIsGas)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationAssimilatedSecondaryCustomHappinessOnGas02" Type="ClassPopulationAssimilated">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="3" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +12 HappinessOnGas -->
+  <!-- +12 Approval on Gas / +12 Science on Gas Hishho -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnGas03" Type="WithPopulationPlanet">
     <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="12"  Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
     <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="12"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsGas)" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScienceHissho" Operation="Addition"    Value="12"   Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue2"	  Operation="Addition"    Left="12"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScienceHissho" Operation="Addition"    Left="$(PopulationAuxValue2)"    BinaryOperation="Multiplication" Right="$(PlanetIsGas)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnGas03" Type="ClassPopulationPlanet">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="12" Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="12" BinaryOperation="Multiplication" Right="$(PlanetIsGas)" TooltipHidden="true"/>
+    <Modifier TargetProperty="BonusPopulationScienceHissho" Operation="Addition" Value="12" Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
+    <BinaryModifier TargetProperty="BonusPopulationScienceHissho" Operation="Addition" Left="12" BinaryOperation="Multiplication" Right="$(PlanetIsGas)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +15 HappinessOnGas -->
+  <!-- +15 Approval on Gas / +15 Science on Gas Hishho -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnGas04" Type="WithPopulationPlanet">
     <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="15"  Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
     <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="15"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsGas)" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScienceHissho" Operation="Addition"    Value="15"   Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue2"	  Operation="Addition"    Left="15"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScienceHissho" Operation="Addition"    Left="$(PopulationAuxValue2)"    BinaryOperation="Multiplication" Right="$(PlanetIsGas)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnGas04" Type="ClassPopulationPlanet">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="15" Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="15" BinaryOperation="Multiplication" Right="$(PlanetIsGas)" TooltipHidden="true"/>
+    <Modifier TargetProperty="BonusPopulationScienceHissho" Operation="Addition" Value="15" Path="FAKEFORGUI/./PlanetGameplayTypeGas"/>
+    <BinaryModifier TargetProperty="BonusPopulationScienceHissho" Operation="Addition" Left="15" BinaryOperation="Multiplication" Right="$(PlanetIsGas)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationAssimilatedSecondaryCustomHappinessOnGas04" Type="ClassPopulationAssimilated">
@@ -561,82 +702,97 @@
   </SimulationDescriptor>
 
   <!-- Happiness on Happy -->
-  <!-- +1 HappinessOnHappy -->
+  <!-- +1 Approval on Happy / +1 Influence on Loyal Hishho -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHappy00" Type="WithPopulationPlanet">
     <Modifier		TargetProperty="BonusPopulationHappiness"		Operation="Addition" Value="1" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
-    <Modifier		TargetProperty="BonusPopulationHappiness"		Operation="Addition" Value="1" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
     <BinaryModifier TargetProperty="PopulationAuxValue1"			Operation="Addition" Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness"		Operation="Addition" Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" TooltipHidden="true"/>
+    <Modifier		TargetProperty="BonusPopulationPrestigeHissho"		Operation="Addition" Value="1" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue2"			Operation="Addition" Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestigeHissho"		Operation="Addition" Left="$(PopulationAuxValue2)"    BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHappy00" Type="ClassPopulationPlanet">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="1" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="1" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="1" BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" TooltipHidden="true"/>
+    <Modifier TargetProperty="BonusPopulationPrestigeHissho" Operation="Addition" Value="1" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestigeHissho" Operation="Addition" Left="1" BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationAssimilatedSecondaryCustomHappinessOnHappy00" Type="ClassPopulationAssimilated">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="1" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +2 HappinessOnHappy -->
+  <!-- +2 Approval on Happy / +1 Influence on Loyal Hishho -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHappy01" Type="WithPopulationPlanet">
     <Modifier		TargetProperty="BonusPopulationHappiness"		Operation="Addition" Value="2" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
-    <Modifier		TargetProperty="BonusPopulationHappiness"		Operation="Addition" Value="2" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
     <BinaryModifier TargetProperty="PopulationAuxValue1"			Operation="Addition" Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness"		Operation="Addition" Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" TooltipHidden="true"/>
+    <Modifier		TargetProperty="BonusPopulationPrestigeHissho"		Operation="Addition" Value="1" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue2"			Operation="Addition" Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestigeHissho"		Operation="Addition" Left="$(PopulationAuxValue2)"    BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHappy01" Type="ClassPopulationPlanet">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="2" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="2" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="2" BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" TooltipHidden="true"/>
+    <Modifier TargetProperty="BonusPopulationPrestigeHissho" Operation="Addition" Value="1" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestigeHissho" Operation="Addition" Left="1" BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +3 HappinessOnHappy -->
+  <!-- +3 Approval on Happy / +2 Influence on Loyal Hishho -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHappy02" Type="WithPopulationPlanet">
     <Modifier		TargetProperty="BonusPopulationHappiness"		Operation="Addition" Value="3" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
-    <Modifier		TargetProperty="BonusPopulationHappiness"		Operation="Addition" Value="3" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
     <BinaryModifier TargetProperty="PopulationAuxValue1"			Operation="Addition" Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness"		Operation="Addition" Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" TooltipHidden="true"/>
+    <Modifier		TargetProperty="BonusPopulationPrestigeHissho"		Operation="Addition" Value="2" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue2"			Operation="Addition" Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestigeHissho"		Operation="Addition" Left="$(PopulationAuxValue2)"    BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHappy02" Type="ClassPopulationPlanet">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="3" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="3" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="3" BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" TooltipHidden="true"/>
+    <Modifier TargetProperty="BonusPopulationPrestigeHissho" Operation="Addition" Value="2" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestigeHissho" Operation="Addition" Left="2" BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationAssimilatedSecondaryCustomHappinessOnHappy02" Type="ClassPopulationAssimilated">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="2" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +4 HappinessOnHappy -->
+  <!-- +4 Approval on Happy / +2 Influence on Loyal Hishho -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHappy03" Type="WithPopulationPlanet">
     <Modifier		TargetProperty="BonusPopulationHappiness"		Operation="Addition" Value="4" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
-    <Modifier		TargetProperty="BonusPopulationHappiness"		Operation="Addition" Value="4" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
     <BinaryModifier TargetProperty="PopulationAuxValue1"			Operation="Addition" Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness"		Operation="Addition" Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" TooltipHidden="true"/>
+    <Modifier		TargetProperty="BonusPopulationPrestigeHissho"		Operation="Addition" Value="2" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue2"			Operation="Addition" Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestigeHissho"		Operation="Addition" Left="$(PopulationAuxValue2)"    BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHappy03" Type="ClassPopulationPlanet">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="4" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="4" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="4" BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" TooltipHidden="true"/>
+    <Modifier TargetProperty="BonusPopulationPrestigeHissho" Operation="Addition" Value="2" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestigeHissho" Operation="Addition" Left="2" BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +5 HappinessOnHappy -->
+  <!-- +5 Approval on Happy / +3 Influence on Loyal Hishho -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHappy04" Type="WithPopulationPlanet">
     <Modifier		TargetProperty="BonusPopulationHappiness"		Operation="Addition" Value="5" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
-    <Modifier		TargetProperty="BonusPopulationHappiness"		Operation="Addition" Value="5" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
     <BinaryModifier TargetProperty="PopulationAuxValue1"			Operation="Addition" Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness"		Operation="Addition" Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" TooltipHidden="true"/>
+    <Modifier		TargetProperty="BonusPopulationPrestigeHissho"		Operation="Addition" Value="3" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue2"			Operation="Addition" Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestigeHissho"		Operation="Addition" Left="$(PopulationAuxValue2)"    BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHappy04" Type="ClassPopulationPlanet">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="5" Path="FAKEFORGUI/./ClassColonizedStarSystem,HappinessStatusStarSystem3"/>
-    <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="5" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="5" BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" TooltipHidden="true"/>
+    <Modifier TargetProperty="BonusPopulationPrestigeHissho" Operation="Addition" Value="3" Path="FAKEFORGUI/./ClassColonizedStarSystem,ObedienceStatusStarSystem3"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestigeHissho" Operation="Addition" Left="3" BinaryOperation="Multiplication" Right="$(HappinessStarSystemIsHappy)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationAssimilatedSecondaryCustomHappinessOnHappy04" Type="ClassPopulationAssimilated">
@@ -644,72 +800,97 @@
   </SimulationDescriptor>
 
   <!-- Happiness on Tiny -->
-  <!-- +1 HappinessOnTiny -->
+  <!-- +1 Approval on Tiny / +15 Defense on Tiny Hishho -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTiny00" Type="WithPopulationPlanet">
     <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="1"   Path="FAKEFORGUI/./PlanetSizeTiny"/>
     <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTiny)" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDefenseHissho" Operation="Addition"    Value="15"   Path="FAKEFORGUI/./PlanetSizeTiny"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue2"	  Operation="Addition"    Left="15"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDefenseHissho" Operation="Addition"    Left="$(PopulationAuxValue2)"    BinaryOperation="Multiplication" Right="$(PlanetIsTiny)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTiny00" Type="ClassPopulationPlanet">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetSizeTiny"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="1" BinaryOperation="Multiplication" Right="$(PlanetIsTiny)" TooltipHidden="true"/>
+    <Modifier TargetProperty="BonusPopulationDefenseHissho" Operation="Addition" Value="15" Path="FAKEFORGUI/./PlanetSizeTiny"/>
+    <BinaryModifier TargetProperty="BonusPopulationDefenseHissho" Operation="Addition" Left="15" BinaryOperation="Multiplication" Right="$(PlanetIsTiny)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationAssimilatedSecondaryCustomHappinessOnTiny00" Type="ClassPopulationAssimilated">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="1" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +2 HappinessOnTiny -->
+  <!-- +2 Approval on Tiny / +30 Defense on Tiny Hishho -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTiny01" Type="WithPopulationPlanet">
     <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetSizeTiny"/>
     <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTiny)" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDefenseHissho" Operation="Addition"    Value="30"   Path="FAKEFORGUI/./PlanetSizeTiny"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue2"	  Operation="Addition"    Left="30"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDefenseHissho" Operation="Addition"    Left="$(PopulationAuxValue2)"    BinaryOperation="Multiplication" Right="$(PlanetIsTiny)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTiny01" Type="ClassPopulationPlanet">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetSizeTiny"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="2" BinaryOperation="Multiplication" Right="$(PlanetIsTiny)" TooltipHidden="true"/>
+    <Modifier TargetProperty="BonusPopulationDefenseHissho" Operation="Addition" Value="30" Path="FAKEFORGUI/./PlanetSizeTiny"/>
+    <BinaryModifier TargetProperty="BonusPopulationDefenseHissho" Operation="Addition" Left="30" BinaryOperation="Multiplication" Right="$(PlanetIsTiny)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +3 HappinessOnTiny -->
+  <!-- +3 Approval on Tiny / +45 Defense on Tiny Hishho -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTiny02" Type="WithPopulationPlanet">
     <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetSizeTiny"/>
     <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTiny)" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDefenseHissho" Operation="Addition"    Value="45"   Path="FAKEFORGUI/./PlanetSizeTiny"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue2"	  Operation="Addition"    Left="45"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDefenseHissho" Operation="Addition"    Left="$(PopulationAuxValue2)"    BinaryOperation="Multiplication" Right="$(PlanetIsTiny)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTiny02" Type="ClassPopulationPlanet">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetSizeTiny"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="3" BinaryOperation="Multiplication" Right="$(PlanetIsTiny)" TooltipHidden="true"/>
+    <Modifier TargetProperty="BonusPopulationDefenseHissho" Operation="Addition" Value="45" Path="FAKEFORGUI/./PlanetSizeTiny"/>
+    <BinaryModifier TargetProperty="BonusPopulationDefenseHissho" Operation="Addition" Left="45" BinaryOperation="Multiplication" Right="$(PlanetIsTiny)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationAssimilatedSecondaryCustomHappinessOnTiny02" Type="ClassPopulationAssimilated">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="2" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +4 HappinessOnTiny -->
+  <!-- +4 Approval on Tiny / +60 Defense on Tiny Hishho -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTiny03" Type="WithPopulationPlanet">
     <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="4"   Path="FAKEFORGUI/./PlanetSizeTiny"/>
     <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTiny)" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDefenseHissho" Operation="Addition"    Value="60"   Path="FAKEFORGUI/./PlanetSizeTiny"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue2"	  Operation="Addition"    Left="60"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDefenseHissho" Operation="Addition"    Left="$(PopulationAuxValue2)"    BinaryOperation="Multiplication" Right="$(PlanetIsTiny)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTiny03" Type="ClassPopulationPlanet">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="4" Path="FAKEFORGUI/./PlanetSizeTiny"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="4" BinaryOperation="Multiplication" Right="$(PlanetIsTiny)" TooltipHidden="true"/>
+    <Modifier TargetProperty="BonusPopulationDefenseHissho" Operation="Addition" Value="60" Path="FAKEFORGUI/./PlanetSizeTiny"/>
+    <BinaryModifier TargetProperty="BonusPopulationDefenseHissho" Operation="Addition" Left="60" BinaryOperation="Multiplication" Right="$(PlanetIsTiny)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +5 HappinessOnTiny -->
+  <!-- +5 Approval on Tiny / +75 Defense on Tiny Hishho -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTiny04" Type="WithPopulationPlanet">
     <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="5"   Path="FAKEFORGUI/./PlanetSizeTiny"/>
     <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsTiny)" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDefenseHissho" Operation="Addition"    Value="75"   Path="FAKEFORGUI/./PlanetSizeTiny"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue2"	  Operation="Addition"    Left="75"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDefenseHissho" Operation="Addition"    Left="$(PopulationAuxValue2)"    BinaryOperation="Multiplication" Right="$(PlanetIsTiny)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnTiny04" Type="ClassPopulationPlanet">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetSizeTiny"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="5" BinaryOperation="Multiplication" Right="$(PlanetIsTiny)" TooltipHidden="true"/>
+    <Modifier TargetProperty="BonusPopulationDefenseHissho" Operation="Addition" Value="75" Path="FAKEFORGUI/./PlanetSizeTiny"/>
+    <BinaryModifier TargetProperty="BonusPopulationDefenseHissho" Operation="Addition" Left="75" BinaryOperation="Multiplication" Right="$(PlanetIsTiny)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationAssimilatedSecondaryCustomHappinessOnTiny04" Type="ClassPopulationAssimilated">
@@ -717,72 +898,97 @@
   </SimulationDescriptor>
 
   <!-- Happiness on Small -->
-  <!-- +1 HappinessOnSmall -->
+  <!-- +1 Approval on Small / +1 Influence on Small Hishho -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnSmall00" Type="WithPopulationPlanet">
     <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="1"   Path="FAKEFORGUI/./PlanetSizeSmall"/>
     <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsSmall)" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationPrestigeHissho" Operation="Addition"    Value="1"   Path="FAKEFORGUI/./PlanetSizeSmall"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue2"	  Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestigeHissho" Operation="Addition"    Left="$(PopulationAuxValue2)"    BinaryOperation="Multiplication" Right="$(PlanetIsSmall)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnSmall00" Type="ClassPopulationPlanet">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetSizeSmall"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="1" BinaryOperation="Multiplication" Right="$(PlanetIsSmall)" TooltipHidden="true"/>
+    <Modifier TargetProperty="BonusPopulationPrestigeHissho" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetSizeSmall"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestigeHissho" Operation="Addition" Left="1" BinaryOperation="Multiplication" Right="$(PlanetIsSmall)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationAssimilatedSecondaryCustomHappinessOnSmall00" Type="ClassPopulationAssimilated">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="1" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +2 HappinessOnSmall -->
+  <!-- +2 Approval on Small / +1 Influence on Small Hishho -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnSmall01" Type="WithPopulationPlanet">
     <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetSizeSmall"/>
     <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsSmall)" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationPrestigeHissho" Operation="Addition"    Value="1"   Path="FAKEFORGUI/./PlanetSizeSmall"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue2"	  Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestigeHissho" Operation="Addition"    Left="$(PopulationAuxValue2)"    BinaryOperation="Multiplication" Right="$(PlanetIsSmall)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnSmall01" Type="ClassPopulationPlanet">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetSizeSmall"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="2" BinaryOperation="Multiplication" Right="$(PlanetIsSmall)" TooltipHidden="true"/>
+    <Modifier TargetProperty="BonusPopulationPrestigeHissho" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetSizeSmall"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestigeHissho" Operation="Addition" Left="1" BinaryOperation="Multiplication" Right="$(PlanetIsSmall)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +3 HappinessOnSmall -->
+  <!-- +3 Approval on Small / +2 Influence on Small Hishho -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnSmall02" Type="WithPopulationPlanet">
     <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetSizeSmall"/>
     <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsSmall)" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationPrestigeHissho" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetSizeSmall"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue2"	  Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestigeHissho" Operation="Addition"    Left="$(PopulationAuxValue2)"    BinaryOperation="Multiplication" Right="$(PlanetIsSmall)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnSmall02" Type="ClassPopulationPlanet">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetSizeSmall"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="3" BinaryOperation="Multiplication" Right="$(PlanetIsSmall)" TooltipHidden="true"/>
+    <Modifier TargetProperty="BonusPopulationPrestigeHissho" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetSizeSmall"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestigeHissho" Operation="Addition" Left="2" BinaryOperation="Multiplication" Right="$(PlanetIsSmall)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationAssimilatedSecondaryCustomHappinessOnSmall02" Type="ClassPopulationAssimilated">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="2" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +4 HappinessOnSmall -->
+  <!-- +4 Approval on Small / +2 Influence on Small Hishho -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnSmall03" Type="WithPopulationPlanet">
     <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="4"   Path="FAKEFORGUI/./PlanetSizeSmall"/>
     <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsSmall)" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationPrestigeHissho" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetSizeSmall"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue2"	  Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestigeHissho" Operation="Addition"    Left="$(PopulationAuxValue2)"    BinaryOperation="Multiplication" Right="$(PlanetIsSmall)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnSmall03" Type="ClassPopulationPlanet">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="4" Path="FAKEFORGUI/./PlanetSizeSmall"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="4" BinaryOperation="Multiplication" Right="$(PlanetIsSmall)" TooltipHidden="true"/>
+    <Modifier TargetProperty="BonusPopulationPrestigeHissho" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetSizeSmall"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestigeHissho" Operation="Addition" Left="2" BinaryOperation="Multiplication" Right="$(PlanetIsSmall)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +5 HappinessOnSmall -->
+  <!-- +5 Approval on Small / +3 Influence on Small Hishho -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnSmall04" Type="WithPopulationPlanet">
     <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="5"   Path="FAKEFORGUI/./PlanetSizeSmall"/>
     <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsSmall)" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationPrestigeHissho" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetSizeSmall"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue2"	  Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestigeHissho" Operation="Addition"    Left="$(PopulationAuxValue2)"    BinaryOperation="Multiplication" Right="$(PlanetIsSmall)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnSmall04" Type="ClassPopulationPlanet">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetSizeSmall"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="5" BinaryOperation="Multiplication" Right="$(PlanetIsSmall)" TooltipHidden="true"/>
+    <Modifier TargetProperty="BonusPopulationPrestigeHissho" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetSizeSmall"/>
+    <BinaryModifier TargetProperty="BonusPopulationPrestigeHissho" Operation="Addition" Left="3" BinaryOperation="Multiplication" Right="$(PlanetIsSmall)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationAssimilatedSecondaryCustomHappinessOnSmall04" Type="ClassPopulationAssimilated">
@@ -790,72 +996,97 @@
   </SimulationDescriptor>
 
   <!-- Happiness on Medium -->
-  <!-- +1 HappinessOnMedium -->
+  <!-- +1 Approval on Medium / +1 Science on Medium Hishho -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnMedium00" Type="WithPopulationPlanet">
     <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="1"   Path="FAKEFORGUI/./PlanetSizeMedium"/>
     <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMedium)" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScienceHissho" Operation="Addition"    Value="1"   Path="FAKEFORGUI/./PlanetSizeMedium"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue2"	  Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScienceHissho" Operation="Addition"    Left="$(PopulationAuxValue2)"    BinaryOperation="Multiplication" Right="$(PlanetIsMedium)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnMedium00" Type="ClassPopulationPlanet">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetSizeMedium"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="1" BinaryOperation="Multiplication" Right="$(PlanetIsMedium)" TooltipHidden="true"/>
+    <Modifier TargetProperty="BonusPopulationScienceHissho" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetSizeMedium"/>
+    <BinaryModifier TargetProperty="BonusPopulationScienceHissho" Operation="Addition" Left="1" BinaryOperation="Multiplication" Right="$(PlanetIsMedium)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationAssimilatedSecondaryCustomHappinessOnMedium00" Type="ClassPopulationAssimilated">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="1" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +2 HappinessOnMedium -->
+  <!-- +2 Approval on Medium / +2 Science on Medium Hishho -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnMedium01" Type="WithPopulationPlanet">
     <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetSizeMedium"/>
     <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMedium)" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScienceHissho" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetSizeMedium"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue2"	  Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScienceHissho" Operation="Addition"    Left="$(PopulationAuxValue2)"    BinaryOperation="Multiplication" Right="$(PlanetIsMedium)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnMedium01" Type="ClassPopulationPlanet">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetSizeMedium"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="2" BinaryOperation="Multiplication" Right="$(PlanetIsMedium)" TooltipHidden="true"/>
+    <Modifier TargetProperty="BonusPopulationScienceHissho" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetSizeMedium"/>
+    <BinaryModifier TargetProperty="BonusPopulationScienceHissho" Operation="Addition" Left="2" BinaryOperation="Multiplication" Right="$(PlanetIsMedium)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +3 HappinessOnMedium -->
+  <!-- +3 Approval on Medium / +3 Science on Medium Hishho -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnMedium02" Type="WithPopulationPlanet">
     <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetSizeMedium"/>
     <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMedium)" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScienceHissho" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetSizeMedium"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue2"	  Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScienceHissho" Operation="Addition"    Left="$(PopulationAuxValue2)"    BinaryOperation="Multiplication" Right="$(PlanetIsMedium)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnMedium02" Type="ClassPopulationPlanet">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetSizeMedium"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="3" BinaryOperation="Multiplication" Right="$(PlanetIsMedium)" TooltipHidden="true"/>
+    <Modifier TargetProperty="BonusPopulationScienceHissho" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetSizeMedium"/>
+    <BinaryModifier TargetProperty="BonusPopulationScienceHissho" Operation="Addition" Left="3" BinaryOperation="Multiplication" Right="$(PlanetIsMedium)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationAssimilatedSecondaryCustomHappinessOnMedium02" Type="ClassPopulationAssimilated">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="2" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +4 HappinessOnMedium -->
+  <!-- +4 Approval on Medium / +4 Science on Medium Hishho -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnMedium03" Type="WithPopulationPlanet">
     <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="4"   Path="FAKEFORGUI/./PlanetSizeMedium"/>
     <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMedium)" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScienceHissho" Operation="Addition"    Value="4"   Path="FAKEFORGUI/./PlanetSizeMedium"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue2"	  Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScienceHissho" Operation="Addition"    Left="$(PopulationAuxValue2)"    BinaryOperation="Multiplication" Right="$(PlanetIsMedium)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnMedium03" Type="ClassPopulationPlanet">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="4" Path="FAKEFORGUI/./PlanetSizeMedium"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="4" BinaryOperation="Multiplication" Right="$(PlanetIsMedium)" TooltipHidden="true"/>
+    <Modifier TargetProperty="BonusPopulationScienceHissho" Operation="Addition" Value="4" Path="FAKEFORGUI/./PlanetSizeMedium"/>
+    <BinaryModifier TargetProperty="BonusPopulationScienceHissho" Operation="Addition" Left="4" BinaryOperation="Multiplication" Right="$(PlanetIsMedium)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +5 HappinessOnMedium -->
+  <!-- +5 Approval on Medium / +5 Science on Medium Hishho -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnMedium04" Type="WithPopulationPlanet">
     <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="5"   Path="FAKEFORGUI/./PlanetSizeMedium"/>
     <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsMedium)" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScienceHissho" Operation="Addition"    Value="5"   Path="FAKEFORGUI/./PlanetSizeMedium"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue2"	  Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScienceHissho" Operation="Addition"    Left="$(PopulationAuxValue2)"    BinaryOperation="Multiplication" Right="$(PlanetIsMedium)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnMedium04" Type="ClassPopulationPlanet">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetSizeMedium"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="5" BinaryOperation="Multiplication" Right="$(PlanetIsMedium)" TooltipHidden="true"/>
+    <Modifier TargetProperty="BonusPopulationScienceHissho" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetSizeMedium"/>
+    <BinaryModifier TargetProperty="BonusPopulationScienceHissho" Operation="Addition" Left="5" BinaryOperation="Multiplication" Right="$(PlanetIsMedium)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationAssimilatedSecondaryCustomHappinessOnMedium04" Type="ClassPopulationAssimilated">
@@ -863,72 +1094,97 @@
   </SimulationDescriptor>
 
   <!-- Happiness on Large -->
-  <!-- +1 HappinessOnLarge -->
+  <!-- +1 Approval on Large / +1 Food on Large Hishho -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnLarge00" Type="WithPopulationPlanet">
     <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="1"   Path="FAKEFORGUI/./PlanetSizeLarge"/>
     <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsLarge)" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationFoodHissho" Operation="Addition"    Value="1"   Path="FAKEFORGUI/./PlanetSizeLarge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue2"	  Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFoodHissho" Operation="Addition"    Left="$(PopulationAuxValue2)"    BinaryOperation="Multiplication" Right="$(PlanetIsLarge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnLarge00" Type="ClassPopulationPlanet">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetSizeLarge"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="1" BinaryOperation="Multiplication" Right="$(PlanetIsLarge)" TooltipHidden="true"/>
+    <Modifier TargetProperty="BonusPopulationFoodHissho" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetSizeLarge"/>
+    <BinaryModifier TargetProperty="BonusPopulationFoodHissho" Operation="Addition" Left="1" BinaryOperation="Multiplication" Right="$(PlanetIsLarge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationAssimilatedSecondaryCustomHappinessOnLarge00" Type="ClassPopulationAssimilated">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="1" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +2 HappinessOnLarge -->
+  <!-- +2 Approval on Large / +2 Food on Large Hishho -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnLarge01" Type="WithPopulationPlanet">
     <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetSizeLarge"/>
     <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsLarge)" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationFoodHissho" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetSizeLarge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue2"	  Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFoodHissho" Operation="Addition"    Left="$(PopulationAuxValue2)"    BinaryOperation="Multiplication" Right="$(PlanetIsLarge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnLarge01" Type="ClassPopulationPlanet">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetSizeLarge"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="2" BinaryOperation="Multiplication" Right="$(PlanetIsLarge)" TooltipHidden="true"/>
+    <Modifier TargetProperty="BonusPopulationFoodHissho" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetSizeLarge"/>
+    <BinaryModifier TargetProperty="BonusPopulationFoodHissho" Operation="Addition" Left="2" BinaryOperation="Multiplication" Right="$(PlanetIsLarge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +3 HappinessOnLarge -->
+  <!-- +3 Approval on Large / +3 Food on Large Hishho -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnLarge02" Type="WithPopulationPlanet">
     <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetSizeLarge"/>
     <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsLarge)" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationFoodHissho" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetSizeLarge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue2"	  Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFoodHissho" Operation="Addition"    Left="$(PopulationAuxValue2)"    BinaryOperation="Multiplication" Right="$(PlanetIsLarge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnLarge02" Type="ClassPopulationPlanet">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetSizeLarge"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="3" BinaryOperation="Multiplication" Right="$(PlanetIsLarge)" TooltipHidden="true"/>
+    <Modifier TargetProperty="BonusPopulationFoodHissho" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetSizeLarge"/>
+    <BinaryModifier TargetProperty="BonusPopulationFoodHissho" Operation="Addition" Left="3" BinaryOperation="Multiplication" Right="$(PlanetIsLarge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationAssimilatedSecondaryCustomHappinessOnLarge02" Type="ClassPopulationAssimilated">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="2" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +4 HappinessOnLarge -->
+  <!-- +4 Approval on Large / +4 Food on Large Hishho -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnLarge03" Type="WithPopulationPlanet">
     <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="4"   Path="FAKEFORGUI/./PlanetSizeLarge"/>
     <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsLarge)" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationFoodHissho" Operation="Addition"    Value="4"   Path="FAKEFORGUI/./PlanetSizeLarge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue2"	  Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFoodHissho" Operation="Addition"    Left="$(PopulationAuxValue2)"    BinaryOperation="Multiplication" Right="$(PlanetIsLarge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnLarge03" Type="ClassPopulationPlanet">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="4" Path="FAKEFORGUI/./PlanetSizeLarge"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="4" BinaryOperation="Multiplication" Right="$(PlanetIsLarge)" TooltipHidden="true"/>
+    <Modifier TargetProperty="BonusPopulationFoodHissho" Operation="Addition" Value="4" Path="FAKEFORGUI/./PlanetSizeLarge"/>
+    <BinaryModifier TargetProperty="BonusPopulationFoodHissho" Operation="Addition" Left="4" BinaryOperation="Multiplication" Right="$(PlanetIsLarge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +5 HappinessOnLarge -->
+  <!-- +5 Approval on Large / +5 Food on Large Hishho -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnLarge04" Type="WithPopulationPlanet">
     <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="5"   Path="FAKEFORGUI/./PlanetSizeLarge"/>
     <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsLarge)" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationFoodHissho" Operation="Addition"    Value="5"   Path="FAKEFORGUI/./PlanetSizeLarge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue2"	  Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFoodHissho" Operation="Addition"    Left="$(PopulationAuxValue2)"    BinaryOperation="Multiplication" Right="$(PlanetIsLarge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnLarge04" Type="ClassPopulationPlanet">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetSizeLarge"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="5" BinaryOperation="Multiplication" Right="$(PlanetIsLarge)" TooltipHidden="true"/>
+    <Modifier TargetProperty="BonusPopulationFoodHissho" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetSizeLarge"/>
+    <BinaryModifier TargetProperty="BonusPopulationFoodHissho" Operation="Addition" Left="5" BinaryOperation="Multiplication" Right="$(PlanetIsLarge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationAssimilatedSecondaryCustomHappinessOnLarge04" Type="ClassPopulationAssimilated">
@@ -936,72 +1192,97 @@
   </SimulationDescriptor>
 
   <!-- Happiness on Huge -->
-  <!-- +1 HappinessOnHuge -->
+  <!-- +5 Approval on Huge / +5 Dust on Huge Hishho -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHuge00" Type="WithPopulationPlanet">
     <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="1"   Path="FAKEFORGUI/./PlanetSizeHuge"/>
     <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHuge)" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDustHissho" Operation="Addition"    Value="1"   Path="FAKEFORGUI/./PlanetSizeHuge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue2"	  Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDustHissho" Operation="Addition"    Left="$(PopulationAuxValue2)"    BinaryOperation="Multiplication" Right="$(PlanetIsHuge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHuge00" Type="ClassPopulationPlanet">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetSizeHuge"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="1" BinaryOperation="Multiplication" Right="$(PlanetIsHuge)" TooltipHidden="true"/>
+    <Modifier TargetProperty="BonusPopulationDustHissho" Operation="Addition" Value="1" Path="FAKEFORGUI/./PlanetSizeHuge"/>
+    <BinaryModifier TargetProperty="BonusPopulationDustHissho" Operation="Addition" Left="1" BinaryOperation="Multiplication" Right="$(PlanetIsHuge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationAssimilatedSecondaryCustomHappinessOnHuge00" Type="ClassPopulationAssimilated">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="1" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +2 HappinessOnHuge -->
+  <!-- +2 Approval on Huge / +2 Dust on Huge Hishho -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHuge01" Type="WithPopulationPlanet">
     <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetSizeHuge"/>
     <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHuge)" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDustHissho" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetSizeHuge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue2"	  Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDustHissho" Operation="Addition"    Left="$(PopulationAuxValue2)"    BinaryOperation="Multiplication" Right="$(PlanetIsHuge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHuge01" Type="ClassPopulationPlanet">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetSizeHuge"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="2" BinaryOperation="Multiplication" Right="$(PlanetIsHuge)" TooltipHidden="true"/>
+    <Modifier TargetProperty="BonusPopulationDustHissho" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetSizeHuge"/>
+    <BinaryModifier TargetProperty="BonusPopulationDustHissho" Operation="Addition" Left="2" BinaryOperation="Multiplication" Right="$(PlanetIsHuge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +3 HappinessOnHuge -->
+  <!-- +3 Approval on Huge / +3 Dust on Huge Hishho -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHuge02" Type="WithPopulationPlanet">
     <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetSizeHuge"/>
     <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHuge)" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDustHissho" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetSizeHuge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue2"	  Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDustHissho" Operation="Addition"    Left="$(PopulationAuxValue2)"    BinaryOperation="Multiplication" Right="$(PlanetIsHuge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHuge02" Type="ClassPopulationPlanet">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetSizeHuge"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="3" BinaryOperation="Multiplication" Right="$(PlanetIsHuge)" TooltipHidden="true"/>
+    <Modifier TargetProperty="BonusPopulationDustHissho" Operation="Addition" Value="3" Path="FAKEFORGUI/./PlanetSizeHuge"/>
+    <BinaryModifier TargetProperty="BonusPopulationDustHissho" Operation="Addition" Left="3" BinaryOperation="Multiplication" Right="$(PlanetIsHuge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationAssimilatedSecondaryCustomHappinessOnHuge02" Type="ClassPopulationAssimilated">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="2" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +4 HappinessOnHuge -->
+  <!-- +4 Approval on Huge / +4 Dust on Huge Hishho -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHuge03" Type="WithPopulationPlanet">
     <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="4"   Path="FAKEFORGUI/./PlanetSizeHuge"/>
     <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHuge)" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDustHissho" Operation="Addition"    Value="4"   Path="FAKEFORGUI/./PlanetSizeHuge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue2"	  Operation="Addition"    Left="4"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDustHissho" Operation="Addition"    Left="$(PopulationAuxValue2)"    BinaryOperation="Multiplication" Right="$(PlanetIsHuge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHuge03" Type="ClassPopulationPlanet">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="4" Path="FAKEFORGUI/./PlanetSizeHuge"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="4" BinaryOperation="Multiplication" Right="$(PlanetIsHuge)" TooltipHidden="true"/>
+    <Modifier TargetProperty="BonusPopulationDustHissho" Operation="Addition" Value="4" Path="FAKEFORGUI/./PlanetSizeHuge"/>
+    <BinaryModifier TargetProperty="BonusPopulationDustHissho" Operation="Addition" Left="4" BinaryOperation="Multiplication" Right="$(PlanetIsHuge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <!-- +5 HappinessOnHuge -->
+  <!-- +5 Approval on Huge / +5 Dust on Huge Hishho -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHuge04" Type="WithPopulationPlanet">
     <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="5"   Path="FAKEFORGUI/./PlanetSizeHuge"/>
     <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetIsHuge)" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDustHissho" Operation="Addition"    Value="5"   Path="FAKEFORGUI/./PlanetSizeHuge"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue2"	  Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDustHissho" Operation="Addition"    Left="$(PopulationAuxValue2)"    BinaryOperation="Multiplication" Right="$(PlanetIsHuge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnHuge04" Type="ClassPopulationPlanet">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetSizeHuge"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="5" BinaryOperation="Multiplication" Right="$(PlanetIsHuge)" TooltipHidden="true"/>
+    <Modifier TargetProperty="BonusPopulationDustHissho" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetSizeHuge"/>
+    <BinaryModifier TargetProperty="BonusPopulationDustHissho" Operation="Addition" Left="5" BinaryOperation="Multiplication" Right="$(PlanetIsHuge)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationAssimilatedSecondaryCustomHappinessOnHuge04" Type="ClassPopulationAssimilated">
@@ -1009,16 +1290,21 @@
   </SimulationDescriptor>
 
   <!-- Happiness on Strategic -->
-  <!-- +2 HappinessOnStrategic -->
+  <!-- +2 Approval on Strategic / +2 Science on Strategic Hishho -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnStrategic00" Type="WithPopulationPlanet">
     <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetHasDepositStrategic"/>
     <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetHasStrategicDeposit)" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationScienceHissho" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetHasDepositStrategic"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue2"	  Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationScienceHissho" Operation="Addition"    Left="$(PopulationAuxValue2)"    BinaryOperation="Multiplication" Right="$(PlanetHasStrategicDeposit)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnStrategic00" Type="ClassPopulationPlanet">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetHasDepositStrategic"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="2" BinaryOperation="Multiplication" Right="$(PlanetHasStrategicDeposit)" TooltipHidden="true"/>
+    <Modifier TargetProperty="BonusPopulationScienceHissho" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetHasDepositStrategic"/>
+    <BinaryModifier TargetProperty="BonusPopulationScienceHissho" Operation="Addition" Left="2" BinaryOperation="Multiplication" Right="$(PlanetHasStrategicDeposit)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationAssimilatedSecondaryCustomHappinessOnStrategic00" Type="ClassPopulationAssimilated">
@@ -1026,16 +1312,21 @@
   </SimulationDescriptor>
 
   <!-- Happiness on Luxury -->
-  <!-- +2 HappinessOnLuxury -->
+  <!-- +2 Approval on Luxury / +2 Dust on Luxury Hishho -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnLuxury00" Type="WithPopulationPlanet">
     <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetHasDepositLuxury"/>
     <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetHasLuxuryDeposit)" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationDustHissho" Operation="Addition"    Value="2"   Path="FAKEFORGUI/./PlanetHasDepositLuxury"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue2"	  Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationDustHissho" Operation="Addition"    Left="$(PopulationAuxValue2)"    BinaryOperation="Multiplication" Right="$(PlanetHasLuxuryDeposit)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnLuxury00" Type="ClassPopulationPlanet">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetHasDepositLuxury"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="2" BinaryOperation="Multiplication" Right="$(PlanetHasLuxuryDeposit)" TooltipHidden="true"/>
+    <Modifier TargetProperty="BonusPopulationDustHissho" Operation="Addition" Value="2" Path="FAKEFORGUI/./PlanetHasDepositLuxury"/>
+    <BinaryModifier TargetProperty="BonusPopulationDustHissho" Operation="Addition" Left="2" BinaryOperation="Multiplication" Right="$(PlanetHasLuxuryDeposit)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationAssimilatedSecondaryCustomHappinessOnLuxury00" Type="ClassPopulationAssimilated">
@@ -1043,16 +1334,21 @@
   </SimulationDescriptor>
 
   <!-- Happiness on Anomaly -->
-  <!-- +5 HappinessOnAnomaly -->
+  <!-- +5 Approval on Anomaly / +5 Food on Anomaly Hishho -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessOnAnomaly00" Type="WithPopulationPlanet">
     <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="5"   Path="FAKEFORGUI/./PlanetAnomaly"/>
     <BinaryModifier TargetProperty="PopulationAuxValue1"	  Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PlanetHasAnomaly)" TooltipHidden="true"/>
+    <Modifier       TargetProperty="BonusPopulationFoodHissho" Operation="Addition"    Value="5"   Path="FAKEFORGUI/./PlanetAnomaly"/>
+    <BinaryModifier TargetProperty="PopulationAuxValue2"	  Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationFoodHissho" Operation="Addition"    Left="$(PopulationAuxValue2)"    BinaryOperation="Multiplication" Right="$(PlanetHasAnomaly)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessOnAnomaly00" Type="ClassPopulationPlanet">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetAnomaly"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="5" BinaryOperation="Multiplication" Right="$(PlanetHasAnomaly)" TooltipHidden="true" Path="ClassPopulation"/>
+    <Modifier TargetProperty="BonusPopulationFoodHissho" Operation="Addition" Value="5" Path="FAKEFORGUI/./PlanetAnomaly"/>
+    <BinaryModifier TargetProperty="BonusPopulationFoodHissho" Operation="Addition" Left="5" BinaryOperation="Multiplication" Right="$(PlanetHasAnomaly)" TooltipHidden="true" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationAssimilatedSecondaryCustomHappinessOnAnomaly00" Type="ClassPopulationAssimilated">
@@ -1060,54 +1356,66 @@
   </SimulationDescriptor>
 
   <!-- Happiness per Minor Faction -->
-  <!-- +1 HappinessPerMinorFaction -->
+  <!-- +1 Approval per Minor Faction / +30 Defense Hishho -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessPerMinorFaction00" Type="WithPopulationPlanet">
-	<Modifier       TargetProperty="BonusPopulationHappiness"        Operation="Addition"    Value="3"   Path="FAKEFORGUI/./ClassPopulation"/>
-	<BinaryModifier TargetProperty="BonusPopulationHappiness"        Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+	<Modifier       TargetProperty="BonusPopulationHappiness"        Operation="Addition"    Value="2"   Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationHappiness"        Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+	<Modifier       TargetProperty="BonusPopulationDefenseHissho"        Operation="Addition"    Value="30"   Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationDefenseHissho"        Operation="Addition"    Left="30"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessPerMinorFaction00" Type="ClassPopulationPlanet">
-    <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="1" BinaryOperation="Multiplication" Right="$(MinorTraitsAssimilated)" TooltipOverride="%PopulationModifiersTraitSecondaryCustomHappinessPerMinorFaction00TooltipOverride" Path="ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="1" BinaryOperation="Multiplication" Right="$(MinorTraitsAssimilated)" TooltipOverride="%PopulationModifiersTraitSecondaryCustomHappinessPerMinorFaction00TooltipOverride" Path="ClassPopulation"/>
+	<Modifier       TargetProperty="BonusPopulationDefenseHissho"        Operation="Addition"    Value="30"   Path="ClassPopulation"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationAssimilatedSecondaryCustomHappinessPerMinorFaction00" Type="ClassPopulationAssimilated">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="1" Path="ClassPopulation"/>
   </SimulationDescriptor>
+  
   <!-- Happiness per Backdoor -->
-  <!-- +1 HappinessPerBackdoor -->
+  <!-- +1 Approval per Backdoor / +1 Influence Hishho -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomHappinessPerBackdoor00" Type="WithPopulationPlanet">
 	<Modifier       TargetProperty="BonusPopulationHappiness"        Operation="Addition"    Value="2"   Path="FAKEFORGUI/./ClassPopulation"/>
 	<BinaryModifier TargetProperty="BonusPopulationHappiness"        Operation="Addition"    Left="2"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+	<Modifier       TargetProperty="BonusPopulationPrestigeHissho"        Operation="Addition"    Value="1"   Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationPrestigeHissho"        Operation="Addition"    Left="1"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>	
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomHappinessPerBackdoor00" Type="ClassPopulationPlanet">
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="1" BinaryOperation="Multiplication" Right="$(BackdoorCount)" TooltipOverride="%PopulationModifiersTraitSecondaryCustomHappinessPerBackdoor00TooltipOverride" Path="ClassPopulation"/>
+	<Modifier       TargetProperty="BonusPopulationPrestigeHissho"        Operation="Addition"    Value="1"   Path="ClassPopulation"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationAssimilatedSecondaryCustomHappinessPerBackdoor00" Type="ClassPopulationAssimilated">
     <Modifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Value="1" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- Happiness per Temple -->
+  <!-- +3 Approval per Temple / +3 Dust Hishho -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitPrimaryCustomHappinessPerTemple00" Type="WithPopulationPlanet">
     <Modifier       TargetProperty="BonusPopulationHappiness" Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetWithTemple"/>
     <BinaryModifier TargetProperty="PopulationAuxValue0"	  Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
     <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition"    Left="$(PopulationAuxValue0)"    BinaryOperation="Multiplication" Right="$(PlanetHasTemple)" TooltipHidden="true"/>
+	<Modifier       TargetProperty="BonusPopulationDustHissho"        Operation="Addition"    Value="3"   Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationDustHissho"        Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>	
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitPrimaryCustomHappinessPerTemple00" Type="ClassPopulationPlanet">
     <Modifier           TargetProperty="BonusPopulationHappiness"    Operation="Addition"    Value="3"   Path="FAKEFORGUI/./PlanetWithTemple"  />
     <BinaryModifier     TargetProperty="BonusPopulationHappiness"    Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PlanetHasTemple)" TooltipHidden="true"/>
+	<Modifier       TargetProperty="BonusPopulationDustHissho"        Operation="Addition"    Value="3"   Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +1 Happiness per System Level -->
+  <!-- +3 Happiness per System Level / +6 Science Hissho -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitPrimaryCustomHappinessLevel00" Type="WithPopulationPlanet">
-    <Modifier       TargetProperty="BonusPopulationHappiness"   Operation="Addition"    Value="3"   Path="FAKEFORGUI./SystemLevel"/>
-    <BinaryModifier TargetProperty="PopulationAuxValue1"	    Operation="Addition"    Left="3"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
-    <BinaryModifier TargetProperty="BonusPopulationHappiness"   Operation="Addition"    Left="$(PopulationAuxValue1)"    BinaryOperation="Multiplication" Right="$(PopulationSystemLevel)" TooltipHidden="true"/>
+	<Modifier       TargetProperty="BonusPopulationHappiness"        Operation="Addition"    Value="6"   Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationHappiness"        Operation="Addition"    Left="6"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
+	<Modifier       TargetProperty="BonusPopulationScienceHissho"   Operation="Addition"    Value="6"   Path="FAKEFORGUI/./ClassPopulation"/>
+	<BinaryModifier TargetProperty="BonusPopulationScienceHissho"   Operation="Addition"    Left="6"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>  
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitPrimaryCustomHappinessLevel00" Type="ClassPopulationPlanet">
-    <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="3" BinaryOperation="Multiplication" Right="$(PopulationSystemLevel)"  Path="ClassPopulation" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="BonusPopulationHappiness" Operation="Addition" Left="3" BinaryOperation="Multiplication" Right="$(PopulationSystemLevel)"  Path="ClassPopulation" TooltipOverride="%PopulationModifiersTraitSecondaryCustomHappinessLevel00TooltipOverride"/>
+	<Modifier       TargetProperty="BonusPopulationScienceHissho"   Operation="Addition"    Value="6"   Path="ClassPopulation"/>
   </SimulationDescriptor>
 </Datatable>

--- a/Endless Space Competitive Mod/Simulation/Traits/SimulationDescriptors[7_Military].xml
+++ b/Endless Space Competitive Mod/Simulation/Traits/SimulationDescriptors[7_Military].xml
@@ -2730,7 +2730,7 @@
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefensePerMinorFaction00" Type="ClassPopulationPlanet">
-    <BinaryModifier TargetProperty="BonusPopulationDefense" Operation="Addition" Left="50" BinaryOperation="Multiplication" Right="$(MinorTraitsAssimilated)" TooltipOverride="%PopulationModifiersTraitSecondaryCustomDefensePerMinorFaction00TooltipOverride" Path="ClassPopulation"/>
+    <BinaryModifier TargetProperty="BonusPopulationDefense" Operation="Addition" Left="25" BinaryOperation="Multiplication" Right="$(MinorTraitsAssimilated)" TooltipOverride="%PopulationModifiersTraitSecondaryCustomDefensePerMinorFaction00TooltipOverride" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationAssimilatedSecondaryCustomDefensePerMinorFaction00" Type="ClassPopulationAssimilated">


### PR DESCRIPTION
This request solves two issues:

- Population trait fixes and compatibility of the dozens of happiness traits with hissho specifics.
- Reversion of fighter combat stances, plus fixes on gravity/plasma distortion.