### PR TITLE
Additional progress counters for quests (part 1)

### DIFF
--- a/Endless Space Competitive Mod/Quests/QuestDefinitions[Horatio].xml
+++ b/Endless Space Competitive Mod/Quests/QuestDefinitions[Horatio].xml
@@ -1060,7 +1060,10 @@
 
             <LocalizationVar LocalizationKey="$MinimumAmount01Name" Source="$MinimumAmount01"/>
             <LocalizationVar LocalizationKey="$MinimumLevel01Name" Source="$MinimumLevel01"/>
-            
+            <InterpretedVar VarName="$Objective_ReligiousVal" Target="$(Empire)">
+                <Expression>MaxProperty(Context, @'ClassEmpire/ClassColonizedStarSystem/ClassHero', Level)</Expression>
+            </InterpretedVar>
+            <Var VarName="$Objective_ReligiousExpr" StringValue="MaxProperty(Context, @'ClassEmpire/ClassColonizedStarSystem/ClassHero', Level)"/>
         </Vars>
 
         <!--============ OBJECTIVES ============-->
@@ -1076,16 +1079,15 @@
                             <Input_PopulationEventDefinition VarName="$PoliticalEffectReligious"/>
                         </Action_TriggerPopulationEvent>
                     </StartActions>
-                    <Objective Name="Objective_Religious">
+                    <Objective StartValue="$Objective_ReligiousVal" EndValue="$MinimumLevel01" Name="Objective_Religious">
                         <!-- TODO -->
                         <AIHint Category="Minimal" MinAutoResolutionTurn="45" MaxAutoResolutionTurn="60" AutoResolutionProbability="1" />
                         <Sequence>
                             <Decorator_BeginTurn>
-                                <Condition_HasHeroes HeroAssignationFilter="System">
-                                    <Input_Empire VarName="$CurrentEmpire"/>
-                                    <Input_MinimumAmount VarName="$MinimumAmount01"/>
-                                    <Input_MinimumLevel VarName="$MinimumLevel01"/>
-                                </Condition_HasHeroes>
+                                <Condition_IsProgressionComplete>
+                                    <Input_Context VarName="$CurrentEmpire"/>
+                                    <Input_Expression VarName="$Objective_ReligiousExpr"/>
+                                </Condition_IsProgressionComplete>
                             </Decorator_BeginTurn>
                             <Action_ChooseOutcome Name="Outcome1"/>
                         </Sequence>
@@ -1281,14 +1283,11 @@
             <Var VarName="$IAEmpire">
                 <From Source="$LesserEmpire"/>
             </Var>
-            <Var VarName="$EcologistPolitic" StringValue="Politics04"/>                   
             <Var VarName="$Amount01" IntValue="3"/>           
             
             <InterpretedVar VarName="$Amount02" Target="$(Empire)">
                 <Expression>(Property(Context, @../ClassEmpire, NetEmpireEmpirePoint)+100)</Expression>
             </InterpretedVar>
-            <Var VarName="$Expression02" StringValue="Property(Context, NetEmpireEmpirePoint) ge $(Amount02)"/>
-
             <Var VarName="$Amount03" IntValue="6"/>
             <Var VarName="$Amount04" IntValue="2"/>
             
@@ -1300,6 +1299,18 @@
             <LocalizationVar LocalizationKey="$Amount02Name"    Source="$Amount02"/>
             <LocalizationVar LocalizationKey="$Amount03Name"    Source="$Amount03"/>
             <LocalizationVar LocalizationKey="$Amount04Name"    Source="$Amount04"/>
+            <InterpretedVar VarName="$Objective_EcologistVal" Target="$(Empire)">
+                <Expression>Count(Context, @'ClassEmpire/ClassSenate/ClassLaw,LawPolitics04')</Expression>
+            </InterpretedVar>
+            <Var VarName="$Objective_EcologistExpr" StringValue="Count(Context, @'ClassEmpire/ClassSenate/ClassLaw,LawPolitics04')"/>
+            <InterpretedVar VarName="$Objective_ReligiousVal" Target="$(Empire)">
+                <Expression>Property(Context, NetEmpireEmpirePoint)</Expression>
+            </InterpretedVar>
+            <Var VarName="$Objective_ReligiousExpr" StringValue="Property(Context, NetEmpireEmpirePoint)"/>
+            <InterpretedVar VarName="$Objective_IndustrialistVal" Target="$(Empire)">
+                <Expression>Count(Context, @'ClassEmpire/ClassColonizedStarSystem', SystemLevel, ge, $(Amount04))</Expression>
+            </InterpretedVar>
+            <Var VarName="$Objective_IndustrialistExpr" StringValue="Count(Context, @'ClassEmpire/ClassColonizedStarSystem', SystemLevel, ge, $(Amount04))"/>
         </Vars>
 
         <!--============ PREREQUISITES ============-->
@@ -1329,18 +1340,24 @@
                         </Action_TriggerPopulationEvent>
                     </StartActions>
 
-                    <Objective Name="Objective_Ecologist">         
+                    <Objective StartValue="$Objective_EcologistVal" EndValue="$Amount01" Name="Objective_Ecologist">
                         <!-- TODO -->
                         <AIHint Category="Minimal" MinAutoResolutionTurn="25" MaxAutoResolutionTurn="35" AutoResolutionProbability="1" />                    
                        <Sequence>
-                           <Decorator_LawActivated>
-                               <Condition_HasLaws>
-                                   <Input_Empire VarName="$CurrentEmpire"/>
-                                   <Input_Politics VarName="$EcologistPolitic"/>
-                                   <Input_MinimumAmount VarName="$Amount01"/>
-                               </Condition_HasLaws>
-                               <Input_Politics VarName="$EcologistPolitic"/>                             
-                           </Decorator_LawActivated>                                               
+                            <Parallel CompletionPolicy="Any">
+                                <Decorator_BeginTurn>
+                                    <Condition_IsProgressionComplete>
+                                        <Input_Context VarName="$CurrentEmpire"/>
+                                        <Input_Expression VarName="$Objective_EcologistExpr"/>
+                                    </Condition_IsProgressionComplete>
+                                </Decorator_BeginTurn>
+                                <Decorator_LawActivated>
+                                    <Condition_IsProgressionComplete>
+                                        <Input_Context VarName="$CurrentEmpire"/>
+                                        <Input_Expression VarName="$Objective_EcologistExpr"/>
+                                    </Condition_IsProgressionComplete>
+                                </Decorator_LawActivated>
+                            </Parallel>
                             <Action_ChooseOutcome Name="Outcome1"/>
                         </Sequence>
                         <Outcome Name="Outcome1">
@@ -1368,15 +1385,15 @@
                         </Action_TriggerPopulationEvent>
                     </StartActions>
 
-                    <Objective Name="Objective_Religious">
+                    <Objective StartValue="$Objective_ReligiousVal" EndValue="$Amount01" Name="Objective_Religious">
                         <!-- TODO -->
                         <AIHint Category="Minimal" MinAutoResolutionTurn="25" MaxAutoResolutionTurn="35" AutoResolutionProbability="1" />
                         <Sequence>
                             <Decorator_BeginTurn>
-                                <Condition_CheckInterpreter>
+                                <Condition_IsProgressionComplete>
                                     <Input_Context VarName="$CurrentEmpire"/>
-                                    <Input_Expression VarName="$Expression02"/>
-                                </Condition_CheckInterpreter>
+                                    <Input_Expression VarName="$Objective_ReligiousExpr"/>
+                                </Condition_IsProgressionComplete>
                             </Decorator_BeginTurn>
                             <Action_ChooseOutcome Name="Outcome1"/>
                         </Sequence>
@@ -1405,32 +1422,25 @@
                         </Action_TriggerPopulationEvent>
                     </StartActions>
 
-                    <Objective Name="Objective_Industrialist">
+                    <Objective StartValue="$Objective_IndustrialistVal" EndValue="$Amount03" Name="Objective_Industrialist">
                         <!-- TODO -->
                         <AIHint Category="Minimal" MinAutoResolutionTurn="25" MaxAutoResolutionTurn="35" AutoResolutionProbability="1" />
                         <Sequence>
                             <Parallel CompletionPolicy="Any">
-                                <Sequence>
-                                    <Decorator_SystemLevelChanged>
-                                        <Condition_HasSystems>
-                                            <Input_Empires VarName="$CurrentEmpire"/>
-                                            <Input_MinimumAmount VarName="$Amount03"/>
-                                            <Input_MinimumLevel VarName="$Amount04"/>
-                                        </Condition_HasSystems>
-                                    </Decorator_SystemLevelChanged>
-                                    <Action_ChooseOutcome Name="Outcome1"/>
-                                </Sequence>
-                                <Sequence> 
-                                    <Decorator_BeginTurn>
-                                        <Condition_HasSystems>
-                                            <Input_Empires VarName="$CurrentEmpire"/>
-                                            <Input_MinimumAmount VarName="$Amount03"/>
-                                            <Input_MinimumLevel VarName="$Amount04"/>
-                                        </Condition_HasSystems>
-                                    </Decorator_BeginTurn>
-                                    <Action_ChooseOutcome Name="Outcome1"/>
-                                </Sequence>
-                                </Parallel>  
+                                <Decorator_SystemLevelChanged>
+                                    <Condition_IsProgressionComplete>
+                                        <Input_Context VarName="$CurrentEmpire"/>
+                                        <Input_Expression VarName="$Objective_IndustrialistExpr"/>
+                                    </Condition_IsProgressionComplete>
+                                </Decorator_SystemLevelChanged>
+                                <Decorator_BeginTurn>
+                                    <Condition_IsProgressionComplete>
+                                        <Input_Context VarName="$CurrentEmpire"/>
+                                        <Input_Expression VarName="$Objective_IndustrialistExpr"/>
+                                    </Condition_IsProgressionComplete>
+                                </Decorator_BeginTurn>
+                            </Parallel>
+                            <Action_ChooseOutcome Name="Outcome1"/>
                         </Sequence>
                         <Outcome Name="Outcome1">
                             <Triggers Weight="1">
@@ -1489,7 +1499,14 @@
             <LocalizationVar LocalizationKey="$Amount01Name"    Source="$Amount01"/>
             <LocalizationVar LocalizationKey="$Amount02Name"    Source="$Amount02"/>
             <LocalizationVar LocalizationKey="$Amount03Name"    Source="$Amount03"/>
-            
+            <InterpretedVar VarName="$Objective_ReligiousVal" Target="$(Empire)">
+                <Expression>Property(Context, NetEmpireEmpirePoint)</Expression>
+            </InterpretedVar>
+            <Var VarName="$Objective_ReligiousExpr" StringValue="Property(Context, NetEmpireEmpirePoint)"/>
+            <InterpretedVar VarName="$Objective_IndustrialistVal" Target="$(Empire)">
+                <Expression>Count(Context, @'ClassEmpire/ClassColonizedStarSystem', SystemLevel, ge, $(Amount02))</Expression>
+            </InterpretedVar>
+            <Var VarName="$Objective_IndustrialistExpr" StringValue="Count(Context, @'ClassEmpire/ClassColonizedStarSystem', SystemLevel, ge, $(Amount02))"/>
         </Vars>
 
         <!--============ PREREQUISITES ============-->
@@ -1518,7 +1535,7 @@
                         </Action_TriggerPopulationEvent>
                     </StartActions>
 
-                    <Objective Name="Objective_Religious">
+                    <Objective StartValue="$Objective_ReligiousVal" EndValue="$Amount01" Name="Objective_Religious">
                         <!-- TODO -->
                         <AIHint Category="Minimal" MinAutoResolutionTurn="25" MaxAutoResolutionTurn="35" AutoResolutionProbability="1" />
                         <Sequence>
@@ -1555,32 +1572,27 @@
                         </Action_TriggerPopulationEvent>
                     </StartActions>
 
-                    <Objective Name="Objective_Industrialist">
+                    <Objective StartValue="$Objective_IndustrialistVal" EndValue="$Amount03" Name="Objective_Industrialist">
                         <!-- TODO -->
                         <AIHint Category="Minimal" MinAutoResolutionTurn="25" MaxAutoResolutionTurn="35" AutoResolutionProbability="1" />
-                       <Sequence>
+                        <Sequence>
                             <Parallel CompletionPolicy="Any">
                                 <Sequence>
                                     <Decorator_SystemLevelChanged>
-                                        <Condition_HasSystems>
-                                            <Input_Empires VarName="$CurrentEmpire"/>
-                                            <Input_MinimumAmount VarName="$Amount03"/>
-                                            <Input_MinimumLevel VarName="$Amount02"/>
-                                        </Condition_HasSystems>
+                                        <Condition_IsProgressionComplete>
+                                            <Input_Context VarName="$CurrentEmpire"/>
+                                            <Input_Expression VarName="$Objective_IndustrialistExpr"/>
+                                        </Condition_IsProgressionComplete>
                                     </Decorator_SystemLevelChanged>
-                                    <Action_ChooseOutcome Name="Outcome1"/>
-                                </Sequence>
-                                <Sequence> 
                                     <Decorator_BeginTurn>
-                                        <Condition_HasSystems>
-                                            <Input_Empires VarName="$CurrentEmpire"/>
-                                            <Input_MinimumAmount VarName="$Amount03"/>
-                                            <Input_MinimumLevel VarName="$Amount02"/>
-                                        </Condition_HasSystems>
+                                        <Condition_IsProgressionComplete>
+                                            <Input_Context VarName="$CurrentEmpire"/>
+                                            <Input_Expression VarName="$Objective_IndustrialistExpr"/>
+                                        </Condition_IsProgressionComplete>
                                     </Decorator_BeginTurn>
-                                    <Action_ChooseOutcome Name="Outcome1"/>
-                                </Sequence>                                
-                             </Parallel>     
+                                </Sequence>
+                            </Parallel>
+                            <Action_ChooseOutcome Name="Outcome1"/>
                         </Sequence>
                         <Outcome Name="Outcome1">
                             <Triggers Weight="1">
@@ -2247,16 +2259,14 @@
             </Var>
 
             <Var VarName="$PoliticalEffectReligious"        StringValue="PopulationEventHoratio05-Religious"/>
-        
-            <Var VarName="$Expression01" StringValue="(Count(Context, @'ClassEmpire/ClassColonizedStarSystem') - Count(Context, @'ClassEmpire/ClassColonizedStarSystem/ClassPopulationStarSystem,PopulationNonMajor') ge 4)"/>
-            <Var VarName="$Path" StringValue="ClassEmpire/ClassColonizedStarSystem"/>
-            <Var VarName="$SubPath" StringValue="ClassColonizedStarSystem/ClassPopulationStarSystem"/>
-            <Var VarName="$Tag" StringValue="PopulationMajor"/>           
-            
             <InterpretedVar VarName="$Amount01" Target="$(Empire)">
                 <Expression>Floor(Max(3,Count(Context, @'ClassEmpire/ColonizedStarSystemStateColony')/3))</Expression>
             </InterpretedVar>
             <LocalizationVar Source="$Amount01" LocalizationKey="$Amount01Name"/>
+            <InterpretedVar VarName="$Objective_ReligiousVal" Target="$(Empire)">
+                <Expression>Count(Context, @'ClassEmpire/ClassColonizedStarSystem', NonMajorPopulationCount, eq, 0)</Expression>
+            </InterpretedVar>
+            <Var VarName="$Objective_ReligiousExpr" StringValue="Count(Context, @'ClassEmpire/ClassColonizedStarSystem', NonMajorPopulationCount, eq, 0)"/>
         </Vars>
 
         <!--============ OBJECTIVES ============-->
@@ -2272,18 +2282,15 @@
                             <Input_PopulationEventDefinition VarName="$PoliticalEffectReligious"/>
                         </Action_TriggerPopulationEvent>
                     </StartActions>
-                    <Objective Name="Objective_Religious">
+                    <Objective StartValue="$Objective_ReligiousVal" EndValue="$Amount01" Name="Objective_Religious">
                         <!-- TODO -->
                         <AIHint Category="Minimal" MinAutoResolutionTurn="45" MaxAutoResolutionTurn="60" AutoResolutionProbability="1" />
                         <Sequence>
                             <Decorator_BeginTurn>
-                                <Condition_CountSimulationObjectsWithTag Composition="Minimum"   SubComposition="All">
-                                    <Input_SimulationObjects VarName="$CurrentEmpire"/>
-                                    <Input_Path VarName="$Path"/>
-                                    <Input_SubPath VarName="$SubPath"/>
-                                    <Input_Tag VarName="$Tag"/>
-                                    <Input_Minimum VarName="$Amount01"/>                                   
-                                </Condition_CountSimulationObjectsWithTag>                        
+                                <Condition_IsProgressionComplete>
+                                    <Input_Context VarName="$CurrentEmpire"/>
+                                    <Input_Expression VarName="$Objective_ReligiousExpr"/>
+                                </Condition_IsProgressionComplete>
                             </Decorator_BeginTurn>
                         </Sequence>
                     </Objective>

--- a/Endless Space Competitive Mod/Quests/QuestDefinitions[MinorFactions].xml
+++ b/Endless Space Competitive Mod/Quests/QuestDefinitions[MinorFactions].xml
@@ -312,11 +312,13 @@
             <InterpretedVar VarName="$Amount02" Target="$(Empire)">
                 <Expression>Property(Context, @ClassEmpire, GameSpeedMultiplier, true)*14</Expression>
             </InterpretedVar>
-            <Var VarName="$Expression1" StringValue="MaxProperty(Context, @'ClassEmpire/ClassColonizedStarSystem',NetSystemResearch) ge $(Amount01)"/>
-            
             <LocalizationVar LocalizationKey="$MinorFactionName" Source="$MinorEmpire"/>
             <LocalizationVar LocalizationKey="$Amount01Name" Source="$Amount01"/>
             <LocalizationVar LocalizationKey="$Amount02Name" Source="$Amount02"/>
+            <InterpretedVar VarName="$Step1_Objective1Val" Target="$(Empire)">
+                <Expression>MaxProperty(Context, @'ClassEmpire/ClassColonizedStarSystem', NetSystemResearch)</Expression>
+            </InterpretedVar>
+            <Var VarName="$Step1_Objective1Expr" StringValue="MaxProperty(Context, @'ClassEmpire/ClassColonizedStarSystem', NetSystemResearch)"/>
         </Vars>
 
         <!--============ PREREQUISITES ============-->
@@ -334,16 +336,16 @@
                             <Output_Timer VarName="$Timer"/>
                         </Action_StartTimer>
                     </StartActions>
-                    <Objective Name="Step1_Objective1">
+                    <Objective StartValue="$Step1_Objective1Val" EndValue="$Amount01" Name="Step1_Objective1">
                         <!-- TODO -->
                         <AIHint Category="Minimal" MinAutoResolutionTurn="17" MaxAutoResolutionTurn="25" AutoResolutionProbability="0.5" />
                         <Parallel CompletionPolicy="First">
                             <Sequence>
                                 <Decorator_BeginTurn>
-                                    <Condition_CheckInterpreter>
+                                    <Condition_IsProgressionComplete>
                                         <Input_Context VarName="$CurrentEmpire"/>
-                                        <Input_Expression VarName="$Expression1"/>
-                                    </Condition_CheckInterpreter>
+                                        <Input_Expression VarName="$Step1_Objective1Expr"/>
+                                    </Condition_IsProgressionComplete>
                                 </Decorator_BeginTurn>
                                 <Action_AssimilateMinorEmpire>
                                     <Input_Empire VarName="$CurrentEmpire"/>
@@ -951,7 +953,10 @@
             
             <LocalizationVar LocalizationKey="$MinorFactionName" Source="$MinorEmpire"/>
             <LocalizationVar LocalizationKey="$Amount01Name" Source="$Amount01"/>
-
+            <InterpretedVar VarName="$Step1_Objective1Val" Target="$(Empire)">
+                <Expression>Count(Context, @'ClassEmpire/ClassSenate/ClassLaw')</Expression>
+            </InterpretedVar>
+            <Var VarName="$Step1_Objective1Expr" StringValue="Count(Context, @'ClassEmpire/ClassSenate/ClassLaw')"/>
         </Vars>
 
         <!--============ PREREQUISITES ============-->
@@ -968,29 +973,25 @@
         <Steps>
             <Step Name="Step1">
                 <ObjectiveSet>
-                    <Objective Name="Step1_Objective1">
+                    <Objective StartValue="$Step1_Objective1Val" EndValue="$Amount01" Name="Step1_Objective1">
                         <!-- TODO -->
                         <AIHint Category="Minimal" MinAutoResolutionTurn="17" MaxAutoResolutionTurn="25" AutoResolutionProbability="0.5" />
                         <Parallel CompletionPolicy="First">
                             <Sequence>
-                            <Parallel CompletionPolicy="Any">
-                                <Sequence>
+                                <Parallel CompletionPolicy="Any">
                                     <Decorator_LawActivated>
-                                        <Condition_HasLaws>
-                                            <Input_Empire VarName="$CurrentEmpire"/>
-                                            <Input_MinimumAmount VarName="$Amount01"/>
-                                        </Condition_HasLaws>
+                                        <Condition_IsProgressionComplete>
+                                            <Input_Context VarName="$CurrentEmpire"/>
+                                            <Input_Expression VarName="$Step1_Objective1Expr"/>
+                                        </Condition_IsProgressionComplete>
                                     </Decorator_LawActivated>
-                                </Sequence>
-                                <Sequence>
                                     <Decorator_BeginTurn>
-                                        <Condition_HasLaws>
-                                            <Input_Empire VarName="$CurrentEmpire"/>
-                                            <Input_MinimumAmount VarName="$Amount01"/>
-                                        </Condition_HasLaws>
+                                        <Condition_IsProgressionComplete>
+                                            <Input_Context VarName="$CurrentEmpire"/>
+                                            <Input_Expression VarName="$Step1_Objective1Expr"/>
+                                        </Condition_IsProgressionComplete>
                                     </Decorator_BeginTurn>
-                                </Sequence>
-                            </Parallel>
+                                </Parallel>
                                 <Action_AssimilateMinorEmpire>
                                     <Input_Empire VarName="$CurrentEmpire"/>
                                     <Input_MinorEmpire VarName="$MinorEmpire"/>

--- a/Endless Space Competitive Mod/Quests/QuestDefinitions[Sophons].xml
+++ b/Endless Space Competitive Mod/Quests/QuestDefinitions[Sophons].xml
@@ -466,6 +466,11 @@
       <Var VarName="$PoliticalEffectMilitary" StringValue="PopulationEventSophons01Military"/>
       <Var VarName="$PoliticalEffectScience" StringValue="PopulationEventSophons01Science"/>
       <Var VarName="$PoliticalEffectPacifist" StringValue="PopulationEventSophons01Pacifist"/>
+
+      <Var VarName="$Step2_2_Objective1Val">
+        <From Source="$CurrentEmpire.$RevealedNodePercentage"/>
+      </Var>
+      <Var VarName="$Step2_2_Objective1Expr" StringValue="$(Step2_2_Objective1Val)"/>
     </Vars>
 
     <!--============ PREREQUISITES ============-->
@@ -539,23 +544,24 @@
               <Input_PopulationEventDefinition VarName="$PoliticalEffectScience"/>
             </Action_TriggerPopulationEvent>
           </StartActions>
-          <Objective Name="Step2_2_Objective1">
-            <!--Reveal 3 Star Systems-->
+          <Objective StartValue="$Step2_2_Objective1Val" EndValue="$GalaxyExplorationRequirement" Name="Step2_2_Objective1">
+            <!--Reveal 25% of nodes-->
             <AIHint Category="Minimal" MinAutoResolutionTurn="45" MaxAutoResolutionTurn="60" AutoResolutionProbability="1"/>
             <Sequence>
               <Parallel CompletionPolicy="First">
                 <Sequence>
                   <Decorator_ExploredNode MinimumState="Revealed" Initiator="Empire">
-                    <Input_MinimumPercentage VarName="$GalaxyExplorationRequirement"/>
+                    <Condition_IsProgressionComplete>
+                      <Input_Expression VarName="$Step2_2_Objective1Expr"/>
+                    </Condition_IsProgressionComplete>
                   </Decorator_ExploredNode>
                   <Action_ChooseOutcome Name="Outcome1"/>
                 </Sequence>
                 <Sequence>
                   <Decorator_BeginTurn>
-                    <Condition_ExplorationProgress MinimumState="Revealed">
-                      <Input_Empire VarName="$CurrentEmpire"/>
-                      <Input_Percentage VarName="$GalaxyExplorationRequirement"/>
-                    </Condition_ExplorationProgress>
+                    <Condition_IsProgressionComplete>
+                      <Input_Expression VarName="$Step2_2_Objective1Expr"/>
+                    </Condition_IsProgressionComplete>
                   </Decorator_BeginTurn>
                   <Action_ChooseOutcome Name="Outcome1"/>
                 </Sequence>
@@ -1151,6 +1157,11 @@
       <LocalizationVar LocalizationKey="$SystemName01" Source="$ColonizedSystemLocation" />
       <LocalizationVar LocalizationKey="$Amount" Source="$MinimumAmount" />
       <LocalizationVar LocalizationKey="$MinObedience02Name" Source="$Amount02" />
+
+      <InterpretedVar VarName="$Step1_Objective1Val">
+        <Expression>Property(ColonizedSystem01, @'ClassColonizedStarSystem', Happiness)</Expression>
+      </InterpretedVar>
+      <Var VarName="$Step1_Objective1Expr" StringValue="Property(ColonizedSystem01, @'ClassColonizedStarSystem', Happiness)"/>
     </Vars>
     <!-- ============ PREREQUISITES ============ -->
     <!-- ============ STEPS ============ -->
@@ -1182,7 +1193,7 @@
               <Output_Markers VarName="$Marker01" />
             </Action_AddQuestMarkers>
           </StartActions>
-          <Objective Name="Step1_Objective1">
+          <Objective StartValue="$Step1_Objective1Val" EndValue="$MinimumAmount" Name="Step1_Objective1">
             <!--  Reach an approval threshold on a specific system  -->
             <AIHint Category="MaximizeResourceOnSystem" Motivation="0.5">
               <Resource>Approval</Resource>
@@ -1190,12 +1201,10 @@
             </AIHint>
             <Sequence>
               <Decorator_BeginTurn>
-                <Condition_HasHappiness>
-                  <!-- Reach XX Approval on SystemName -->
-                  <Input_Empire VarName="$CurrentEmpire" />
-                  <Input_System VarName="$ColonizedSystemLocation" />
-                  <Input_MinimumAmount VarName="$MinimumAmount" />
-                </Condition_HasHappiness>
+                <!-- Reach XX Approval on SystemName -->
+                <Condition_IsProgressionComplete>
+                  <Input_Expression VarName="$Step1_Objective1Expr"/>
+                </Condition_IsProgressionComplete>
               </Decorator_BeginTurn>
               <Action_RemoveQuestMarkers>
                 <Input_Markers VarName="$Marker01" />
@@ -1288,6 +1297,14 @@
       <LocalizationVar LocalizationKey="$SystemName01" Source="$ColonizedSystemLocation" />
       <!-- POLITICAL EFFECT  -->
       <Var VarName="$PoliticalEffectPacifist" StringValue="PopulationEventSophons02.3Pacifist" />
+      <InterpretedVar VarName="$Step1_Objective1Val" Target="$(Empire)">
+        <Expression>Count(Context, @'ClassEmpire/ClassColonizedStarSystem', NetSystemEmpirePoint, gt, $(Amount))</Expression>
+      </InterpretedVar>
+      <Var VarName="$Step1_Objective1Expr" StringValue="Count(Context, @'ClassEmpire/ClassColonizedStarSystem', NetSystemEmpirePoint, gt, $(Amount))"/>
+      <InterpretedVar VarName="$Step1_Objective1AltVal" Target="$(Empire)">
+        <Expression>MaxProperty(Context, @'ClassEmpire/ClassColonizedStarSystem', NetSystemEmpirePoint)</Expression>
+      </InterpretedVar>
+      <Var VarName="$Step1_Objective1AltExpr" StringValue="MaxProperty(Context, @'ClassEmpire/ClassColonizedStarSystem', NetSystemEmpirePoint)"/>
     </Vars>
     <!-- ============ PREREQUISITES ============ -->
     <!-- ============ STEPS ============ -->
@@ -1314,18 +1331,17 @@
               <Input_PopulationEventDefinition VarName="$PoliticalEffectPacifist" />
             </Action_TriggerPopulationEvent>
           </StartActions>
-          <Objective Name="Step1_Objective1">
+          <Objective StartValue="$Step1_Objective1Val" EndValue="$SystemCount" Name="Step1_Objective1">
             <!--  Generate 20 Influence per turn in at least 2 Systems  -->
             <AIHint Category="MaximizeResource" Motivation="0.5">
               <Resource>EmpirePoint</Resource>
             </AIHint>
             <Sequence>
               <Decorator_BeginTurn>
-                <Condition_SystemsHaveFidsi>
-                  <Input_Empire VarName="$CurrentEmpire" />
-                  <Input_SystemCount VarName="$SystemCount" />
-                  <Input_NetEmpirePoint VarName="$Amount" />
-                </Condition_SystemsHaveFidsi>
+                <Condition_IsProgressionComplete>
+                  <Input_Context VarName="$CurrentEmpire"/>
+                  <Input_Expression VarName="$Step1_Objective1Expr"/>
+                </Condition_IsProgressionComplete>
               </Decorator_BeginTurn>
               <Action_ChooseOutcome Name="Outcome1" />
             </Sequence>
@@ -1347,18 +1363,17 @@
               <Input_PopulationEventDefinition VarName="$PoliticalEffectPacifist" />
             </Action_TriggerPopulationEvent>
           </StartActions>
-          <Objective Name="Step1_Objective1Alt">
+          <Objective StartValue="$Step1_Objective1AltVal" EndValue="$AmountAlt" Name="Step1_Objective1Alt">
             <!--  Generate X Influence per turn in 1 System  -->
             <AIHint Category="MaximizeResource" Motivation="0.5">
               <Resource>EmpirePoint</Resource>
             </AIHint>
             <Sequence>
               <Decorator_BeginTurn>
-                <Condition_SystemsHaveFidsi>
-                  <Input_Empire VarName="$CurrentEmpire" />
-                  <Input_SystemCount VarName="$SystemCountAlt" />
-                  <Input_NetEmpirePoint VarName="$AmountAlt" />
-                </Condition_SystemsHaveFidsi>
+                <Condition_IsProgressionComplete>
+                  <Input_Context VarName="$CurrentEmpire"/>
+                  <Input_Expression VarName="$Step1_Objective1AltExpr"/>
+                </Condition_IsProgressionComplete>
               </Decorator_BeginTurn>
               <Action_ChooseOutcome Name="Outcome2" />
             </Sequence>

--- a/Endless Space Competitive Mod/Quests/QuestDefinitions[TimeLords].xml
+++ b/Endless Space Competitive Mod/Quests/QuestDefinitions[TimeLords].xml
@@ -206,7 +206,7 @@
 
         <!--============ TAGS ============-->
         <Tags>BeginTurn</Tags>
-        
+
         <!--============ CONTEXT ============-->
         <QuestContextSolo/>
 
@@ -226,12 +226,12 @@
             <Var VarName="$AllStarSystems">
                 <From Source="$Constellations.$StarSystems"/>
             </Var>
-            <Var VarName="$AllStarSystemsClose">                
-                    <From Source="$AllStarSystems">
-                        <OrderBy>
-                            <SortSystemByDistance OriginVarName="$MyHomeSystem" SortBy="Farthest" MinimumDistance="10" MaximumDistance="60" MinimumCandidateCount="5"/>
-                        </OrderBy>
-                    </From>              
+            <Var VarName="$AllStarSystemsClose">
+                <From Source="$AllStarSystems">
+                    <OrderBy>
+                        <SortSystemByDistance OriginVarName="$MyHomeSystem" SortBy="Farthest" MinimumDistance="10" MaximumDistance="60" MinimumCandidateCount="5"/>
+                    </OrderBy>
+                </From>
             </Var>
             <Var VarName="$FirstSystem">
                 <Any>
@@ -272,7 +272,7 @@
                     <From Source="$ThirdSystem.$Planets"/>
                 </Any>
             </Var>
-            
+
             <Var VarName="$Curiosity01" StringValue="Curiosity_Loot_Lifeform_Era2"/>
             <Var VarName="$Curiosity02" StringValue="Curiosity_Loot_Signal_Era2"/>
             <Var VarName="$Curiosity03" StringValue="Curiosity_Loot_Underground_Era2"/>
@@ -283,13 +283,6 @@
             <Var VarName="$Amount01" IntValue="12"/>
             <!--Improvements we have to Build-->
             <Var VarName="$Amount02" IntValue="4"/>
-
-            <Var VarName="$Path" StringValue="ClassEmpire/ClassColonizedStarSystem"/>
-            <Var VarName="$SubPath" StringValue="ClassColonizedStarSystem/ClassImprovement"/>
-            <Var VarName="$Tag" StringValue="ClassImprovement"/>
-            <Var VarName="$Count" IntValue="1"/>
-            <Var VarName="$SubCount" IntValue="4"/>          
-          
 
             <!--MinorFaction NB-->
             <Var VarName="$Amount03" IntValue="1"/>
@@ -311,8 +304,12 @@
             <LocalizationVar Source="$Amount03" LocalizationKey="$Amount03Name"/>
             <!--Nb of requiered points-->
             <LocalizationVar Source="$Amount04" LocalizationKey="$Amount04Name"/>
+            <InterpretedVar VarName="$Objective_IndustrialistVal" Target="$(Empire)">
+                <Expression>MaxProperty(Context, @'ClassEmpire/ClassColonizedStarSystem', NumberOfImprovementsBuilt)</Expression>
+            </InterpretedVar>
+            <Var VarName="$Objective_IndustrialistExpr" StringValue="MaxProperty(Context, @'ClassEmpire/ClassColonizedStarSystem', NumberOfImprovementsBuilt)"/>
         </Vars>
-        
+
         <!--============ PREREQUISITES ============-->
 
         <Prerequisites Target="$(Empire)">
@@ -350,7 +347,7 @@
                                 <Input_CuriosityDefinition VarName="$Curiosity01"/>
                                 <Output_CuriosityGUIDs VarName="$Curiosity01GUID"/>
                             </Action_SpawnCuriosity>
-                            <Loop Count="2">                         
+                            <Loop Count="2">
                                 <Action_SpawnCuriosity>
                                     <Input_Empires VarName="$CurrentEmpire"/>
                                     <Input_Planets VarName="$Planet02"/>
@@ -362,7 +359,7 @@
                                     <Input_Planets VarName="$Planet03"/>
                                     <Input_CuriosityDefinition VarName="$Curiosity03"/>
                                     <Output_CuriosityGUIDs VarName="$Curiosity03GUID"/>
-                                </Action_SpawnCuriosity>                               
+                                </Action_SpawnCuriosity>
                             </Loop>
                             <Loop>
                                 <Decorator_CuriosityDiscovered OnlyAllowDiscoveryByFleet="true" Initiator="Empire" ProgressionIncrement="1">
@@ -383,7 +380,7 @@
                     </Objective>
 
                     <Reward Droplist="DroplistStrategicsEra2" Picks="1"/>
-                
+
                 </ObjectiveSet>
 
                 <!--============ Choice Index 1: INDUSTRIALIST ============-->
@@ -395,23 +392,19 @@
                             <Input_PopulationEventDefinition VarName="$PoliticalEffectIndustrialist"/>
                         </Action_TriggerPopulationEvent>
                     </StartActions>
-                    
-                    <Objective Name="Objective_Industrialist">    
+
+                    <Objective StartValue="$Objective_IndustrialistVal" EndValue="$Amount02" Name="Objective_Industrialist">
                         <!-- TODO -->
-                        <AIHint Category="Minimal" MinAutoResolutionTurn="25" MaxAutoResolutionTurn="35" AutoResolutionProbability="1" />            
+                        <AIHint Category="Minimal" MinAutoResolutionTurn="25" MaxAutoResolutionTurn="35" AutoResolutionProbability="1" />
                         <Sequence>
-                            <Decorator_BeginTurn>                                
-                                <Condition_CountSimulationObjectsWithTag Composition="Minimum" SubComposition="Minimum">
-                                    <Input_SimulationObjects VarName="$CurrentEmpire"/>
-                                    <Input_Path VarName="$Path"/>
-                                    <Input_SubPath VarName="$SubPath"/>
-                                    <Input_Tag VarName="$Tag"/>
-                                    <Input_Minimum VarName="$Count"/>
-                                    <Input_SubMinimum VarName="$SubCount"/>
-                                </Condition_CountSimulationObjectsWithTag>
+                            <Decorator_BeginTurn>
+                                <Condition_IsProgressionComplete>
+                                    <Input_Context VarName="$CurrentEmpire"/>
+                                    <Input_Expression VarName="$Objective_IndustrialistExpr"/>
+                                </Condition_IsProgressionComplete>
                             </Decorator_BeginTurn>
                             <Action_ChooseOutcome Name="Outcome1"/>
-                        </Sequence>                        
+                        </Sequence>
                         <Outcome Name="Outcome1">
                             <Triggers Weight="1">
                                 <QuestTrigger>
@@ -421,9 +414,9 @@
                             </Triggers>
                         </Outcome>
                     </Objective>
-                    
+
                     <Reward Droplist="DroplistStrategicsEra2" Picks="1"/>
-                    
+
                 </ObjectiveSet>
 
                 <!--============ Choice Index 2: Pacifist ============-->
@@ -440,15 +433,15 @@
                         <AIHint Category="Minimal" MinAutoResolutionTurn="25" MaxAutoResolutionTurn="35" AutoResolutionProbability="1" />
                         <Sequence>
                             <Parallel CompletionPolicy="Any">
-                                 <Sequence>                            
+                                <Sequence>
                                     <Decorator_BeginTurn>
-                                        <Condition_MinorFactionRelationship>                                  
+                                        <Condition_MinorFactionRelationship>
                                             <Input_MajorEmpire VarName="$CurrentEmpire"/>
                                             <Input_NumberOfMinorFactions VarName="$Amount03"/>
                                             <Input_MinimumRelationPoints VarName="$Amount04"/>
                                         </Condition_MinorFactionRelationship>
                                     </Decorator_BeginTurn>
-                                 </Sequence>
+                                </Sequence>
                                 <Sequence>
                                     <Parallel CompletionPolicy="All">
                                         <Sequence>
@@ -459,7 +452,7 @@
                                                     <Input_MinimumRelationPoints VarName="$Amount04"/>
                                                 </Condition_MinorFactionRelationship>
                                             </Decorator_BeginTurn>
-                                       </Sequence>
+                                        </Sequence>
                                         <Sequence>
                                             <Decorator_BeginTurn>
                                                 <Condition_MinorFactionRelationship>
@@ -491,12 +484,12 @@
                                 </QuestTrigger>
                             </Triggers>
                         </Outcome>
-                    </Objective>                    
+                    </Objective>
 
                     <Reward Droplist="DroplistStrategicsEra2" Picks="1"/>
-                    
+
                 </ObjectiveSet>
-            </Step>            
+            </Step>
         </Steps>
     </QuestDefinition>
 
@@ -1160,7 +1153,7 @@
             </InterpretedVar>
             <!--Expression to get the current amout of Dust currently produced by trade routes-->
             <Var VarName="$DustAmountExpression" StringValue="Floor(Property(Context,@'ClassEmpire',TradingRouteIncome_EmpireMoney))"/>
-            
+
             <Var VarName="$PoliticalEffectEcologist"         StringValue="PopulationEventTimeLords04-Ecologist"/>
             <Var VarName="$PoliticalEffectIndustrialist"     StringValue="PopulationEventTimeLords04-Industrialist"/>
             <Var VarName="$PoliticalEffectPacifist"          StringValue="PopulationEventTimeLords04-Pacifist"/>
@@ -1168,12 +1161,19 @@
             <LocalizationVar LocalizationKey="$Amount01Name" Source="$Amount01"/>
             <LocalizationVar LocalizationKey="$Amount02Name" Source="$Amount02"/>
             <LocalizationVar LocalizationKey="$Amount04Name" Source="$Amount04"/>
-            <LocalizationVar  LocalizationKey="$DustObjectiveAmountName" Source="$DustObjectiveAmount"/>
-
+            <LocalizationVar LocalizationKey="$DustObjectiveAmountName" Source="$DustObjectiveAmount"/>
+            <InterpretedVar VarName="$Objective_EcologistVal" Target="$(Empire)">
+                <Expression>Count(Context, @'ClassEmpire/ClassColonizedStarSystem', SystemLevel, ge, $(Amount01))</Expression>
+            </InterpretedVar>
+            <Var VarName="$Objective_EcologistExpr" StringValue="Count(Context, @'ClassEmpire/ClassColonizedStarSystem', SystemLevel, ge, $(Amount01))"/>
+            <InterpretedVar VarName="$Objective_IndustrialistVal" Target="$(Empire)">
+                <Expression>Property(Context, @'../ClassEmpire', MaximumEmpireManpowerStock)</Expression>
+            </InterpretedVar>
+            <Var VarName="$Objective_IndustrialistExpr" StringValue="Property(Context, @'../ClassEmpire', MaximumEmpireManpowerStock)"/>
         </Vars>
 
         <!--============ PREREQUISITES ============-->
-     
+
         <!--============ STEPS ============-->
         <Steps>
             <Step Name="Step1">
@@ -1197,31 +1197,25 @@
                             <Input_PopulationEventDefinition VarName="$PoliticalEffectEcologist"/>
                         </Action_TriggerPopulationEvent>
                     </StartActions>
-                    <Objective Name="Objective_Ecologist">
+                    <Objective StartValue="$Objective_EcologistVal" EndValue="$Amount02" Name="Objective_Ecologist">
                         <!-- TODO -->
                         <AIHint Category="Minimal" MinAutoResolutionTurn="25" MaxAutoResolutionTurn="35" AutoResolutionProbability="1" />
                         <Sequence>
-                        <Parallel CompletionPolicy="Any">
-                            <Sequence>
+                            <Parallel CompletionPolicy="Any">
                                 <Decorator_SystemLevelChanged Initiator="Empire">
-                                    <Condition_HasSystems>
-                                        <Input_Empires VarName="$CurrentEmpire"/>
-                                        <Input_MinimumAmount VarName="$Amount02"/>
-                                        <Input_MinimumLevel VarName="$Amount01"/>
-                                    </Condition_HasSystems>                                    
+                                    <Condition_IsProgressionComplete>
+                                        <Input_Context VarName="$CurrentEmpire"/>
+                                        <Input_Expression VarName="$Objective_EcologistExpr"/>
+                                    </Condition_IsProgressionComplete>
                                 </Decorator_SystemLevelChanged>
-                            </Sequence>
-                            <Sequence>
                                 <Decorator_BeginTurn>
-                                    <Condition_HasSystems>
-                                        <Input_Empires VarName="$CurrentEmpire"/>
-                                        <Input_MinimumAmount VarName="$Amount02"/>
-                                        <Input_MinimumLevel VarName="$Amount01"/>
-                                    </Condition_HasSystems>
+                                    <Condition_IsProgressionComplete>
+                                        <Input_Context VarName="$CurrentEmpire"/>
+                                        <Input_Expression VarName="$Objective_EcologistExpr"/>
+                                    </Condition_IsProgressionComplete>
                                 </Decorator_BeginTurn>
-                            </Sequence>
-                        </Parallel>
-                        <Action_ChooseOutcome Name="Outcome1"/>
+                            </Parallel>
+                            <Action_ChooseOutcome Name="Outcome1"/>
                         </Sequence>
                         <Outcome Name="Outcome1">
                             <Triggers Weight="1">
@@ -1247,15 +1241,15 @@
                         </Action_TriggerPopulationEvent>
                     </StartActions>
 
-                    <Objective Name="Objective_Industrialist" StartValue="$Amount03" EndValue="$Amount04">
+                    <Objective StartValue="$Objective_IndustrialistVal" EndValue="$Amount04" Name="Objective_Industrialist">
                         <!-- TODO -->
                         <AIHint Category="Minimal" MinAutoResolutionTurn="25" MaxAutoResolutionTurn="35" AutoResolutionProbability="1" />
                         <Sequence>
                             <Decorator_BeginTurn ProgressionIncrement="1">
-                                <Condition_CheckInterpreter>
+                                <Condition_IsProgressionComplete>
                                     <Input_Context VarName="$CurrentEmpire"/>
-                                    <Input_Expression VarName="$Expression1"/>
-                                </Condition_CheckInterpreter>
+                                    <Input_Expression VarName="$Objective_IndustrialistExpr"/>
+                                </Condition_IsProgressionComplete>
                             </Decorator_BeginTurn>
                             <Action_ChooseOutcome Name="Outcome1"/>
                         </Sequence>

--- a/Endless Space Competitive Mod/Quests/QuestDefinitions[TimeLords].xml
+++ b/Endless Space Competitive Mod/Quests/QuestDefinitions[TimeLords].xml
@@ -1141,7 +1141,6 @@
             <InterpretedVar VarName="$Amount04" Target="$(Empire)">
                 <Expression>Property(Context, @'../ClassEmpire', MaximumEmpireManpowerStock)+500 </Expression>
             </InterpretedVar>
-            <Var VarName="$Expression1" StringValue="Property(Context, @'../ClassEmpire', MaximumEmpireManpowerStock) ge $(Amount04)"/>
 
             <!--Amout of Dust currently produced by trade routes-->
             <InterpretedVar VarName="$DustAmount" Target="$(Empire)">
@@ -1245,7 +1244,7 @@
                         <!-- TODO -->
                         <AIHint Category="Minimal" MinAutoResolutionTurn="25" MaxAutoResolutionTurn="35" AutoResolutionProbability="1" />
                         <Sequence>
-                            <Decorator_BeginTurn ProgressionIncrement="1">
+                            <Decorator_BeginTurn>
                                 <Condition_IsProgressionComplete>
                                     <Input_Context VarName="$CurrentEmpire"/>
                                     <Input_Expression VarName="$Objective_IndustrialistExpr"/>

--- a/Endless Space Competitive Mod/Quests/QuestDefinitions[TimeLords].xml
+++ b/Endless Space Competitive Mod/Quests/QuestDefinitions[TimeLords].xml
@@ -1134,23 +1134,19 @@
                 <Expression>Min(4, (MaxProperty(Context, @'../ClassEmpire/ClassColonizedStarSystem', SystemLevel)+1))</Expression>
             </InterpretedVar>
             <Var VarName="$Amount02" IntValue="4"/>
-
-            <InterpretedVar VarName="$Amount03" Target="$(Empire)">
-                <Expression>Property(Context, @'../ClassEmpire', MaximumEmpireManpowerStock)</Expression>
-            </InterpretedVar>
             <InterpretedVar VarName="$Amount04" Target="$(Empire)">
                 <Expression>Property(Context, @'../ClassEmpire', MaximumEmpireManpowerStock)+500 </Expression>
             </InterpretedVar>
 
-            <!--Amout of Dust currently produced by trade routes-->
+            <!--Amount of Dust currently produced by trade routes-->
             <InterpretedVar VarName="$DustAmount" Target="$(Empire)">
                 <Expression>Floor(Property(Context,@'ClassEmpire',TradingRouteIncome_EmpireMoney))</Expression>
             </InterpretedVar>
-            <!--Amout of Dust to produce by trade routes-->
+            <!--Amount of Dust to produce by trade routes-->
             <InterpretedVar VarName="$DustObjectiveAmount" Target ="$(Empire)">
                 <Expression>Max(Floor(Property(Context,@'ClassEmpire',TradingRouteIncome_EmpireMoney))+75,150)</Expression>
             </InterpretedVar>
-            <!--Expression to get the current amout of Dust currently produced by trade routes-->
+            <!--Expression to get the current amount of Dust currently produced by trade routes-->
             <Var VarName="$DustAmountExpression" StringValue="Floor(Property(Context,@'ClassEmpire',TradingRouteIncome_EmpireMoney))"/>
 
             <Var VarName="$PoliticalEffectEcologist"         StringValue="PopulationEventTimeLords04-Ecologist"/>

--- a/Endless Space Competitive Mod/Quests/QuestDefinitions[UE].xml
+++ b/Endless Space Competitive Mod/Quests/QuestDefinitions[UE].xml
@@ -171,8 +171,8 @@
 
 		<!--============ OCCURENCES ============-->
 		<RepetitionRules  NumberOfOccurrencesPerGame="0"
-                      NumberOfOccurrencesPerEmpire="1"
-                      NumberOfConcurrentInstances="0"/>
+						  NumberOfOccurrencesPerEmpire="1"
+						  NumberOfConcurrentInstances="0"/>
 
 		<!--============ VARIABLES ============-->
 		<Vars>
@@ -203,6 +203,18 @@
 			<LocalizationVar LocalizationKey="$ManpowerAmountName" Source="$ManpowerAmount"/>
 			<LocalizationVar LocalizationKey="$DustAmoutName" Source="$DustAmout"/>
 			<LocalizationVar LocalizationKey="$LoopCountName" Source="$LoopCount"/>
+			<InterpretedVar VarName="$Step2_2_Objective1Val" Target="$(Empire)">
+				<Expression>Property(Context, @'ClassEmpire', BankAccount)</Expression>
+			</InterpretedVar>
+			<Var VarName="$Step2_2_Objective1Expr" StringValue="Property(Context, @'ClassEmpire', BankAccount)"/>
+			<InterpretedVar VarName="$Step2_2Bis_Objective1Val" Target="$(Empire)">
+				<Expression>Property(Context, @'ClassEmpire', BankAccount)</Expression>
+			</InterpretedVar>
+			<Var VarName="$Step2_2Bis_Objective1Expr" StringValue="Property(Context, @'ClassEmpire', BankAccount)"/>
+			<InterpretedVar VarName="$Step2_2Ter_Objective1Val" Target="$(Empire)">
+				<Expression>Property(Context, @'ClassEmpire', BankAccount)</Expression>
+			</InterpretedVar>
+			<Var VarName="$Step2_2Ter_Objective1Expr" StringValue="Property(Context, @'ClassEmpire', BankAccount)"/>
 		</Vars>
 
 		<!--============ PREREQUISITES ============-->
@@ -294,17 +306,16 @@
 							<Input_PopulationEventDefinition VarName="$PoliticalEffectIndustry"/>
 						</Action_TriggerPopulationEvent>
 					</StartActions>
-					<Objective Name="Step2_2_Objective1">
+					<Objective StartValue="$Step2_2_Objective1Val" EndValue="$DustAmout" Name="Step2_2_Objective1">
 						<!-- TODO -->
 						<AIHint Category="Minimal" MinAutoResolutionTurn="25" MaxAutoResolutionTurn="35" AutoResolutionProbability="1" />
 						<!--Spawn the good fleet-->
 						<Sequence>
 							<Decorator_PostEndTurn>
-								<Condition_HasResource>
-									<Input_Location VarName="$CurrentEmpire"/>
-									<Input_ResourceName VarName="$DustResources"/>
-									<Input_Minimum VarName="$DustAmout"/>
-								</Condition_HasResource>
+								<Condition_IsProgressionComplete>
+									<Input_Context VarName="$CurrentEmpire"/>
+									<Input_Expression VarName="$Step2_2_Objective1Expr"/>
+								</Condition_IsProgressionComplete>
 							</Decorator_PostEndTurn>
 							<Action_SetInvisibility Invisible="false">
 								<Input_Empires VarName="$AllEmpires"/>
@@ -344,17 +355,16 @@
 							<Input_PopulationEventDefinition VarName="$PoliticalEffectIndustry"/>
 						</Action_TriggerPopulationEvent>
 					</StartActions>
-					<Objective Name="Step2_2Bis_Objective1">
+					<Objective StartValue="$Step2_2Bis_Objective1Val" EndValue="$DustAmout" Name="Step2_2Bis_Objective1">
 						<!-- TODO -->
 						<AIHint Category="Minimal" MinAutoResolutionTurn="25" MaxAutoResolutionTurn="35" AutoResolutionProbability="1" />
 						<!--Spawn the good fleet-->
 						<Sequence>
 							<Decorator_PostEndTurn>
-								<Condition_HasResource>
-									<Input_Location VarName="$CurrentEmpire"/>
-									<Input_ResourceName VarName="$DustResources"/>
-									<Input_Minimum VarName="$DustAmout"/>
-								</Condition_HasResource>
+								<Condition_IsProgressionComplete>
+									<Input_Context VarName="$CurrentEmpire"/>
+									<Input_Expression VarName="$Step2_2Bis_Objective1Expr"/>
+								</Condition_IsProgressionComplete>
 							</Decorator_PostEndTurn>
 							<Action_ChooseOutcome Name="Outcome1"/>
 						</Sequence>
@@ -382,18 +392,16 @@
 							<Input_PopulationEventDefinition VarName="$PoliticalEffectIndustry"/>
 						</Action_TriggerPopulationEvent>
 					</StartActions>
-					<Objective Name="Step2_2Ter_Objective1">
+					<Objective StartValue="$Step2_2Ter_Objective1Val" EndValue="$DustAmout" Name="Step2_2Ter_Objective1">
 						<!-- TODO -->
 						<AIHint Category="Minimal" MinAutoResolutionTurn="25" MaxAutoResolutionTurn="35" AutoResolutionProbability="1" />
 						<!--Spawn the good fleet-->
 						<Sequence>
 							<Decorator_PostEndTurn>
-								<Condition_HasResource>
-									<Input_Location VarName="$CurrentEmpire"/>
-									<Input_ResourceName VarName="$DustResources"/>
-									<Input_Minimum VarName="$DustAmout"/>
-								</Condition_HasResource>
-							</Decorator_PostEndTurn>
+								<Condition_IsProgressionComplete>
+									<Input_Context VarName="$CurrentEmpire"/>
+									<Input_Expression VarName="$Step2_2Ter_Objective1Expr"/>
+								</Condition_IsProgressionComplete>							</Decorator_PostEndTurn>
 							<Action_ChooseOutcome Name="Outcome1"/>
 						</Sequence>
 						<Outcome Name="Outcome1">
@@ -460,8 +468,8 @@
 
 
 		<RepetitionRules  NumberOfOccurrencesPerGame="0"
-                      NumberOfOccurrencesPerEmpire="1"
-                      NumberOfConcurrentInstances="0"/>
+						  NumberOfOccurrencesPerEmpire="1"
+						  NumberOfConcurrentInstances="0"/>
 
 		<!--============ VARIABLES ============-->
 		<Vars>
@@ -508,6 +516,14 @@
 			<LocalizationVar LocalizationKey="$DustAmount" Source="$DustObjective"/>
 			<LocalizationVar LocalizationKey="$ScienceAmount" Source="$ScienceObjective"/>
 
+			<InterpretedVar VarName="$Step2_2_Objective1Val" Target="$(Empire)">
+				<Expression>Property(Context, NetEmpireMoney)</Expression>
+			</InterpretedVar>
+			<Var VarName="$Step2_2_Objective1Expr" StringValue="Property(Context, NetEmpireMoney)"/>
+			<InterpretedVar VarName="$Step2_3_Objective1Val" Target="$(Empire)">
+				<Expression>Property(Context, NetEmpireResearch)</Expression>
+			</InterpretedVar>
+			<Var VarName="$Step2_3_Objective1Expr" StringValue="Property(Context, NetEmpireResearch)"/>
 		</Vars>
 
 		<!--============ PREREQUISITES ============-->
@@ -585,7 +601,7 @@
 							<Input_PopulationEventDefinition VarName="$PoliticalEffectIndustry"/>
 						</Action_TriggerPopulationEvent>
 					</StartActions>
-					<Objective Name="Step2_2_Objective1">
+					<Objective StartValue="$Step2_2_Objective1Val" EndValue="$DustObjective" Name="Step2_2_Objective1">
 						<!-- Produce a minimum amount of dust per turn -->
 						<AIHint Category="MaximizeResource" Motivation="0.7">
 							<Resource>Dust</Resource>
@@ -593,10 +609,10 @@
 						<!--Spawn the good fleet-->
 						<Sequence>
 							<Decorator_BeginTurn>
-								<Condition_CheckInterpreter>
+								<Condition_IsProgressionComplete>
 									<Input_Context VarName="$CurrentEmpire"/>
-									<Input_Expression VarName="$Expression1"/>
-								</Condition_CheckInterpreter>
+									<Input_Expression VarName="$Step2_2_Objective1Expr"/>
+								</Condition_IsProgressionComplete>
 							</Decorator_BeginTurn>
 							<Action_SpawnHero>
 								<Input_Empire VarName="$CurrentEmpire"/>
@@ -639,17 +655,17 @@
 							<Input_PopulationEventDefinition VarName="$PoliticalEffectScience"/>
 						</Action_TriggerPopulationEvent>
 					</StartActions>
-					<Objective Name="Step2_3_Objective1">
+					<Objective StartValue="$Step2_3_Objective1Val" EndValue="$ScienceObjective" Name="Step2_3_Objective1">
 						<!-- Produce a minimum amount of science per turn -->
 						<AIHint Category="MaximizeResource" Motivation="0.7">
 							<Resource>Science</Resource>
 						</AIHint>
 						<Sequence>
 							<Decorator_BeginTurn>
-								<Condition_CheckInterpreter>
+								<Condition_IsProgressionComplete>
 									<Input_Context VarName="$CurrentEmpire"/>
-									<Input_Expression VarName="$Expression2"/>
-								</Condition_CheckInterpreter>
+									<Input_Expression VarName="$Step2_3_Objective1Expr"/>
+								</Condition_IsProgressionComplete>
 							</Decorator_BeginTurn>
 							<Action_SpawnHero>
 								<Input_Empire VarName="$CurrentEmpire"/>
@@ -686,7 +702,6 @@
 		</Steps>
 	</QuestDefinition>
 
-
 	<!-- ####################################### -->
 	<!--    UNITED EMPIRE QUEST Chapter2.1       -->
 	<!-- ####################################### -->
@@ -700,8 +715,8 @@
 
 
 		<RepetitionRules  NumberOfOccurrencesPerGame="0"
-											NumberOfOccurrencesPerEmpire="1"
-											NumberOfConcurrentInstances="0"/>
+						  NumberOfOccurrencesPerEmpire="1"
+						  NumberOfConcurrentInstances="0"/>
 
 		<!--============ VARIABLES ============-->
 		<Vars>
@@ -730,6 +745,13 @@
 
 			<Var VarName="$MinSystemAmountAlt" IntValue="1"/>
 			<LocalizationVar Source="$MinSystemAmountAlt"       LocalizationKey="$MinSystemAmountAltName"/>
+
+			<Var VarName="$Step2_2_Objective1Expr" StringValue="Count(Context, @'ClassEmpire/ClassColonizedStarSystem', SystemLevel, ge, $(MinLevelAmount))"/>
+			<Var VarName="$Three" IntValue="3"/>
+			<InterpretedVar VarName="$Step2_3_Objective1Val" Target="$(Empire)">
+				<Expression>Min(1, Count(Context, @'ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet,PlanetGameplayTypeHot')) + Min(1, Count(Context, @'ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet,PlanetGameplayTypeTemperate')) + Min(1, Count(Context, @'ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet,PlanetGameplayTypeCold'))</Expression>
+			</InterpretedVar>
+			<Var VarName="$Step2_3_Objective1Expr" StringValue="Min(1, Count(Context, @'ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet,PlanetGameplayTypeHot')) + Min(1, Count(Context, @'ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet,PlanetGameplayTypeTemperate')) + Min(1, Count(Context, @'ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet,PlanetGameplayTypeCold'))"/>
 		</Vars>
 
 		<!--============ PREREQUISITES ============-->
@@ -797,27 +819,25 @@
 							<Input_PopulationEventDefinition VarName="$PoliticalEffectIndustry"/>
 						</Action_TriggerPopulationEvent>
 					</StartActions>
-					<Objective Name="Step2_2_Objective1">
+					<Objective StartValue="$Step2_2_Objective1Val" EndValue="$MinSystemAmount" Name="Step2_2_Objective1">
 						<!-- TODO -->
 						<AIHint Category="Minimal" MinAutoResolutionTurn="25" MaxAutoResolutionTurn="35" AutoResolutionProbability="1" />
 						<Sequence>
 							<Parallel CompletionPolicy="First">
 								<Sequence>
 									<Decorator_SystemLevelChanged Initiator="Empire">
-										<Condition_HasSystems>
-											<Input_Empires VarName="$CurrentEmpire"/>
-											<Input_MinimumAmount VarName="$MinSystemAmount"/>
-											<Input_MinimumLevel VarName="$MinLevelAmount"/>
-										</Condition_HasSystems>
+										<Condition_IsProgressionComplete>
+											<Input_Context VarName="$CurrentEmpire"/>
+											<Input_Expression VarName="$Step2_2_Objective1Expr"/>
+										</Condition_IsProgressionComplete>
 									</Decorator_SystemLevelChanged>
 								</Sequence>
 								<Sequence>
 									<Decorator_BeginTurn>
-										<Condition_HasSystems>
-											<Input_Empires VarName="$CurrentEmpire"/>
-											<Input_MinimumAmount VarName="$MinSystemAmount"/>
-											<Input_MinimumLevel VarName="$MinLevelAmount"/>
-										</Condition_HasSystems>
+										<Condition_IsProgressionComplete>
+											<Input_Context VarName="$CurrentEmpire"/>
+											<Input_Expression VarName="$Step2_2_Objective1Expr"/>
+										</Condition_IsProgressionComplete>
 									</Decorator_BeginTurn>
 								</Sequence>
 							</Parallel>
@@ -895,26 +915,15 @@
 							<Input_PopulationEventDefinition VarName="$PoliticalEffectScience"/>
 						</Action_TriggerPopulationEvent>
 					</StartActions>
-					<Objective Name="Step2_3_Objective1">
+					<Objective StartValue="$Step2_3_Objective1Val" EndValue="$Three" Name="Step2_3_Objective1">
 						<!-- TODO -->
 						<AIHint Category="Minimal" MinAutoResolutionTurn="25" MaxAutoResolutionTurn="35" AutoResolutionProbability="1" />
 						<Sequence>
 							<Decorator_BeginTurn>
-								<Condition_HasPlanets>
-									<Input_EmpireOrSystem VarName="$CurrentEmpire"/>
-									<Input_MinimumAmount VarName="$PlanetAmount" />
-									<Input_PlanetGameplayType VarName="$TemperatePlanet"/>
-								</Condition_HasPlanets>
-								<Condition_HasPlanets>
-									<Input_EmpireOrSystem VarName="$CurrentEmpire"/>
-									<Input_MinimumAmount VarName="$PlanetAmount" />
-									<Input_PlanetGameplayType VarName="$ColdPlanet"/>
-								</Condition_HasPlanets>
-								<Condition_HasPlanets>
-									<Input_EmpireOrSystem VarName="$CurrentEmpire"/>
-									<Input_MinimumAmount VarName="$PlanetAmount" />
-									<Input_PlanetGameplayType VarName="$HotPlanet"/>
-								</Condition_HasPlanets>
+								<Condition_IsProgressionComplete>
+									<Input_Context VarName="$CurrentEmpire"/>
+									<Input_Expression VarName="$Step2_3_Objective1Expr"/>
+								</Condition_IsProgressionComplete>
 							</Decorator_BeginTurn>
 							<Action_ChooseOutcome Name="Outcome1"/>
 						</Sequence>
@@ -1865,8 +1874,8 @@
 		<QuestContextSolo/>
 
 		<RepetitionRules  NumberOfOccurrencesPerGame="0"
-                      NumberOfOccurrencesPerEmpire="1"
-                      NumberOfConcurrentInstances="0"/>
+						  NumberOfOccurrencesPerEmpire="1"
+						  NumberOfConcurrentInstances="0"/>
 
 		<!--============ VARIABLES ============-->
 		<Vars>
@@ -1927,6 +1936,11 @@
 			<LocalizationVar LocalizationKey="$MinAmountName" Source="$MinAmount"/>
 			<LocalizationVar Source="$MySystem" LocalizationKey="$MySystemName"/>
 			<LocalizationVar Source="$Amount03" LocalizationKey="$Amount03Name"/>
+
+			<InterpretedVar VarName="$Step2_2_Objective1Val" Target="$(Empire)">
+				<Expression>Property(Context, @'ClassEmpire', Population)</Expression>
+			</InterpretedVar>
+			<Var VarName="$Step2_2_Objective1Expr" StringValue="Property(Context, @'ClassEmpire', Population)"/>
 		</Vars>
 
 		<!--============ PREREQUISITES ============-->
@@ -2001,15 +2015,15 @@
 							<Input_PopulationEventDefinition VarName="$PoliticalEffectScience"/>
 						</Action_TriggerPopulationEvent>
 					</StartActions>
-					<Objective Name="Step2_2_Objective1">
+					<Objective StartValue="$Step2_2_Objective1Val" EndValue="$Amount01" Name="Step2_2_Objective1">
 						<!-- TODO -->
 						<AIHint Category="Minimal" MinAutoResolutionTurn="25" MaxAutoResolutionTurn="35" AutoResolutionProbability="1" />
 						<Sequence>
 							<Decorator_BeginTurn>
-								<Condition_HasPopulationAmount>
-									<Input_Empire VarName="$CurrentEmpire"/>
-									<Input_MinimumAmount VarName="$Amount01" />
-								</Condition_HasPopulationAmount>
+								<Condition_IsProgressionComplete>
+									<Input_Context VarName="$CurrentEmpire"/>
+									<Input_Expression VarName="$Step2_2_Objective1Expr"/>
+								</Condition_IsProgressionComplete>
 							</Decorator_BeginTurn>
 							<Action_ChooseOutcome Name="Outcome1"/>
 							<Action_ApplyDescriptor>
@@ -2032,7 +2046,6 @@
 			</Step>
 		</Steps>
 	</QuestDefinition>
-
 
 	<!-- ####################################### -->
 	<!--  UNITED EMPIRE QUEST Chapter4 MEZARI    -->

--- a/Endless Space Competitive Mod/Quests/QuestDefinitions[Unfallen].xml
+++ b/Endless Space Competitive Mod/Quests/QuestDefinitions[Unfallen].xml
@@ -260,7 +260,6 @@
             <InterpretedVar VarName="$Amount01" Target="$(Empire)">
                 <Expression>Property(Context, @'ClassEmpire', NetEmpireResearch) + 200</Expression>
             </InterpretedVar>
-            <Var VarName="$Expression01" StringValue="Property(Context, @'ClassEmpire', NetEmpireResearch) ge $(Amount01)" />
             <Var VarName="$PoliticalEffectScience" StringValue="PopulationEventUnfallen04-Science" />
             <Var VarName="$PoliticalEffectEcologist" StringValue="PopulationEventUnfallen04-Ecologist" />
             <Var VarName="$Amount02" IntValue="95" />
@@ -272,6 +271,11 @@
             <!-- EcologistObjective -->
             <LocalizationVar LocalizationKey="$Amount02Name" Source="$Amount02" />
             <LocalizationVar LocalizationKey="$Amount03Name" Source="$Amount03" />
+
+            <InterpretedVar VarName="$Objective_ScientistVal" Target="$(Empire)">
+                <Expression>Property(Context, @'ClassEmpire', NetEmpireResearch)</Expression>
+            </InterpretedVar>
+            <Var VarName="$Objective_ScientistExpr" StringValue="Property(Context, @'ClassEmpire', NetEmpireResearch)"/>
         </Vars>
         <!-- ============ STEPS ============ -->
         <Steps>
@@ -294,17 +298,17 @@
                             <Input_PopulationEventDefinition VarName="$PoliticalEffectScience" />
                         </Action_TriggerPopulationEvent>
                     </StartActions>
-                    <Objective Name="Objective_Scientist">
+                    <Objective StartValue="$Objective_ScientistVal" EndValue="$Amount01" Name="Objective_Scientist">
                         <!--  TODO  -->
                         <AIHint Category="MaximizeResource" Motivation="0.5">
                             <Resource>Science</Resource>
                         </AIHint>
                         <Sequence>
                             <Decorator_BeginTurn>
-                                <Condition_CheckInterpreter>
-                                    <Input_Context VarName="$CurrentEmpire" />
-                                    <Input_Expression VarName="$Expression01" />
-                                </Condition_CheckInterpreter>
+                                <Condition_IsProgressionComplete>
+                                    <Input_Context VarName="$CurrentEmpire"/>
+                                    <Input_Expression VarName="$Objective_ScientistExpr"/>
+                                </Condition_IsProgressionComplete>
                             </Decorator_BeginTurn>
                             <Action_ChooseOutcome Name="Outcome1" />
                         </Sequence>

--- a/Endless Space Competitive Mod/Quests/QuestDefinitions[Vampirilis].xml
+++ b/Endless Space Competitive Mod/Quests/QuestDefinitions[Vampirilis].xml
@@ -1990,12 +1990,28 @@
             <Var VarName="$MinAmount01" IntValue="600"/>
             <Var VarName="$ResourceName" StringValue="EmpireEmpirePoint"/>
             <LocalizationVar LocalizationKey="$MinAmount01Name" Source="$MinAmount01"/>
+            <InterpretedVar VarName="$Step1_0_Objective1Val" Target="$(Empire)">
+                <Expression>Property(Context, @'ClassEmpire', EmpireEmpirePointStock)</Expression>
+            </InterpretedVar>
+            <Var VarName="$Step1_0_Objective1Expr" StringValue="Property(Context, @'ClassEmpire', EmpireEmpirePointStock)"/>
+            <InterpretedVar VarName="$Step1_1_Objective1Val" Target="$(Empire)">
+                <Expression>Property(Context, @'ClassEmpire', EmpireEmpirePointStock)</Expression>
+            </InterpretedVar>
+            <Var VarName="$Step1_1_Objective1Expr" StringValue="Property(Context, @'ClassEmpire', EmpireEmpirePointStock)"/>
+            <InterpretedVar VarName="$Step1_2_Objective1Val" Target="$(Empire)">
+                <Expression>Property(Context, @'ClassEmpire', EmpireEmpirePointStock)</Expression>
+            </InterpretedVar>
+            <Var VarName="$Step1_2_Objective1Expr" StringValue="Property(Context, @'ClassEmpire', EmpireEmpirePointStock)"/>
+            <InterpretedVar VarName="$Step1_3_Objective1Val" Target="$(Empire)">
+                <Expression>Property(Context, @'ClassEmpire', EmpireEmpirePointStock)</Expression>
+            </InterpretedVar>
+            <Var VarName="$Step1_3_Objective1Expr" StringValue="Property(Context, @'ClassEmpire', EmpireEmpirePointStock)"/>
         </Vars>
 
         <!--============ PREREQUISITES ============-->
 
         <!--============ STEPS ============-->
-        
+
         <Steps>
             <Step Name="Step1">
                 <Choice DefaultChoiceIndex="0">
@@ -2005,16 +2021,15 @@
                     <ChoiceItem ObjectiveSetIndex="3"/>
                 </Choice>
                 <ObjectiveSet>
-                    <Objective Name="Step1_0_Objective1">
+                    <Objective StartValue="$Step1_0_Objective1Val" EndValue="$MinAmount01" Name="Step1_0_Objective1">
                         <!-- Option 1 -->
                         <AIHint Category="Minimal" MinAutoResolutionTurn="25" MaxAutoResolutionTurn="35" AutoResolutionProbability="1" />
                         <Sequence>
                             <Decorator_BeginTurn>
-                                <Condition_HasResource>
-                                    <Input_Location VarName="$CurrentEmpire"/>
-                                    <Input_ResourceName VarName="$ResourceName"/>
-                                    <Input_Minimum VarName="$MinAmount01"/>
-                                </Condition_HasResource>
+                                <Condition_IsProgressionComplete>
+                                    <Input_Context VarName="$CurrentEmpire"/>
+                                    <Input_Expression VarName="$Step1_0_Objective1Expr"/>
+                                </Condition_IsProgressionComplete>
                             </Decorator_BeginTurn>
                             <Action_ChooseOutcome Name="Outcome1"/>
                         </Sequence>
@@ -2026,21 +2041,20 @@
                                 </QuestTrigger>
                             </Triggers>
                         </Outcome>
-                    </Objective>                    
+                    </Objective>
                     <Reward Droplist="DroplistVampirilisReward99a" Picks="1"/>
                     <Reward Droplist="DroplistVampirilisReward99b" Picks="1"/>
                 </ObjectiveSet>
                 <ObjectiveSet>
-                    <Objective Name="Step1_1_Objective1">
+                    <Objective StartValue="$Step1_1_Objective1Val" EndValue="$MinAmount01" Name="Step1_1_Objective1">
                         <!-- Option 2 -->
                         <AIHint Category="Minimal" MinAutoResolutionTurn="25" MaxAutoResolutionTurn="35" AutoResolutionProbability="1" />
                         <Sequence>
                             <Decorator_BeginTurn>
-                                <Condition_HasResource>
-                                    <Input_Location VarName="$CurrentEmpire"/>
-                                    <Input_ResourceName VarName="$ResourceName"/>
-                                    <Input_Minimum VarName="$MinAmount01"/>
-                                </Condition_HasResource>
+                                <Condition_IsProgressionComplete>
+                                    <Input_Context VarName="$CurrentEmpire"/>
+                                    <Input_Expression VarName="$Step1_1_Objective1Expr"/>
+                                </Condition_IsProgressionComplete>
                             </Decorator_BeginTurn>
                             <Action_ChooseOutcome Name="Outcome1"/>
                         </Sequence>
@@ -2052,21 +2066,20 @@
                                 </QuestTrigger>
                             </Triggers>
                         </Outcome>
-                    </Objective>                    
+                    </Objective>
                     <Reward Droplist="DroplistVampirilisReward99c" Picks="1"/>
                     <Reward Droplist="DroplistVampirilisReward99d" Picks="1"/>
                 </ObjectiveSet>
                 <ObjectiveSet>
-                    <Objective Name="Step1_2_Objective1">
+                    <Objective StartValue="$Step1_2_Objective1Val" EndValue="$MinAmount01" Name="Step1_2_Objective1">
                         <!-- Option 3 -->
                         <AIHint Category="Minimal" MinAutoResolutionTurn="25" MaxAutoResolutionTurn="35" AutoResolutionProbability="1" />
                         <Sequence>
                             <Decorator_BeginTurn>
-                                <Condition_HasResource>
-                                    <Input_Location VarName="$CurrentEmpire"/>
-                                    <Input_ResourceName VarName="$ResourceName"/>
-                                    <Input_Minimum VarName="$MinAmount01"/>
-                                </Condition_HasResource>
+                                <Condition_IsProgressionComplete>
+                                    <Input_Context VarName="$CurrentEmpire"/>
+                                    <Input_Expression VarName="$Step1_2_Objective1Expr"/>
+                                </Condition_IsProgressionComplete>
                             </Decorator_BeginTurn>
                             <Action_ChooseOutcome Name="Outcome1"/>
                         </Sequence>
@@ -2078,21 +2091,20 @@
                                 </QuestTrigger>
                             </Triggers>
                         </Outcome>
-                    </Objective>                    
+                    </Objective>
                     <Reward Droplist="DroplistVampirilisReward99e" Picks="1"/>
                     <Reward Droplist="DroplistVampirilisReward99f" Picks="1"/>
                 </ObjectiveSet>
                 <ObjectiveSet>
-                    <Objective Name="Step1_3_Objective1">
+                    <Objective StartValue="$Step1_3_Objective1Val" EndValue="$MinAmount01" Name="Step1_3_Objective1">
                         <!-- Option 4 -->
                         <AIHint Category="Minimal" MinAutoResolutionTurn="25" MaxAutoResolutionTurn="35" AutoResolutionProbability="1" />
                         <Sequence>
                             <Decorator_BeginTurn>
-                                <Condition_HasResource>
-                                    <Input_Location VarName="$CurrentEmpire"/>
-                                    <Input_ResourceName VarName="$ResourceName"/>
-                                    <Input_Minimum VarName="$MinAmount01"/>
-                                </Condition_HasResource>
+                                <Condition_IsProgressionComplete>
+                                    <Input_Context VarName="$CurrentEmpire"/>
+                                    <Input_Expression VarName="$Step1_3_Objective1Expr"/>
+                                </Condition_IsProgressionComplete>
                             </Decorator_BeginTurn>
                             <Action_ChooseOutcome Name="Outcome1"/>
                         </Sequence>
@@ -2104,7 +2116,7 @@
                                 </QuestTrigger>
                             </Triggers>
                         </Outcome>
-                    </Objective>                    
+                    </Objective>
                     <Reward Droplist="DroplistVampirilisReward99g" Picks="1"/>
                     <Reward Droplist="DroplistVampirilisReward99h" Picks="1"/>
                 </ObjectiveSet>
@@ -2132,16 +2144,24 @@
         <Vars>
             <Var VarName="$CurrentEmpire">
                 <From Source="$Empire"/>
-            </Var>    
+            </Var>
             <InterpretedVar VarName="$Amount01" Target="$(Empire)">
                 <Expression>Min(4, (MaxProperty(Context, @'../ClassEmpire/ClassColonizedStarSystem', SystemLevel)+1))</Expression>
             </InterpretedVar>
             <Var VarName="$Amount02" IntValue="4"/>
             <LocalizationVar LocalizationKey="$Amount01Name" Source="$Amount01"/>
             <LocalizationVar LocalizationKey="$Amount02Name" Source="$Amount02"/>
+            <InterpretedVar VarName="$Step2_Objective1Val" Target="$(Empire)">
+                <Expression>Count(Context, @'ClassEmpire/ClassColonizedStarSystem', SystemLevel, ge, $(Amount01))</Expression>
+            </InterpretedVar>
+            <Var VarName="$Step2_Objective1Expr" StringValue="Count(Context, @'ClassEmpire/ClassColonizedStarSystem', SystemLevel, ge, $(Amount01))"/>
+            <InterpretedVar VarName="$Step2_Objective2Val" Target="$(Empire)">
+                <Expression>Count(Context, @'ClassEmpire/ClassColonizedStarSystem', SystemLevel, ge, $(Amount01))</Expression>
+            </InterpretedVar>
+            <Var VarName="$Step2_Objective2Expr" StringValue="Count(Context, @'ClassEmpire/ClassColonizedStarSystem', SystemLevel, ge, $(Amount01))"/>
         </Vars>
 
-        <!--============ PREREQUISITES ============-->       
+        <!--============ PREREQUISITES ============-->
 
         <!--============ STEPS ============-->
         <Steps>
@@ -2159,31 +2179,25 @@
                         </Prerequisites>
                     </ChoiceItem>
                 </Choice>
-                
+
                 <ObjectiveSet>
-                    <Objective Name="Step2_Objective1">
+                    <Objective StartValue="$Step2_Objective1Val" EndValue="$Amount02" Name="Step2_Objective1">
                         <!-- TODO -->
                         <AIHint Category="Minimal" MinAutoResolutionTurn="25" MaxAutoResolutionTurn="35" AutoResolutionProbability="1" />
                         <Sequence>
                             <Parallel CompletionPolicy="Any">
-                                <Sequence>
-                                    <Decorator_SystemLevelChanged Initiator="Empire">
-                                        <Condition_HasSystems>
-                                            <Input_Empires VarName="$CurrentEmpire"/>
-                                            <Input_MinimumAmount VarName="$Amount02"/>
-                                            <Input_MinimumLevel VarName="$Amount01"/>
-                                        </Condition_HasSystems>                                    
-                                    </Decorator_SystemLevelChanged>
-                                </Sequence>
-                                <Sequence>
-                                    <Decorator_BeginTurn>
-                                        <Condition_HasSystems>
-                                            <Input_Empires VarName="$CurrentEmpire"/>
-                                            <Input_MinimumAmount VarName="$Amount02"/>
-                                            <Input_MinimumLevel VarName="$Amount01"/>
-                                        </Condition_HasSystems>
-                                    </Decorator_BeginTurn>
-                                </Sequence>
+                                <Decorator_SystemLevelChanged Initiator="Empire">
+                                    <Condition_IsProgressionComplete>
+                                        <Input_Context VarName="$CurrentEmpire"/>
+                                        <Input_Expression VarName="$Step2_Objective1Expr"/>
+                                    </Condition_IsProgressionComplete>
+                                </Decorator_SystemLevelChanged>
+                                <Decorator_BeginTurn>
+                                    <Condition_IsProgressionComplete>
+                                        <Input_Context VarName="$CurrentEmpire"/>
+                                        <Input_Expression VarName="$Step2_Objective1Expr"/>
+                                    </Condition_IsProgressionComplete>
+                                </Decorator_BeginTurn>
                             </Parallel>
                             <Action_ChooseOutcome Name="Outcome1"/>
                         </Sequence>
@@ -2200,29 +2214,23 @@
                 </ObjectiveSet>
 
                 <ObjectiveSet>
-                    <Objective Name="Step2_Objective2">
+                    <Objective StartValue="$Step2_Objective2Val" EndValue="$Amount02" Name="Step2_Objective2">
                         <!-- TODO -->
                         <AIHint Category="Minimal" MinAutoResolutionTurn="25" MaxAutoResolutionTurn="35" AutoResolutionProbability="1" />
                         <Sequence>
                             <Parallel CompletionPolicy="Any">
-                                <Sequence>
-                                    <Decorator_SystemLevelChanged Initiator="Empire">
-                                        <Condition_HasSystems>
-                                            <Input_Empires VarName="$CurrentEmpire"/>
-                                            <Input_MinimumAmount VarName="$Amount02"/>
-                                            <Input_MinimumLevel VarName="$Amount01"/>
-                                        </Condition_HasSystems>                                    
-                                    </Decorator_SystemLevelChanged>
-                                </Sequence>
-                                <Sequence>
-                                    <Decorator_BeginTurn>
-                                        <Condition_HasSystems>
-                                            <Input_Empires VarName="$CurrentEmpire"/>
-                                            <Input_MinimumAmount VarName="$Amount02"/>
-                                            <Input_MinimumLevel VarName="$Amount01"/>
-                                        </Condition_HasSystems>
-                                    </Decorator_BeginTurn>
-                                </Sequence>
+                                <Decorator_SystemLevelChanged Initiator="Empire">
+                                    <Condition_IsProgressionComplete>
+                                        <Input_Context VarName="$CurrentEmpire"/>
+                                        <Input_Expression VarName="$Step2_Objective2Expr"/>
+                                    </Condition_IsProgressionComplete>
+                                </Decorator_SystemLevelChanged>
+                                <Decorator_BeginTurn>
+                                    <Condition_IsProgressionComplete>
+                                        <Input_Context VarName="$CurrentEmpire"/>
+                                        <Input_Expression VarName="$Step2_Objective2Expr"/>
+                                    </Condition_IsProgressionComplete>
+                                </Decorator_BeginTurn>
                             </Parallel>
                             <Action_ChooseOutcome Name="Outcome1"/>
                         </Sequence>

--- a/Endless Space Competitive Mod/Quests/QuestDefinitions[Vaulters].xml
+++ b/Endless Space Competitive Mod/Quests/QuestDefinitions[Vaulters].xml
@@ -784,17 +784,20 @@
             <Var VarName="$AllStarSystems">
                 <From Source="$Constellations.$StarSystems"/>
             </Var>
-         
+
             <Var VarName="$Amount01" IntValue="13"/>
             <Var VarName="$Amount02" IntValue="35"/>
-            <Var VarName="$FleetGUID"/>          
-          
+            <Var VarName="$FleetGUID"/>
+
             <Var VarName="$PoliticalEffectMilitarist"      StringValue="PopulationEventVaulters04-Militarist"/>
             <Var VarName="$PoliticalEffectScientist"       StringValue="PopulationEventVaulters04-Scientist"/>
 
             <LocalizationVar LocalizationKey="$Amount01Name" Source="$Amount01"/>
             <LocalizationVar LocalizationKey="$Amount02Name" Source="$Amount02"/>
-        
+            <Var VarName="$Objective_ScientistVal">
+                <From Source="$CurrentEmpire.$RevealedNodePercentage"/>
+            </Var>
+            <Var VarName="$Objective_ScientistExpr" StringValue="$(Objective_ScientistVal)"/>
         </Vars>
 
         <!--============ PREREQUISITES ============-->
@@ -823,12 +826,12 @@
                         <AIHint Category="Minimal" MinAutoResolutionTurn="45" MaxAutoResolutionTurn="60" AutoResolutionProbability="1" />
                         <Sequence>
                             <Loop>
-                            <Decorator_CuriosityDiscovered Initiator="Empire" ProgressionIncrement="1" StopAtFirstFailedCondition="true">
-                                <Condition_IsVariableNotEmpty>
-                                    <Input_Variable VarName="$FleetGUID"/>                                    
-                                </Condition_IsVariableNotEmpty>
-                                <Output_FleetGUID VarName="$FleetGUID"/>
-                            </Decorator_CuriosityDiscovered>
+                                <Decorator_CuriosityDiscovered Initiator="Empire" ProgressionIncrement="1" StopAtFirstFailedCondition="true">
+                                    <Condition_IsVariableNotEmpty>
+                                        <Input_Variable VarName="$FleetGUID"/>
+                                    </Condition_IsVariableNotEmpty>
+                                    <Output_FleetGUID VarName="$FleetGUID"/>
+                                </Decorator_CuriosityDiscovered>
                                 <Input_Count VarName="$Amount01"/>
                             </Loop>
                             <Action_ChooseOutcome Name="Outcome1"/>
@@ -857,10 +860,10 @@
                         </Action_TriggerPopulationEvent>
                     </StartActions>
 
-                    <Objective Name="Objective_Scientist">
+                    <Objective StartValue="$Objective_ScientistVal" EndValue="$Amount02" Name="Objective_Scientist">
                         <!-- TODO -->
-                        <AIHint Category="MaximizeExploration" Motivation="0.5"/>                          
-                    
+                        <AIHint Category="MaximizeExploration" Motivation="0.5"/>
+
                         <Sequence>
                             <Parallel CompletionPolicy="First">
                                 <Sequence>
@@ -873,7 +876,9 @@
                                 </Sequence>
                                 <Sequence>
                                     <Decorator_ExploredNode MinimumState="Revealed" Initiator="Empire">
-                                        <Input_MinimumPercentage VarName="$Amount02"/>
+                                        <Condition_IsProgressionComplete>
+                                            <Input_Expression VarName="$Objective_ScientistExpr"/>
+                                        </Condition_IsProgressionComplete>
                                     </Decorator_ExploredNode>
                                 </Sequence>
                             </Parallel>
@@ -918,7 +923,7 @@
             <Var VarName="$CurrentEmpire">
                 <From Source="$Empire"/>
             </Var>
-       
+
 
             <Var VarName="$PoliticalEffectMilitarist"      StringValue="PopulationEventVaulters05-Militarist"/>
             <Var VarName="$PoliticalEffectScientist"       StringValue="PopulationEventVaulters05-Scientist"/>
@@ -927,7 +932,7 @@
 
             <InterpretedVar VarName="$Amount02" Target="$(Empire)">
                 <Expression>Min(500, (MaxProperty(Context, @'../ClassEmpire/ClassGarrisonFleet/ClassShip', DefensiveMilitaryPower)+150))</Expression>
-            </InterpretedVar>       
+            </InterpretedVar>
 
             <InterpretedVar VarName="$Amount03" Target="$(Empire)">
                 <Expression>Count(Context, @'ClassEmpire/ClassColonizedStarSystem/PlanetGameplayTypeTemperate,ClassColonizedPlanet')</Expression>
@@ -940,7 +945,10 @@
             <LocalizationVar LocalizationKey="$Amount01Name" Source="$Amount01"/>
             <LocalizationVar LocalizationKey="$Amount02Name" Source="$Amount02"/>
             <LocalizationVar LocalizationKey="$Amount04Name" Source="$Amount04"/>
-
+            <InterpretedVar VarName="$Objective_MilitaristVal" Target="$(Empire)">
+                <Expression>Count(Context, @'ClassEmpire/ClassGarrisonFleet/ClassShip', DefensiveMilitaryPower, gt, $(Amount02))</Expression>
+            </InterpretedVar>
+            <Var VarName="$Objective_MilitaristExpr" StringValue="Count(Context, @'ClassEmpire/ClassGarrisonFleet/ClassShip', DefensiveMilitaryPower, gt, $(Amount02))"/>
         </Vars>
 
         <!--============ PREREQUISITES ============-->
@@ -965,15 +973,14 @@
                         </Action_TriggerPopulationEvent>
                     </StartActions>
 
-                    <Objective Name="Objective_Militarist">
+                    <Objective StartValue="$Objective_MilitaristVal" EndValue="$Amount01" Name="Objective_Militarist">
                         <AIHint Category="Minimal" MinAutoResolutionTurn="45" MaxAutoResolutionTurn="60" AutoResolutionProbability="1" />
                         <Sequence>
                             <Decorator_BeginTurn>
-                                <Condition_ShipStats>
-                                    <Input_Empire VarName="$CurrentEmpire"/>
-                                    <Input_MinimumAmount VarName="$Amount01"/>
-                                    <Input_MinimumDefensiveMilitaryPower VarName="$Amount02"/>                                                                
-                                </Condition_ShipStats>
+                                <Condition_IsProgressionComplete>
+                                    <Input_Context VarName="$CurrentEmpire"/>
+                                    <Input_Expression VarName="$Objective_MilitaristExpr"/>
+                                </Condition_IsProgressionComplete>
                             </Decorator_BeginTurn>
                             <Action_ChooseOutcome Name="Outcome1"/>
                         </Sequence>

--- a/Endless Space Competitive Mod/Quests/QuestDefinitions[Venetians].xml
+++ b/Endless Space Competitive Mod/Quests/QuestDefinitions[Venetians].xml
@@ -319,7 +319,7 @@
         <Tags>VenetiansQuest-Chapter1.2-Industry</Tags>
 
         <QuestContextSolo/>
-        
+
 
         <RepetitionRules  NumberOfOccurrencesPerGame="0"
                           NumberOfOccurrencesPerEmpire="1"
@@ -334,6 +334,11 @@
             <Var VarName="$MinAmount" IntValue="1"/>
             <Var VarName="$MinLevel" IntValue="6"/>
             <LocalizationVar Source="$MinLevel" LocalizationKey="$MinLevelName"/>
+
+            <InterpretedVar VarName="$Step1_Objective1Val" Target="$(Empire)">
+                <Expression>MaxProperty(Context, @'ClassEmpire/ClassColonizedStarSystem/ClassHero', Level)</Expression>
+            </InterpretedVar>
+            <Var VarName="$Step1_Objective1Expr" StringValue="MaxProperty(Context, @'ClassEmpire/ClassColonizedStarSystem/ClassHero', Level)"/>
         </Vars>
 
         <!--============ PREREQUISITES ============-->
@@ -347,16 +352,15 @@
             <!--============ STEP 1 ============-->
             <Step Name="Step1">
                 <ObjectiveSet>
-                    <Objective Name="Step1_Objective1">
+                    <Objective StartValue="$Step1_Objective1Val" EndValue="$MinLevel" Name="Step1_Objective1">
                         <!-- TODO -->
                         <AIHint Category="Minimal" MinAutoResolutionTurn="25" MaxAutoResolutionTurn="35" AutoResolutionProbability="1" />
                         <Sequence>
                             <Decorator_BeginTurn>
-                                <Condition_HasHeroes HeroAssignationFilter="System">
-                                    <Input_Empire VarName="$CurrentEmpire"/>
-                                    <Input_MinimumAmount VarName="$MinAmount"/>
-                                    <Input_MinimumLevel VarName="$MinLevel"/>
-                                </Condition_HasHeroes>
+                                <Condition_IsProgressionComplete>
+                                    <Input_Context VarName="$CurrentEmpire"/>
+                                    <Input_Expression VarName="$Step1_Objective1Expr"/>
+                                </Condition_IsProgressionComplete>
                             </Decorator_BeginTurn>
                             <Action_ChooseOutcome Name="Outcome1"/>
                         </Sequence>
@@ -387,7 +391,7 @@
         <Tags>VenetiansQuest-Chapter1.2-Pacifism</Tags>
 
         <QuestContextSolo/>
-        
+
 
         <RepetitionRules  NumberOfOccurrencesPerGame="0"
                           NumberOfOccurrencesPerEmpire="1"
@@ -401,31 +405,33 @@
             </Var>
             <Var VarName="$SystemAmount" IntValue="1"/>
             <Var VarName="$DustAmount" IntValue="150"/>
-            
-            <LocalizationVar LocalizationKey="$DustAmountLoc" Source="$DustAmount"/>
 
-        </Vars> 
+            <LocalizationVar LocalizationKey="$DustAmountLoc" Source="$DustAmount"/>
+            <InterpretedVar VarName="$Step1_Objective1Val" Target="$(Empire)">
+                <Expression>MaxProperty(Context, @'ClassEmpire/ClassColonizedStarSystem', NetSystemMoney)</Expression>
+            </InterpretedVar>
+            <Var VarName="$Step1_Objective1Expr" StringValue="MaxProperty(Context, @'ClassEmpire/ClassColonizedStarSystem', NetSystemMoney)"/>
+        </Vars>
 
         <!--============ PREREQUISITES ============-->
-       
+
         <!--============ STEPS ============-->
 
         <Steps>
             <!--============ STEP 1 ============-->
             <Step Name="Step1">
                 <ObjectiveSet>
-                    <Objective Name="Step1_Objective1">
-                       <!-- TODO -->
+                    <Objective StartValue="$Step1_Objective1Val" EndValue="$DustAmount" Name="Step1_Objective1">
+                        <!-- TODO -->
                         <AIHint Category="MaximizeResource" Motivation="0.5">
                             <Resource>Dust</Resource>
                         </AIHint>
                         <Sequence>
                             <Decorator_BeginTurn>
-                                <Condition_SystemsHaveFidsi>
-                                    <Input_Empire VarName="$CurrentEmpire"/>
-                                    <Input_SystemCount VarName="$SystemAmount"/>
-                                    <Input_NetMoney VarName="$DustAmount"/>
-                                </Condition_SystemsHaveFidsi>
+                                <Condition_IsProgressionComplete>
+                                    <Input_Context VarName="$CurrentEmpire"/>
+                                    <Input_Expression VarName="$Step1_Objective1Expr"/>
+                                </Condition_IsProgressionComplete>
                             </Decorator_BeginTurn>
                             <Action_ChooseOutcome Name="Outcome1"/>
                         </Sequence>
@@ -938,27 +944,30 @@
             <Var VarName="$MinLevel" IntValue="5"/>
             <Var VarName="$PlanetSize" StringValue="PlanetSizeHuge"/>
             <LocalizationVar LocalizationKey="$MinAmountName" Source="$MinAmount"/>
+            <InterpretedVar VarName="$Step1_Objective1Val" Target="$(Empire)">
+                <Expression>Count(Context, @'ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet,PlanetSizeHuge')</Expression>
+            </InterpretedVar>
+            <Var VarName="$Step1_Objective1Expr" StringValue="Count(Context, @'ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet,PlanetSizeHuge')"/>
         </Vars>
 
         <!--============ PREREQUISITES ============-->
-   
+
         <!--============ STEPS ============-->
 
         <Steps>
             <!--============ STEP 1 ============-->
-            <Step Name="Step1">              
-                
+            <Step Name="Step1">
+
                 <ObjectiveSet>
-                    <Objective Name="Step1_Objective1">
+                    <Objective StartValue="$Step1_Objective1Val" EndValue="$MinAmount" Name="Step1_Objective1">
                         <!-- TODO -->
                         <AIHint Category="Minimal" MinAutoResolutionTurn="25" MaxAutoResolutionTurn="35" AutoResolutionProbability="1" />
                         <Sequence>
                             <Decorator_BeginTurn>
-                                <Condition_HasPlanets>                                    
-                                    <Input_EmpireOrSystem VarName="$CurrentEmpire"/>
-                                    <Input_MinimumAmount VarName="$MinAmount"/>
-                                    <Input_PlanetSize VarName="$PlanetSize"/>                              
-                                </Condition_HasPlanets>
+                                <Condition_IsProgressionComplete>
+                                    <Input_Context VarName="$CurrentEmpire"/>
+                                    <Input_Expression VarName="$Step1_Objective1Expr"/>
+                                </Condition_IsProgressionComplete>
                             </Decorator_BeginTurn>
                             <Action_ChooseOutcome Name="Outcome1"/>
                         </Sequence>
@@ -973,11 +982,10 @@
                     </Objective>
                     <Reward Droplist="DroplistVenetians08" Picks="1"/>
                 </ObjectiveSet>
-                
+
             </Step>
         </Steps>
     </QuestDefinition>
-
 
     <!-- ############################################## -->
     <!-- Venetians QUEST Chapter 3 Step 2 OMOKOR AND ARRAKYO  -->
@@ -1001,12 +1009,20 @@
                 <From Source="$Empire"/>
             </Var>
             <Var VarName="$MinAmount" IntValue="3"/>
-            <Var VarName="$MinLevel" IntValue="3"/>  
-        <LocalizationVar Source="$MinLevel" LocalizationKey="$MinLevelName"/>
+            <Var VarName="$MinLevel" IntValue="3"/>
+            <LocalizationVar Source="$MinLevel" LocalizationKey="$MinLevelName"/>
+            <InterpretedVar VarName="$Step1_Objective1Val" Target="$(Empire)">
+                <Expression>MaxProperty(Context, @'ClassEmpire/ClassColonizedStarSystem', SystemLevel)</Expression>
+            </InterpretedVar>
+            <Var VarName="$Step1_Objective1Expr" StringValue="MaxProperty(Context, @'ClassEmpire/ClassColonizedStarSystem', SystemLevel)"/>
+            <InterpretedVar VarName="$Step1_Objective2Val" Target="$(Empire)">
+                <Expression>MaxProperty(Context, @'ClassEmpire/ClassColonizedStarSystem', SystemLevel)</Expression>
+            </InterpretedVar>
+            <Var VarName="$Step1_Objective2Expr" StringValue="MaxProperty(Context, @'ClassEmpire/ClassColonizedStarSystem', SystemLevel)"/>
         </Vars>
 
         <!--============ PREREQUISITES ============-->
-  
+
         <!--============ STEPS ============-->
 
         <Steps>
@@ -1024,15 +1040,26 @@
                         </Prerequisites>
                     </ChoiceItem>
                 </Choice>
-                
-                <ObjectiveSet>                   
-                    <Objective Name="Step1_Objective1">
+
+                <ObjectiveSet>
+                    <Objective StartValue="$Step1_Objective1Val" EndValue="$MinLevel" Name="Step1_Objective1">
                         <!-- TODO -->
                         <AIHint Category="Minimal" MinAutoResolutionTurn="25" MaxAutoResolutionTurn="35" AutoResolutionProbability="1" />
-                        <Sequence>                           
-                            <Decorator_SystemLevelChanged Initiator="Empire">
-                                <Input_MinimumLevel VarName="$MinLevel"/>
-                            </Decorator_SystemLevelChanged>
+                        <Sequence>
+                            <Parallel CompletionPolicy="Any">
+                                <Decorator_SystemLevelChanged Initiator="Empire">
+                                    <Condition_IsProgressionComplete>
+                                        <Input_Context VarName="$CurrentEmpire"/>
+                                        <Input_Expression VarName="$Step1_Objective1Expr"/>
+                                    </Condition_IsProgressionComplete>
+                                </Decorator_SystemLevelChanged>
+                                <Decorator_BeginTurn>
+                                    <Condition_IsProgressionComplete>
+                                        <Input_Context VarName="$CurrentEmpire"/>
+                                        <Input_Expression VarName="$Step1_Objective1Expr"/>
+                                    </Condition_IsProgressionComplete>
+                                </Decorator_BeginTurn>
+                            </Parallel>
                             <Action_ChooseOutcome Name="Outcome1"/>
                         </Sequence>
                         <Outcome Name="Outcome1">
@@ -1047,13 +1074,24 @@
                     <Reward Droplist="DroplistVenetians09" Picks="1"/>
                 </ObjectiveSet>
                 <ObjectiveSet>
-                    <Objective Name="Step1_Objective2">
+                    <Objective StartValue="$Step1_Objective2Val" EndValue="$MinLevel" Name="Step1_Objective2">
                         <!-- TODO -->
                         <AIHint Category="Minimal" MinAutoResolutionTurn="25" MaxAutoResolutionTurn="35" AutoResolutionProbability="1" />
                         <Sequence>
-                            <Decorator_SystemLevelChanged Initiator="Empire">
-                                <Input_MinimumLevel VarName="$MinLevel"/>
-                            </Decorator_SystemLevelChanged>
+                            <Parallel CompletionPolicy="Any">
+                                <Decorator_SystemLevelChanged Initiator="Empire">
+                                    <Condition_IsProgressionComplete>
+                                        <Input_Context VarName="$CurrentEmpire"/>
+                                        <Input_Expression VarName="$Step1_Objective1Expr"/>
+                                    </Condition_IsProgressionComplete>
+                                </Decorator_SystemLevelChanged>
+                                <Decorator_BeginTurn>
+                                    <Condition_IsProgressionComplete>
+                                        <Input_Context VarName="$CurrentEmpire"/>
+                                        <Input_Expression VarName="$Step1_Objective1Expr"/>
+                                    </Condition_IsProgressionComplete>
+                                </Decorator_BeginTurn>
+                            </Parallel>
                             <Action_ChooseOutcome Name="Outcome1"/>
                         </Sequence>
                         <Outcome Name="Outcome1">
@@ -1096,33 +1134,36 @@
             <Var VarName="$MinAmount" IntValue="3"/>
             <Var VarName="$HomeSystems">
                 <From Source="$Constellations.$StarSystems">
-                    <Where>                        
+                    <Where>
                         <PathPrerequisite Flags="Prerequisite">ClassStarSystem,HomeSystem</PathPrerequisite>
                     </Where>
                 </From>
             </Var>
             <LocalizationVar Source="$MinAmount" LocalizationKey="$MinAmountName"/>
+            <InterpretedVar VarName="$Step1_Objective1Val" Target="$(Empire)">
+                <Expression>Count(Context, @'ClassEmpire/ClassColonizedStarSystem,HomeSystem')</Expression>
+            </InterpretedVar>
+            <Var VarName="$Step1_Objective1Expr" StringValue="Count(Context, @'ClassEmpire/ClassColonizedStarSystem,HomeSystem')"/>
         </Vars>
 
         <!--============ PREREQUISITES ============-->
-       
+
         <!--============ STEPS ============-->
 
         <Steps>
             <!--============ STEP 1 ============-->
             <Step Name="Step1">
                 <ObjectiveSet>
-                    <Objective Name="Step1_Objective1">
+                    <Objective StartValue="$Step1_Objective1Val" EndValue="$MinAmount" Name="Step1_Objective1">
                         <!-- TODO -->
                         <AIHint Category="Minimal" MinAutoResolutionTurn="25" MaxAutoResolutionTurn="35" AutoResolutionProbability="1" />
                         <Sequence>
                             <Decorator_BeginTurn>
                                 <!--SHOULD BE: SYSTEM WITH WONDERS-->
-                                <Condition_HasSystems>                                    
-                                    <Input_Empires VarName="$CurrentEmpire"/>
-                                    <Input_MinimumAmount VarName="$MinAmount"/>
-                                    <Input_Systems VarName="$HomeSystems"/>
-                                </Condition_HasSystems>
+                                <Condition_IsProgressionComplete>
+                                    <Input_Context VarName="$CurrentEmpire"/>
+                                    <Input_Expression VarName="$Step1_Objective1Expr"/>
+                                </Condition_IsProgressionComplete>
                             </Decorator_BeginTurn>
                             <Action_ChooseOutcome Name="Outcome1"/>
                         </Sequence>
@@ -1136,7 +1177,7 @@
                         </Outcome>
                     </Objective>
                     <Reward Droplist="DroplistVenetians08" Picks="1"/>
-                </ObjectiveSet>                
+                </ObjectiveSet>
             </Step>
         </Steps>
     </QuestDefinition>
@@ -1298,7 +1339,7 @@
             </Var>
             <Var VarName="$IncomeAmount" IntValue="250"/>
             <Var VarName="$ResourceName00" StringValue="EmpireResearch"/>
-            <Var VarName="$ResourceName01" StringValue="EmpireMoney"/>           
+            <Var VarName="$ResourceName01" StringValue="EmpireMoney"/>
             <InterpretedVar VarName="$MinAmount" Target="$(Empire)">
                 <Expression>Property(Context, @'ClassEmpire/ClassColonizedStarSystems/ClassColonizedPlanet', PlanetTypeDesert, true) + 2</Expression>
             </InterpretedVar>
@@ -1309,14 +1350,29 @@
             <LocalizationVar LocalizationKey="$MinAmountName" Source="$MinAmount"/>
             <LocalizationVar LocalizationKey="$IncomeAmountName" Source="$IncomeAmount"/>
             <LocalizationVar LocalizationKey="$SixName" Source="$Six"/>
-        </Vars>
+            <InterpretedVar VarName="$Step2_1_Objective1Val" Target="$(Empire)">
+                <Expression>Count(Context, @'ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet,PlanetTypeDesert')</Expression>
+            </InterpretedVar>
+            <Var VarName="$Step2_1_Objective1Expr" StringValue="Count(Context, @'ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet,PlanetTypeDesert')"/>
+            <InterpretedVar VarName="$Step2_2_Objective1Val" Target="$(Empire)">
+                <Expression>SumProperty(Context, @'ClassEmpire/DepartmentOfCommerce/ClassTradingCompany', EmpireResearch)</Expression>
+            </InterpretedVar>
+            <Var VarName="$Step2_2_Objective1Expr" StringValue="SumProperty(Context, @'ClassEmpire/DepartmentOfCommerce/ClassTradingCompany', EmpireResearch)"/>
+            <InterpretedVar VarName="$Step2_3_Objective1Val" Target="$(Empire)">
+                <Expression>SumProperty(Context, @'ClassEmpire/DepartmentOfCommerce/ClassTradingCompany', EmpireMoney)</Expression>
+            </InterpretedVar>
+            <Var VarName="$Step2_3_Objective1Expr" StringValue="SumProperty(Context, @'ClassEmpire/DepartmentOfCommerce/ClassTradingCompany', EmpireMoney)"/>
+            <InterpretedVar VarName="$Step2_4_Objective1Val" Target="$(Empire)">
+                <Expression>Count(Context, @'ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet/ClassResourceDeposit,ResourceTypeLuxury')</Expression>
+            </InterpretedVar>
+            <Var VarName="$Step2_4_Objective1Expr" StringValue="Count(Context, @'ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet/ClassResourceDeposit,ResourceTypeLuxury')"/>        </Vars>
 
         <!--============ PREREQUISITE ============-->
-    
-      <!--============ STEPS ============-->
+
+        <!--============ STEPS ============-->
         <Steps>
             <Step Name="Step1">
-          <!--============ STEP 0 - Choose ============-->
+                <!--============ STEP 0 - Choose ============-->
                 <Choice DefaultChoiceIndex="0">
                     <ChoiceItem ObjectiveSetIndex="0"/>
                     <ChoiceItem ObjectiveSetIndex="1"/>
@@ -1324,71 +1380,68 @@
                     <ChoiceItem ObjectiveSetIndex="3"/>
                 </Choice>
                 <ObjectiveSet>
-                    <Objective Name="Step2_1_Objective1">
+                    <Objective StartValue="$Step2_1_Objective1Val" EndValue="$MinAmount" Name="Step2_1_Objective1">
                         <!-- TODO -->
                         <AIHint Category="Minimal" MinAutoResolutionTurn="45" MaxAutoResolutionTurn="60" AutoResolutionProbability="1" />
-                    <!--OMOKOR-->
+                        <!--OMOKOR-->
                         <Sequence>
                             <Decorator_BeginTurn>
-                                <Condition_HasPlanets>
-                                    <Input_EmpireOrSystem VarName="$CurrentEmpire"/>
-                                    <Input_MinimumAmount VarName="$MinAmount"/>
-                                    <Input_PlanetType VarName="$PlanetType"/>
-                                </Condition_HasPlanets>
-                            </Decorator_BeginTurn>                     
-                        </Sequence>                        
+                                <Condition_IsProgressionComplete>
+                                    <Input_Context VarName="$CurrentEmpire"/>
+                                    <Input_Expression VarName="$Step2_1_Objective1Expr"/>
+                                </Condition_IsProgressionComplete>
+                            </Decorator_BeginTurn>
+                        </Sequence>
                     </Objective>
                     <Reward Droplist="DroplistVenetians10" Picks="1"/>
                 </ObjectiveSet>
                 <ObjectiveSet>
-                    <Objective Name="Step2_2_Objective1">
+                    <Objective StartValue="$Step2_2_Objective1Val" EndValue="$IncomeAmount" Name="Step2_2_Objective1">
                         <!-- TODO -->
                         <AIHint Category="MaximizeTradeCompagny" Motivation="0.5">
                             <Resource>Science</Resource>
                         </AIHint>
-                    <!--ARRAKYO-->
+                        <!--ARRAKYO-->
                         <Sequence>
                             <Decorator_BeginTurn>
-                                <Condition_HasTradeIncome SummedAmount="true">
-                                    <Input_Empire VarName="$CurrentEmpire"/>
-                                    <Input_ResourceName VarName="$ResourceName00"/>
-                                    <Input_MinimumAmount VarName="$IncomeAmount"/>
-                                </Condition_HasTradeIncome>
-                            </Decorator_BeginTurn>                           
-                        </Sequence>                        
+                                <Condition_IsProgressionComplete>
+                                    <Input_Context VarName="$CurrentEmpire"/>
+                                    <Input_Expression VarName="$Step2_2_Objective1Expr"/>
+                                </Condition_IsProgressionComplete>
+                            </Decorator_BeginTurn>
+                        </Sequence>
                     </Objective>
                     <Reward Droplist="DroplistVenetians11" Picks="1"/>
                 </ObjectiveSet>
                 <ObjectiveSet>
-                    <Objective Name="Step2_3_Objective1">
+                    <Objective StartValue="$Step2_3_Objective1Val" EndValue="$IncomeAmount" Name="Step2_3_Objective1">
                         <!-- TODO -->
                         <AIHint Category="MaximizeTradeCompagny" Motivation="0.5">
                             <Resource>Dust</Resource>
                         </AIHint>
-                      <!--LANCELLUM-->                       
+                        <!--LANCELLUM-->
                         <Sequence>
                             <Decorator_BeginTurn>
-                                <Condition_HasTradeIncome SummedAmount="true">
-                                    <Input_Empire VarName="$CurrentEmpire"/>
-                                    <Input_ResourceName VarName="$ResourceName01"/>
-                                    <Input_MinimumAmount VarName="$IncomeAmount"/>
-                                </Condition_HasTradeIncome>
+                                <Condition_IsProgressionComplete>
+                                    <Input_Context VarName="$CurrentEmpire"/>
+                                    <Input_Expression VarName="$Step2_3_Objective1Expr"/>
+                                </Condition_IsProgressionComplete>
                             </Decorator_BeginTurn>
                         </Sequence>
                     </Objective>
                     <Reward Droplist="DroplistVenetians12" Picks="1"/>
                 </ObjectiveSet>
                 <ObjectiveSet>
-                    <Objective Name="Step2_4_Objective1">
+                    <Objective StartValue="$Step2_4_Objective1Val" EndValue="$Six" Name="Step2_4_Objective1">
                         <!-- TODO -->
                         <AIHint Category="Minimal" MinAutoResolutionTurn="45" MaxAutoResolutionTurn="60" AutoResolutionProbability="1" />
                         <!--MEOS-->
                         <Sequence>
                             <Decorator_BeginTurn>
-                                <Condition_HasDeposits Input_ResourceType="Luxury">
-                                    <Input_Empire VarName="$CurrentEmpire"/>
-                                    <Input_MinimumAmount VarName="$Six"/>
-                                </Condition_HasDeposits>
+                                <Condition_IsProgressionComplete>
+                                    <Input_Context VarName="$CurrentEmpire"/>
+                                    <Input_Expression VarName="$Step2_4_Objective1Expr"/>
+                                </Condition_IsProgressionComplete>
                             </Decorator_BeginTurn>
                         </Sequence>
                     </Objective>
@@ -1433,16 +1486,28 @@
             <Var VarName="$ResourceName07" StringValue="EmpireMoney"/>
             <Var VarName="$IncomeAmount01" IntValue="250"/>
             <Var VarName="$Ship"/>
-            <Var VarName="$PlanetType" StringValue="PlanetTypeDesert"/>     
+            <Var VarName="$PlanetType" StringValue="PlanetTypeDesert"/>
             <LocalizationVar LocalizationKey="$MinAmountName" Source="$MinAmountPlanet"/>
-            <Var VarName="$Six" IntValue="6"/>           
+            <Var VarName="$Six" IntValue="6"/>
             <LocalizationVar LocalizationKey="$IncomeAmountName" Source="$IncomeAmount"/>
             <LocalizationVar LocalizationKey="$SixName" Source="$Six"/>
             <LocalizationVar LocalizationKey="$FiveName" Source="$MinAmount"/>
+            <InterpretedVar VarName="$Step2_1_Objective1Val" Target="$(Empire)">
+                <Expression>Count(Context, @'ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet,PlanetTypeDesert')</Expression>
+            </InterpretedVar>
+            <Var VarName="$Step2_1_Objective1Expr" StringValue="Count(Context, @'ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet,PlanetTypeDesert')"/>
+            <InterpretedVar VarName="$Step2_2_Objective1Val" Target="$(Empire)">
+                <Expression>SumProperty(Context, @'ClassEmpire/DepartmentOfCommerce/ClassTradingCompany', EmpireResearch)</Expression>
+            </InterpretedVar>
+            <Var VarName="$Step2_2_Objective1Expr" StringValue="SumProperty(Context, @'ClassEmpire/DepartmentOfCommerce/ClassTradingCompany', EmpireResearch)"/>
+            <InterpretedVar VarName="$Step2_4_Objective1Val" Target="$(Empire)">
+                <Expression>Count(Context, @'ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet/ClassResourceDeposit,ResourceTypeLuxury')</Expression>
+            </InterpretedVar>
+            <Var VarName="$Step2_4_Objective1Expr" StringValue="Count(Context, @'ClassEmpire/ClassColonizedStarSystem/ClassColonizedPlanet/ClassResourceDeposit,ResourceTypeLuxury')"/>
         </Vars>
 
         <!--============ PREREQUISITE ============-->
-     
+
         <!--============ STEPS ============-->
         <Steps>
             <Step Name="Step1">
@@ -1454,24 +1519,23 @@
                     <ChoiceItem ObjectiveSetIndex="3"/>
                 </Choice>
                 <ObjectiveSet>
-                    <Objective Name="Step2_1_Objective1">
+                    <Objective StartValue="$Step2_1_Objective1Val" EndValue="$MinAmountPlanet" Name="Step2_1_Objective1">
                         <!-- TODO -->
                         <AIHint Category="Minimal" MinAutoResolutionTurn="45" MaxAutoResolutionTurn="60" AutoResolutionProbability="1" />
                         <!--OMOKOR-->
                         <Sequence>
                             <Decorator_BeginTurn>
-                                <Condition_HasPlanets>
-                                    <Input_EmpireOrSystem VarName="$CurrentEmpire"/>
-                                    <Input_MinimumAmount VarName="$MinAmountPlanet"/>
-                                    <Input_PlanetType VarName="$PlanetType"/>                                    
-                                </Condition_HasPlanets>
+                                <Condition_IsProgressionComplete>
+                                    <Input_Context VarName="$CurrentEmpire"/>
+                                    <Input_Expression VarName="$Step2_1_Objective1Expr"/>
+                                </Condition_IsProgressionComplete>
                             </Decorator_BeginTurn>
                         </Sequence>
                     </Objective>
                     <Reward Droplist="DroplistVenetians10" Picks="1"/>
                 </ObjectiveSet>
                 <ObjectiveSet>
-                    <Objective Name="Step2_2_Objective1">
+                    <Objective StartValue="$Step2_2_Objective1Val" EndValue="$IncomeAmount" Name="Step2_2_Objective1">
                         <!-- TODO -->
                         <AIHint Category="MaximizeTradeCompagny" Motivation="0.5">
                             <Resource>Science</Resource>
@@ -1479,11 +1543,10 @@
                         <!--ARRAKYO-->
                         <Sequence>
                             <Decorator_BeginTurn>
-                                <Condition_HasTradeIncome SummedAmount="true">
-                                    <Input_Empire VarName="$CurrentEmpire"/>
-                                    <Input_ResourceName VarName="$ResourceName00"/>
-                                    <Input_MinimumAmount VarName="$IncomeAmount"/>
-                                </Condition_HasTradeIncome>
+                                <Condition_IsProgressionComplete>
+                                    <Input_Context VarName="$CurrentEmpire"/>
+                                    <Input_Expression VarName="$Step2_2_Objective1Expr"/>
+                                </Condition_IsProgressionComplete>
                             </Decorator_BeginTurn>
                         </Sequence>
                     </Objective>
@@ -1533,18 +1596,18 @@
                     <Reward Droplist="DroplistVenetians12" Picks="1"/>
                 </ObjectiveSet>
                 <ObjectiveSet>
-                    <Objective Name="Step2_4_Objective1">
+                    <Objective StartValue="$Step2_4_Objective1Val" EndValue="$Six" Name="Step2_4_Objective1">
                         <!--MEOS LANCELLUM-->
                         <Sequence>
                             <Decorator_BeginTurn>
-                                <Condition_HasDeposits Input_ResourceType="Luxury">
-                                    <Input_Empire VarName="$CurrentEmpire"/>
-                                    <Input_MinimumAmount VarName="$Six"/>
-                                </Condition_HasDeposits>
-                            </Decorator_BeginTurn>                  
+                                <Condition_IsProgressionComplete>
+                                    <Input_Context VarName="$CurrentEmpire"/>
+                                    <Input_Expression VarName="$Step2_4_Objective1Expr"/>
+                                </Condition_IsProgressionComplete>
+                            </Decorator_BeginTurn>
                         </Sequence>
                     </Objective>
-                    <Reward Droplist="DroplistVenetians13" Picks="1"/>              
+                    <Reward Droplist="DroplistVenetians13" Picks="1"/>
                 </ObjectiveSet>
             </Step>
         </Steps>


### PR DESCRIPTION
This PR adds progress counters to a range of quests that don't have them in the vanilla game.

The basic patching strategy runs as follows:

1. Find a quest objective `{objective_name}` that does not have a progression counter, but whose "success" criterion may be expressed as `{interpreter_expression} >= {threshold_value}` 
2. Introduce `InterpretedVar` named `${objective_name}Val` defined as `{interpreter_expression}` (this will act as the initial value of the counter)
3. Introduce a regular `Var` named `${objective_name}Expr` defined to be the string value of `{interpreter_expression}` (this will be used to refresh the counter)
4. Replace whatever `<Condition_XXX>` block was leading to the `<Action_ChooseOutcome>` beforehand with `<Condition_IsProgressionComplete>` (this will refresh the value of the counter and progress if it passes the threshold)

Et voilà, the quest now has a progress counter. Some are more helpful than others, of course, but I'd venture all add a least a little bit of convenience.

I used a script to identify places where this pattern may be applied, which was the basis of my mod "More Quest Counters". This PR has most of those changes, but skips the quests that don't already have overrides in ESG (since they're a bit harder to review). I'll do the rest of them in a subsequent round, assuming no major objections to this one.