### PR TITLE
Light's March Madness 1

### DIFF
--- a/Endless Space Competitive Mod/GUI/GUIElements[CustomFactionTraits].xml
+++ b/Endless Space Competitive Mod/GUI/GUIElements[CustomFactionTraits].xml
@@ -39,97 +39,195 @@
     <Title>%CategoryTechnologyTraitTitle</Title>
   </GuiElement>
 
-  <!-- Starting planet -->
-  <GuiElement Name="FactionTraitHomePlanetPlanetTypeGasFrozen">
-    <Title>%FactionTraitHomePlanetPlanetTypeGasFrozenTitle</Title>
-    <Description>%FactionTraitHomePlanetPlanetTypeGasFrozenDescription</Description>
-    <Icons>
-      <Icon Size="Small" Path="Bitmaps\Atlased\Categories\CategoryPlanetImprovementSmall"/>
-    </Icons>
+  <!-- Starting planets with vanilla entries commented out -->
+<!-- 
+  <GuiElement Name="FactionTraitHomePlanetPlanetTypeAtoll">
+    <Title>%FactionTraitHomePlanetPlanetTypeAtollTitle</Title>
+    <Description>%FactionTraitHomePlanetPlanetTypeAtollDescription</Description>
+    <TooltipElement>
+      <EffectOverride>%FactionTraitHomePlanetPlanetTypeAtollTooltipEffect</EffectOverride>
+    </TooltipElement>
   </GuiElement>
-  <GuiElement Name="FactionTraitHomePlanetPlanetTypeBarren">
-    <Title>%FactionTraitHomePlanetPlanetTypeBarrenTitle</Title>
-    <Description>%FactionTraitHomePlanetPlanetTypeBarrenDescription</Description>
-    <Icons>
-      <Icon Size="Small" Path="Bitmaps\Atlased\Categories\CategoryPlanetImprovementSmall"/>
-    </Icons>
+  <GuiElement Name="FactionTraitHomePlanetPlanetTypeForest">
+    <Title>%FactionTraitHomePlanetPlanetTypeForestTitle</Title>
+    <Description>%FactionTraitHomePlanetPlanetTypeForestDescription</Description>
+    <TooltipElement>
+      <EffectOverride>%FactionTraitHomePlanetPlanetTypeForestTooltipEffect</EffectOverride>
+    </TooltipElement>
   </GuiElement>
-  <GuiElement Name="FactionTraitHomePlanetPlanetTypeIce">
-    <Title>%FactionTraitHomePlanetPlanetTypeIceTitle</Title>
-    <Description>%FactionTraitHomePlanetPlanetTypeIceDescription</Description>
-    <Icons>
-      <Icon Size="Small" Path="Bitmaps\Atlased\Categories\CategoryPlanetImprovementSmall"/>
-    </Icons>
+  <GuiElement Name="FactionTraitHomePlanetPlanetTypeTerran">
+    <Title>%FactionTraitHomePlanetPlanetTypeTerranTitle</Title>
+    <Description>%FactionTraitHomePlanetPlanetTypeTerranDescription</Description>
+    <TooltipElement>
+      <EffectOverride>%FactionTraitHomePlanetPlanetTypeTerranTooltipEffect</EffectOverride>
+    </TooltipElement>
   </GuiElement>
-  <GuiElement Name="FactionTraitHomePlanetPlanetTypeGasCold">
-    <Title>%FactionTraitHomePlanetPlanetTypeGasColdTitle</Title>
-    <Description>%FactionTraitHomePlanetPlanetTypeGasColdDescription</Description>
-    <Icons>
-      <Icon Size="Small" Path="Bitmaps\Atlased\Categories\CategoryPlanetImprovementSmall"/>
-    </Icons>
+  <GuiElement Name="FactionTraitHomePlanetPlanetTypeOcean">
+    <Title>%FactionTraitHomePlanetPlanetTypeOceanTitle</Title>
+      <Description>%FactionTraitHomePlanetPlanetTypeOceanDescription</Description>
+      <TooltipElement>
+        <EffectOverride>%FactionTraitHomePlanetPlanetTypeOceanTooltipEffect</EffectOverride>
+      </TooltipElement>
+  </GuiElement>
+
+  <GuiElement Name="FactionTraitHomePlanetPlanetTypeJungle">
+    <Title>%FactionTraitHomePlanetPlanetTypeJungleTitle</Title>
+      <Description>%FactionTraitHomePlanetPlanetTypeJungleDescription</Description>
+      <TooltipElement>
+        <EffectOverride>%FactionTraitHomePlanetPlanetTypeJungleTooltipEffect</EffectOverride>
+      </TooltipElement>
+  </GuiElement>
+  <GuiElement Name="FactionTraitHomePlanetPlanetTypeBoreal">
+    <Title>%FactionTraitHomePlanetPlanetTypeBorealTitle</Title>
+      <Description>%FactionTraitHomePlanetPlanetTypeBorealDescription</Description>
+      <TooltipElement>
+        <EffectOverride>%FactionTraitHomePlanetPlanetTypeBorealTooltipEffect</EffectOverride>
+      </TooltipElement>
+  </GuiElement>
+
+  <GuiElement Name="FactionTraitHomePlanetPlanetTypeTropical">
+    <Title>%FactionTraitHomePlanetPlanetTypeTropicalTitle</Title>
+      <Description>%FactionTraitHomePlanetPlanetTypeTropicalDescription</Description>
+      <TooltipElement>
+        <EffectOverride>%FactionTraitHomePlanetPlanetTypeTropicalTooltipEffect</EffectOverride>
+      </TooltipElement>
+  </GuiElement>
+  <GuiElement Name="FactionTraitHomePlanetPlanetTypeMonsoon">
+    <Title>%FactionTraitHomePlanetPlanetTypeMonsoonTitle</Title>
+      <Description>%FactionTraitHomePlanetPlanetTypeMonsoonDescription</Description>
+      <TooltipElement>
+        <EffectOverride>%FactionTraitHomePlanetPlanetTypeMonsoonTooltipEffect</EffectOverride>
+      </TooltipElement>
+  </GuiElement>
+  <GuiElement Name="FactionTraitHomePlanetPlanetTypeTundra">
+    <Title>%FactionTraitHomePlanetPlanetTypeTundraTitle</Title>
+      <Description>%FactionTraitHomePlanetPlanetTypeTundraDescription</Description>
+      <TooltipElement>
+        <EffectOverride>%FactionTraitHomePlanetPlanetTypeTundraTooltipEffect</EffectOverride>
+      </TooltipElement>
+  </GuiElement>
+
+  <GuiElement Name="FactionTraitHomePlanetPlanetTypeVeldt">
+    <Title>%FactionTraitHomePlanetPlanetTypeVeldtTitle</Title>
+      <Description>%FactionTraitHomePlanetPlanetTypeVeldtDescription</Description>
+      <TooltipElement>
+        <EffectOverride>%FactionTraitHomePlanetPlanetTypeVeldtTooltipEffect</EffectOverride>
+      </TooltipElement>
+  </GuiElement>
+  <GuiElement Name="FactionTraitHomePlanetPlanetTypeSteppes">
+    <Title>%FactionTraitHomePlanetPlanetTypeSteppesTitle</Title>
+      <Description>%FactionTraitHomePlanetPlanetTypeSteppesDescription</Description>
+      <TooltipElement>
+        <EffectOverride>%FactionTraitHomePlanetPlanetTypeSteppesTooltipEffect</EffectOverride>
+      </TooltipElement>
+  </GuiElement>
+
+  <GuiElement Name="FactionTraitHomePlanetPlanetTypeArid">
+    <Title>%FactionTraitHomePlanetPlanetTypeAridTitle</Title>
+      <Description>%FactionTraitHomePlanetPlanetTypeAridDescription</Description>
+      <TooltipElement>
+        <EffectOverride>%FactionTraitHomePlanetPlanetTypeAridTooltipEffect</EffectOverride>
+      </TooltipElement>
+  </GuiElement>
+  <GuiElement Name="FactionTraitHomePlanetPlanetTypeSnow">
+    <Title>%FactionTraitHomePlanetPlanetTypeSnowTitle</Title>
+      <Description>%FactionTraitHomePlanetPlanetTypeSnowDescription</Description>
+      <TooltipElement>
+        <EffectOverride>%FactionTraitHomePlanetPlanetTypeSnowTooltipEffect</EffectOverride>
+      </TooltipElement>
+  </GuiElement>
+-->
+  <GuiElement Name="FactionTraitHomePlanetPlanetTypeDesert">
+    <Title>%FactionTraitHomePlanetPlanetTypeDesertTitle</Title>
+    <Description>%FactionTraitHomePlanetPlanetTypeDesertDescription</Description>
+    <TooltipElement>
+      <EffectOverride>%FactionTraitHomePlanetPlanetTypeDesertTooltipEffect</EffectOverride>
+    </TooltipElement>
   </GuiElement>
   <GuiElement Name="FactionTraitHomePlanetPlanetTypeArctic">
     <Title>%FactionTraitHomePlanetPlanetTypeArcticTitle</Title>
     <Description>%FactionTraitHomePlanetPlanetTypeArcticDescription</Description>
-    <Icons>
-      <Icon Size="Small" Path="Bitmaps\Atlased\Categories\CategoryPlanetImprovementSmall"/>
-    </Icons>
   </GuiElement>
-  <GuiElement Name="FactionTraitHomePlanetPlanetTypeGasTemperate">
-    <Title>%FactionTraitHomePlanetPlanetTypeGasTemperateTitle</Title>
-    <Description>%FactionTraitHomePlanetPlanetTypeGasTemperateDescription</Description>
-    <Icons>
-      <Icon Size="Small" Path="Bitmaps\Atlased\Categories\CategoryPlanetImprovementSmall"/>
-    </Icons>
+
+  <GuiElement Name="FactionTraitHomePlanetPlanetTypeAsh">
+    <Title>%FactionTraitHomePlanetPlanetTypeAshTitle</Title>
+    <Description>%FactionTraitHomePlanetPlanetTypeAshDescription</Description>
+    <TooltipElement>
+      <EffectOverride>%FactionTraitHomePlanetPlanetTypeAshTooltipEffect</EffectOverride>
+    </TooltipElement>
   </GuiElement>
+
   <GuiElement Name="FactionTraitHomePlanetPlanetTypeSwamp">
     <Title>%FactionTraitHomePlanetPlanetTypeSwampTitle</Title>
     <Description>%FactionTraitHomePlanetPlanetTypeSwampDescription</Description>
-    <Icons>
-      <Icon Size="Small" Path="Bitmaps\Atlased\Categories\CategoryPlanetImprovementSmall"/>
-    </Icons>
+    <TooltipElement>
+      <EffectOverride>%FactionTraitHomePlanetPlanetTypeSwampTooltipEffect</EffectOverride>
+    </TooltipElement>
   </GuiElement>
-  <GuiElement Name="FactionTraitHomePlanetPlanetTypeGasWarm">
-    <Title>%FactionTraitHomePlanetPlanetTypeGasWarmTitle</Title>
-    <Description>%FactionTraitHomePlanetPlanetTypeGasWarmDescription</Description>
-    <Icons>
-      <Icon Size="Small" Path="Bitmaps\Atlased\Categories\CategoryPlanetImprovementSmall"/>
-    </Icons>
+  <GuiElement Name="FactionTraitHomePlanetPlanetTypeIce">
+    <Title>%FactionTraitHomePlanetPlanetTypeIceTitle</Title>
+    <Description>%FactionTraitHomePlanetPlanetTypeIceDescription</Description>
+    <TooltipElement>
+      <EffectOverride>%FactionTraitHomePlanetPlanetTypeIceTooltipEffect</EffectOverride>
+    </TooltipElement>
   </GuiElement>
-  <GuiElement Name="FactionTraitHomePlanetPlanetTypeDesert">
-    <Title>%FactionTraitHomePlanetPlanetTypeDesertTitle</Title>
-    <Description>%FactionTraitHomePlanetPlanetTypeDesertDescription</Description>
-    <Icons>
-      <Icon Size="Small" Path="Bitmaps\Atlased\Categories\CategoryPlanetImprovementSmall"/>
-    </Icons>
+
+  <GuiElement Name="FactionTraitHomePlanetPlanetTypeLava">
+    <Title>%FactionTraitHomePlanetPlanetTypeLavaTitle</Title>
+    <Description>%FactionTraitHomePlanetPlanetTypeLavaDescription</Description>
+    <TooltipElement>
+      <EffectOverride>%FactionTraitHomePlanetPlanetTypeLavaTooltipEffect</EffectOverride>
+    </TooltipElement>
+  </GuiElement>
+  <GuiElement Name="FactionTraitHomePlanetPlanetTypeBarren">
+    <Title>%FactionTraitHomePlanetPlanetTypeBarrenTitle</Title>
+    <Description>%FactionTraitHomePlanetPlanetTypeBarrenDescription</Description>
+    <TooltipElement>
+      <EffectOverride>%FactionTraitHomePlanetPlanetTypeBarrenTooltipEffect</EffectOverride>
+    </TooltipElement>
+  </GuiElement>
+
+  <GuiElement Name="FactionTraitHomePlanetPlanetTypeGasBurning">
+    <Title>%FactionTraitHomePlanetPlanetTypeGasBurningTitle</Title>
+    <Description>%FactionTraitHomePlanetPlanetTypeGasBurningDescription</Description>
+    <TooltipElement>
+      <EffectOverride>%FactionTraitHomePlanetPlanetTypeGasBurningTooltipEffect</EffectOverride>
+    </TooltipElement>
   </GuiElement>
   <GuiElement Name="FactionTraitHomePlanetPlanetTypeGasHot">
     <Title>%FactionTraitHomePlanetPlanetTypeGasHotTitle</Title>
     <Description>%FactionTraitHomePlanetPlanetTypeGasHotDescription</Description>
-    <Icons>
-      <Icon Size="Small" Path="Bitmaps\Atlased\Categories\CategoryPlanetImprovementSmall"/>
-    </Icons>
+    <TooltipElement>
+      <EffectOverride>%FactionTraitHomePlanetPlanetTypeGasHotTooltipEffect</EffectOverride>
+    </TooltipElement>
   </GuiElement>
-  <GuiElement Name="FactionTraitHomePlanetPlanetTypeAsh">
-    <Title>%FactionTraitHomePlanetPlanetTypeAshTitle</Title>
-    <Description>%FactionTraitHomePlanetPlanetTypeAshDescription</Description>
-    <Icons>
-      <Icon Size="Small" Path="Bitmaps\Atlased\Categories\CategoryPlanetImprovementSmall"/>
-    </Icons>
+  <GuiElement Name="FactionTraitHomePlanetPlanetTypeGasWarm">
+    <Title>%FactionTraitHomePlanetPlanetTypeGasWarmTitle</Title>
+    <Description>%FactionTraitHomePlanetPlanetTypeGasWarmDescription</Description>
+    <TooltipElement>
+      <EffectOverride>%FactionTraitHomePlanetPlanetTypeGasWarmTooltipEffect</EffectOverride>
+    </TooltipElement>
   </GuiElement>
-  <GuiElement Name="FactionTraitHomePlanetPlanetTypeLava">
-    <Title>%FactionTraitHomePlanetPlanetTypeLavaTitle</Title>
-    <Description>%FactionTraitHomePlanetPlanetTypeLavaDescription</Description>
-    <Icons>
-      <Icon Size="Small" Path="Bitmaps\Atlased\Categories\CategoryPlanetImprovementSmall"/>
-    </Icons>
+  <GuiElement Name="FactionTraitHomePlanetPlanetTypeGasTemperate">
+    <Title>%FactionTraitHomePlanetPlanetTypeGasTemperateTitle</Title>
+    <Description>%FactionTraitHomePlanetPlanetTypeGasTemperateDescription</Description>
+    <TooltipElement>
+      <EffectOverride>%FactionTraitHomePlanetPlanetTypeGasTemperateTooltipEffect</EffectOverride>
+    </TooltipElement>
   </GuiElement>
-  <GuiElement Name="FactionTraitHomePlanetPlanetTypeGasBurning">
-    <Title>%FactionTraitHomePlanetPlanetTypeGasBurningTitle</Title>
-    <Description>%FactionTraitHomePlanetPlanetTypeGasBurningDescription</Description>
-    <Icons>
-      <Icon Size="Small" Path="Bitmaps\Atlased\Categories\CategoryPlanetImprovementSmall"/>
-    </Icons>
+  <GuiElement Name="FactionTraitHomePlanetPlanetTypeGasCold">
+    <Title>%FactionTraitHomePlanetPlanetTypeGasColdTitle</Title>
+    <Description>%FactionTraitHomePlanetPlanetTypeGasColdDescription</Description>
+    <TooltipElement>
+      <EffectOverride>%FactionTraitHomePlanetPlanetTypeGasColdTooltipEffect</EffectOverride>
+    </TooltipElement>
+  </GuiElement>
+  <GuiElement Name="FactionTraitHomePlanetPlanetTypeGasFrozen">
+    <Title>%FactionTraitHomePlanetPlanetTypeGasFrozenTitle</Title>
+    <Description>%FactionTraitHomePlanetPlanetTypeGasFrozenDescription</Description>
+    <TooltipElement>
+      <EffectOverride>%FactionTraitHomePlanetPlanetTypeGasFrozenTooltipEffect</EffectOverride>
+    </TooltipElement>
   </GuiElement>
 
   <!-- Starting Major Population -->

--- a/Endless Space Competitive Mod/Localization/english/ES2_Localization_1-5-3.xml
+++ b/Endless Space Competitive Mod/Localization/english/ES2_Localization_1-5-3.xml
@@ -97,4 +97,251 @@ This Improvement is destroyed instead of the System
   <LocalizationPair Name="%FactionTraitColonizeAnywhereTitle">Unbound by Flesh</LocalizationPair>
   <LocalizationPair Name="%FactionTraitColonizeAnywhereDescription">Physical constraints mean little to a people unbound by flesh. They can establish a foothold on any world, though without proper adaptation, such installations remain inert and unproductive.</LocalizationPair>
   <LocalizationPair Name="%FactionTraitColonizeAnywhereEffectOverride">Can colonize any planet, but with a -100% [FIDS] penalty without the appropriate colonization technology</LocalizationPair>
+  
+  <!--Homeworlds here in FIDS order by size & happiness would cause Ice Lava Barren and Swamp entries to bug-->
+<!--
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeLavaTitle">Lava</LocalizationPair>
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeAtollTooltipEffect">8 [population] slots at Medium size
++8 [foodColored] per [population]
++6 [industryColored] per [population]
++4 [dustColored] per [population]
++2 [scienceColored] per [population]
+-0 [happinessColored] per [population]</LocalizationPair>
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeForestTooltipEffect">8 [population] slots at Medium size
++8 [foodColored] per [population]
++5 [industryColored] per [population]
++4 [dustColored] per [population]
++3 [scienceColored] per [population]
+-0 [happinessColored] per [population]</LocalizationPair>
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeTerranTooltipEffect">8 [population] slots at Medium size
++8 [foodColored] per [population]
++3 [industryColored] per [population]
++4 [dustColored] per [population]
++5 [scienceColored] per [population]
+-0 [happinessColored] per [population]</LocalizationPair>
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeOceanTooltipEffect">8 [population] slots at Medium size
++8 [foodColored] per [population]
++2 [industryColored] per [population]
++4 [dustColored] per [population]
++6 [scienceColored] per [population]
+-0 [happinessColored] per [population]</LocalizationPair>
+
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeJungleTooltipEffect">7 [population] slots at Medium size
++7 [foodColored] per [population]
++8 [industryColored] per [population]
++5 [dustColored] per [population]
++0 [scienceColored] per [population]</LocalizationPair>
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeBorealTooltipEffect">7 [population] slots at Medium size
++7 [foodColored] per [population]
++0 [industryColored] per [population]
++5 [dustColored] per [population]
++8 [scienceColored] per [population]
+-0 [happinessColored] per [population]</LocalizationPair>
+
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeTropicalTooltipEffect">7 [population] slots at Medium size
++6 [foodColored] per [population]
++7 [industryColored] per [population]
++5 [dustColored] per [population]
++2 [scienceColored] per [population]
+-1 [happinessColored] per [population]</LocalizationPair>
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeMonsoonTooltipEffect">7 [population] slots at Medium size
++6 [foodColored] per [population]
++2 [industryColored] per [population]
++10 [dustColored] per [population]
++2 [scienceColored] per [population]
+-1 [happinessColored] per [population]</LocalizationPair>
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeTundraTooltipEffect">7 [population] slots at Medium size
++6 [foodColored] per [population]
++2 [industryColored] per [population]
++5 [dustColored] per [population]
++7 [scienceColored] per [population]
+-1 [happinessColored] per [population]</LocalizationPair>
+
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeVeldtTooltipEffect">7 [population] slots at Medium size
++4 [foodColored] per [population]
++3 [industryColored] per [population]
++12 [dustColored] per [population]
++1 [scienceColored] per [population]
+-1 [happinessColored] per [population]</LocalizationPair>
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeSteppesTooltipEffect">7 [population] slots at Medium size
++4 [foodColored] per [population]
++1 [industryColored] per [population]
++12 [dustColored] per [population]
++3 [scienceColored] per [population]
+-1 [happinessColored] per [population]</LocalizationPair>
+
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeAridTooltipEffect">5 [population] slots at Medium size
++4 [foodColored] per [population]
++8 [industryColored] per [population]
++4 [dustColored] per [population]
++2 [scienceColored] per [population]
+-3 [happinessColored] per [population]</LocalizationPair>
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeSnowTooltipEffect">5 [population] slots at Medium size
++4 [foodColored] per [population]
++2 [industryColored] per [population]
++4 [dustColored] per [population]
++8 [scienceColored] per [population]
+-3 [happinessColored] per [population]</LocalizationPair>
+
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeDesertTooltipEffect">5 [population] slots at Medium size
++2 [foodColored] per [population]
++10 [industryColored] per [population]
++7 [dustColored] per [population]
++1 [scienceColored] per [population]
+-3 [happinessColored] per [population]</LocalizationPair>
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeArcticTooltipEffect">5 [population] slots at Medium size
++2 [foodColored] per [population]
++1 [industryColored] per [population]
++7 [dustColored] per [population]
++10 [scienceColored] per [population]
+-3 [happinessColored] per [population]</LocalizationPair>
+
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeAshTooltipEffect">4 [population] slots at Medium size
++1 [foodColored] per [population]
++12 [industryColored] per [population]
++6 [dustColored] per [population]
++1 [scienceColored] per [population]
+-5 [happinessColored] per [population]</LocalizationPair>
+
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeSwampTooltipEffect">4 [population] slots at Medium size
++2 [foodColored] per [population]
++2 [industryColored] per [population]
++16 [dustColored] per [population]
++2 [scienceColored] per [population]
+-5 [happinessColored] per [population]</LocalizationPair>
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeIceTooltipEffect">4 [population] slots at Medium size
++1 [foodColored] per [population]
++1 [industryColored] per [population]
++6 [dustColored] per [population]
++12 [scienceColored] per [population]
+-5 [happinessColored] per [population]</LocalizationPair>
+
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeLavaTooltipEffect">3 [population] slots at Medium size
++0 [foodColored] per [population]
++16 [industryColored] per [population]
++4 [dustColored] per [population]
++0 [scienceColored] per [population]
+-8 [happinessColored] per [population]</LocalizationPair>
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeBarrenTooltipEffect">3 [population] slots at Medium size
++0 [foodColored] per [population]
++0 [industryColored] per [population]
++4 [dustColored] per [population]
++16 [scienceColored] per [population]
+-8 [happinessColored] per [population]</LocalizationPair>
+
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeGasBurningTooltipEffect">1 [population] slot at Medium or Large size
++0 [foodColored] per [population]
++30 [industryColored] per [population]
++0 [dustColored] per [population]
++0 [scienceColored] per [population]
+-5 [happinessColored] per [population]</LocalizationPair>
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeGasHotTooltipEffect">1 [population] slot at Medium or Large size
++0 [foodColored] per [population]
++15 [industryColored] per [population]
++15 [dustColored] per [population]
++0 [scienceColored] per [population]
+-5 [happinessColored] per [population]</LocalizationPair>
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeWarmHotTooltipEffect">1 [population] slot at Medium or Large size
++0 [foodColored] per [population]
++10 [industryColored] per [population]
++10 [dustColored] per [population]
++10 [scienceColored] per [population]
+-5 [happinessColored] per [population]</LocalizationPair>
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeGasTemperateTooltipEffect">1 [population] slot at Medium or Large size
++0 [foodColored] per [population]
++0 [industryColored] per [population]
++30 [dustColored] per [population]
++0 [scienceColored] per [population]
+-5 [happinessColored] per [population]</LocalizationPair>
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeGasColdTooltipEffect">1 [population] slot at Medium or Large size
++0 [foodColored] per [population]
++0 [industryColored] per [population]
++15 [dustColored] per [population]
++15 [scienceColored] per [population]
+-5 [happinessColored] per [population]</LocalizationPair>
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeGasFrozenTooltipEffect">1 [population] slot at Medium or Large size
++0 [foodColored] per [population]
++0 [industryColored] per [population]
++0 [dustColored] per [population]
++30 [scienceColored] per [population]
+-5 [happinessColored] per [population]</LocalizationPair>
+
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeAtollTitle">Atoll</LocalizationPair>
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeAtollDescription">Coral chains stretching for thousands of kilometers in ringed and spiral formations create countless shallow lagoons where microcosms of evolution play out--and provide ample easy fishing. Sometimes it really is literally shooting fish in a barrel.</LocalizationPair>
+
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeForestTitle">Forest</LocalizationPair>
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeForestDescription">Trees, glorious trees. Every scrap of earth colonized by the woody specimens, from rubber-producing sapwoods to iron-barked behemoths. Fuel, shelter, food, and an ecologist's wet dream—there are few worlds that can match these planets for broad appeal.</LocalizationPair>
+
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeTerranTitle">Terran</LocalizationPair>
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeTerranDescription">A crucible for the development of life in all its myriad forms, this planet is a world of roiling oceans, vast grasslands, teeming forests, and a restless climate. With hail and rain, sunshine and wind, most species find this world very accommodating.</LocalizationPair>
+
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeOceanTitle">Ocean</LocalizationPair>
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeOceanDescription">Rich in life and in oxygen and atmosphere, an ocean planet teems with possibility. There are innumerable sources of food in the plants and animals of the oceanic biosphere, and tides and waves provide a ready source of energy.</LocalizationPair></LocalizationPair>
+
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeJungleTitle">Jungle</LocalizationPair>
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeJungleDescription">A sweltering, humid cauldron of a planet blanketed in thick rainforest alive with danger--and opportunity. Everything grows in excess, the planet a fecund source of food and predators, set against a backdrop of blazing-skied thunderstorms.</LocalizationPair>
+
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeBorealTitle">Boreal</LocalizationPair>
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeBorealDescription">Typified by dense magnetic cores of molten iron, boreal planets allow scientists to explore a range of atmospheric, electromagnetic, and cosmic ray interactions in a chilly climate. Expect hardwoods and shaggy-haired mammals.</LocalizationPair>
+
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeTropicalTitle">Mediterranean</LocalizationPair>
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeTropicalDescription">A hot and humid crucible of a hundred thousand archipelagos in a shining sea, Mediterranean worlds harbor golden-sanded bays, dense rainforests, and hydrothermal vents belching cascades of rare metals. Come for the adventures, stay for the standard of living.</LocalizationPair></LocalizationPair>
+
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeMonsoonTitle">Monsoon</LocalizationPair>
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeMonsoonDescription">No rain for most of the year, and then an absolute deluge for days upon days upon days. Wreaks havoc on transportation networks. Plants love it though, and apparently even higher-lifeforms do, given the inflated fertility rates. Guess there's not much else to do when it rains for days.</LocalizationPair>
+
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeTundraTitle">Tundra</LocalizationPair>
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeTundraDescription">Somewhat dry and rather chilly, Tundra planets are nevertheless useful destinations for colonization. A wealth of scientific discovery, from thermodynamic studies to hardy plants and animals, waits the intrepid explorer, as do sources of wind and geothermal power for industry.</LocalizationPair>
+
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeAridTitle">Arid</LocalizationPair>
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeAridDescription">What little water this planet holds is jealousy guarded in spine-covered gorse, hidden underground lakes, and rare storm clouds, but overcome the constant feeling of thirst, and you will find a planet rich in possibilities.</LocalizationPair>
+
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeVeldtTitle">Savannah</LocalizationPair>
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeVeldtDescription">One of the most life-friendly worlds around, Savannahs cradle many diverse ecosystems from verdant grasslands to hardy scrub to thin forests, and can support many uses. As regional breadbaskets, industrial bases, centers of science, and even Dust mining sites, Savannah planets encourage brisk population growth.</LocalizationPair>
+
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeSteppesTitle">Steppes</LocalizationPair>
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeSteppesDescription">A world of rolling grasslands, this planet offers limited opportunities for farming on account of its poor soils and low rainfall. However, these worlds offer decent Dust yields, a result of a little understood biochemical process of the hardy grasses. Cud-chewers tend to make the most content settlers.</LocalizationPair>
+
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeSnowTitle">Snow</LocalizationPair>
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeSnowDescription">Temperate enough for water to shuttle between its solid and liquid forms, a snow world is nonetheless pretty blinking cold. Crop yields are decent with the correct seedlines, but the biggest boon of these planets is their ability to inspire scientific thinking. Perhaps it's the snowflakes.</LocalizationPair>
+
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeDesertTitle">Desert</LocalizationPair>
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeDesertDescription">Most life finds it a struggle to plant roots into the dry, shifting sands of the earth of this planet, but for the tenacious species who do, they will find a stark beauty to the world. With relatively little rainfall, erosion and decay are minimal, giving longevity to any civilization's constructions.</LocalizationPair>
+
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeArcticTitle">Arctic</LocalizationPair>
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeArcticDescription">Icy-cold with hard-packed snows that last fell a million years past, this planet is a windswept, wintry graveyard. Those that hope to exploit this planet's natural wealth should steel themselves for hardship.</LocalizationPair>
+
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeAshTitle">Ash</LocalizationPair>
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeAshDescription">Millennia of volcanic activity have coated the surface with layer upon layer of fine ash, leading to vast lakes of soft charcoal--and rich mineral deposits. Industry-heads love these worlds. Their workers? Not so much. Fierce winds blow the ash skywards, creating surreal blizzards, and terrible living conditions.</LocalizationPair>
+
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeSwampTitle">Swamp</LocalizationPair>
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeSwampDescription">Favored by monsters and hermits, toxic worlds offer fetid bogs, thick mists, and decent yields of methane gas. Less widely known, however, is their capacity for producing incredible crops of funky, yet still edible, fungi, due to the perfect conditions of moisture and mulch.</LocalizationPair>
+
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeIceTitle">Ice</LocalizationPair>
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeIceDescription">Water, the miracle molecule, proves itself once again a god among its chemical brethren on ice worlds. Once researched, a mix of hydroponic and cryogenic technologies enables these icy, unchanging wastelands to become super breadbaskets, capable of feeding trillions.</LocalizationPair>
+
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeLavaTitle">Lava</LocalizationPair>
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeLavaDescription">Though often unstable and not always pleasant to live on, the very substance of lava planets makes them a rich source of revenues and industry. Metals and unusual geologies are created in the heart of these roiling planets, and wealth and practical applications await those who harvest them.</LocalizationPair>
+
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeBarrenTitle">Barren</LocalizationPair>
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeBarrenDescription">A harsh, unforgiving landscape of desolate plains and vast mountain ranges, the lack of water together with the freezing temperatures make this planet doubly difficult to exploit. But exploit it, species will. The world might lack atmosphere, literally, but as a place for research it is second to none.</LocalizationPair>
+
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeGasBurningTitle">Gas Burning</LocalizationPair>
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeGasBurningDescription">In a different life, this planet would've leapt on the path to full starhood. A little closer to the igniting heat of a companion sun, a little more gravitation, a passing nebulae, and this place could've been a photon factory. Still, industry loves these planets and their furnace-like conditions.</LocalizationPair>
+
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeGasHotTitle">Gas Hot</LocalizationPair>
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeGasHotDescription">Devoid of any life, this world is a scorching hellhole of fiery winds and molten lakes. Expect any residents to feel aggrieved at the hand life has dealt them, but as an industrial base it cannot be beaten.</LocalizationPair>
+
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeGasWarmTitle">Gas Warm</LocalizationPair>
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeGasWarmDescription">Incredible sunsets the brochure says, failing to mention the methane rain, toxic clouds, and a hundred other lethal aspects. Dust deposits are off the charts though, so fortunes can be made.</LocalizationPair>
+
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeGasTemperateTitle">Gas Temperate</LocalizationPair>
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeGasTemperateDescription">Occupying a Dust "goldilocks" zone, temperate gas worlds are an incredible source of the near-magical substance--if you've got the tech to survive on a surface that makes quicksand seem like a safe bet for walking on. Leave the kids at home if you visit.</LocalizationPair>
+
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeGasColdTitle">Gas Cold</LocalizationPair>
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeGasColdDescription">Positively mild compared to their frozen gas siblings, these worlds are nonetheless only a hundred or so degrees above absolute zero, and contain all manner of weird and wonderful chemistry from rivers of liquid nitrogen to lakes of methane. Nerd heaven.</LocalizationPair>
+
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeGasFrozenTitle">Gas Frozen</LocalizationPair>
+  <LocalizationPair Name="%FactionTraitHomePlanetPlanetTypeGasFrozenDescription">Utterly inhospitable, these planets are so cold that even the air has frozen, rendering them without even the most scant of atmospheres to cover their nakedness. Staying alive, never mind, living, is a huge challenge, but the scientific insights more than make up for the hardship.</LocalizationPair>
+-->
 </Datatable>

--- a/Endless Space Competitive Mod/Localization/english/ES2_Localization_Assets_Locales.xml
+++ b/Endless Space Competitive Mod/Localization/english/ES2_Localization_Assets_Locales.xml
@@ -1,0 +1,199 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Datatable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <LocalizationPair Name="%PlanetTypeAtollDescription">Coral chains stretching for thousands of kilometers in ringed and spiral formations create countless shallow lagoons where microcosms of evolution play out--and provide ample easy fishing. Sometimes it really is literally shooting fish in a barrel.
+
+8 [population] slots at Medium size
++8 [foodColored] per [population]
++6 [industryColored] per [population]
++4 [dustColored] per [population]
++2 [scienceColored] per [population]
+-0 [happinessColored] per [population]</LocalizationPair>
+  <LocalizationPair Name="%PlanetTypeForestDescription">Trees, glorious trees. Every scrap of earth colonized by the woody specimens, from rubber-producing sapwoods to iron-barked behemoths. Fuel, shelter, food, and an ecologist's wet dream—there are few worlds that can match these planets for broad appeal.
+
+8 [population] slots at Medium size
++8 [foodColored] per [population]
++5 [industryColored] per [population]
++4 [dustColored] per [population]
++3 [scienceColored] per [population]
+-0 [happinessColored] per [population]</LocalizationPair>
+  <LocalizationPair Name="%PlanetTypeTerranDescription">A crucible for the development of life in all its myriad forms, this planet is a world of roiling oceans, vast grasslands, teeming forests, and a restless climate. With hail and rain, sunshine and wind, most species find this world very accommodating.
+
+8 [population] slots at Medium size
++8 [foodColored] per [population]
++6 [industryColored] per [population]
++4 [dustColored] per [population]
++2 [scienceColored] per [population]
+-0 [happinessColored] per [population]</LocalizationPair>
+  <LocalizationPair Name="%PlanetTypeOceanDescription">Rich in life and in oxygen and atmosphere, an ocean planet teems with possibility. There are innumerable sources of food in the plants and animals of the oceanic biosphere, and tides and waves provide a ready source of energy.
+
+8 [population] slots at Medium size
++8 [foodColored] per [population]
++2 [industryColored] per [population]
++4 [dustColored] per [population]
++6 [scienceColored] per [population]
+-0 [happinessColored] per [population]</LocalizationPair>
+
+  <LocalizationPair Name="%PlanetTypeJungleDescription">A sweltering, humid cauldron of a planet blanketed in thick rainforest alive with danger--and opportunity. Everything grows in excess, the planet a fecund source of food and predators, set against a backdrop of blazing-skied thunderstorms.
+
+7 [population] slots at Medium size
++7 [foodColored] per [population]
++8 [industryColored] per [population]
++5 [dustColored] per [population]
++0 [scienceColored] per [population]</LocalizationPair>
+  <LocalizationPair Name="%PlanetTypeBorealDescription">Typified by dense magnetic cores of molten iron, boreal planets allow scientists to explore a range of atmospheric, electromagnetic, and cosmic ray interactions in a chilly climate. Expect hardwoods and shaggy-haired mammals.
+
+7 [population] slots at Medium size
++7 [foodColored] per [population]
++0 [industryColored] per [population]
++5 [dustColored] per [population]
++8 [scienceColored] per [population]
+-0 [happinessColored] per [population]</LocalizationPair>
+
+  <LocalizationPair Name="%PlanetTypeTropicalDescription">A hot and humid crucible of a hundred thousand archipelagos in a shining sea, Mediterranean worlds harbor golden-sanded bays, dense rainforests, and hydrothermal vents belching cascades of rare metals. Come for the adventures, stay for the standard of living.
+
+7 [population] slots at Medium size
++6 [foodColored] per [population]
++7 [industryColored] per [population]
++5 [dustColored] per [population]
++2 [scienceColored] per [population]</LocalizationPair>
+  <LocalizationPair Name="%PlanetTypeMonsoonDescription">No rain for most of the year, and then an absolute deluge for days upon days upon days. Wreaks havoc on transportation networks. Plants love it though, and apparently even higher-lifeforms do, given the inflated fertility rates. Guess there's not much else to do when it rains for days.
+
+7 [population] slots at Medium size
++6 [foodColored] per [population]
++2 [industryColored] per [population]
++10 [dustColored] per [population]
++2 [scienceColored] per [population]</LocalizationPair>
+  <LocalizationPair Name="%PlanetTypeTundraDescription">Somewhat dry and rather chilly, Tundra planets are nevertheless useful destinations for colonization. A wealth of scientific discovery, from thermodynamic studies to hardy plants and animals, waits the intrepid explorer, as do sources of wind and geothermal power for industry.
+
+7 [population] slots at Medium size
++6 [foodColored] per [population]
++2 [industryColored] per [population]
++5 [dustColored] per [population]
++7 [scienceColored] per [population]</LocalizationPair>
+
+  <LocalizationPair Name="%PlanetTypeVeldtDescription">One of the most life-friendly worlds around, Savannahs cradle many diverse ecosystems from verdant grasslands to hardy scrub to thin forests, and can support many uses. As regional breadbaskets, industrial bases, centers of science, and even Dust mining sites, Savannah planets encourage brisk population growth.
+
+7 [population] slots at Medium size
++4 [foodColored] per [population]
++3 [industryColored] per [population]
++12 [dustColored] per [population]
++1 [scienceColored] per [population]</LocalizationPair>
+  <LocalizationPair Name="%PlanetTypeSteppesDescription">A world of rolling grasslands, this planet offers limited opportunities for farming on account of its poor soils and low rainfall. However, these worlds offer decent Dust yields, a result of a little understood biochemical process of the hardy grasses. Cud-chewers tend to make the most content settlers.
+
+7 [population] slots at Medium size
++4 [foodColored] per [population]
++1 [industryColored] per [population]
++12 [dustColored] per [population]
++3 [scienceColored] per [population]</LocalizationPair>
+
+  <LocalizationPair Name="%PlanetTypeAridDescription">What little water this planet holds is jealousy guarded in spine-covered gorse, hidden underground lakes, and rare storm clouds, but overcome the constant feeling of thirst, and you will find a planet rich in possibilities.
+
+5 [population] slots at Medium size
++4 [foodColored] per [population]
++8 [industryColored] per [population]
++4 [dustColored] per [population]
++2 [scienceColored] per [population]</LocalizationPair>
+  <LocalizationPair Name="%PlanetTypeSnowDescription">Temperate enough for water to shuttle between its solid and liquid forms, a snow world is nonetheless pretty blinking cold. Crop yields are decent with the correct seedlines, but the biggest boon of these planets is their ability to inspire scientific thinking. Perhaps it's the snowflakes.
+
+5 [population] slots at Medium size
++4 [foodColored] per [population]
++2 [industryColored] per [population]
++4 [dustColored] per [population]
++8 [scienceColored] per [population]</LocalizationPair>
+
+  <LocalizationPair Name="%PlanetTypeDesertDescription">Most life finds it a struggle to plant roots into the dry, shifting sands of the earth of this planet, but for the tenacious species who do, they will find a stark beauty to the world. With relatively little rainfall, erosion and decay are minimal, giving longevity to any civilization's constructions.
+
+5 [population] slots at Medium size
++2 [foodColored] per [population]
++10 [industryColored] per [population]
++7 [dustColored] per [population]
++1 [scienceColored] per [population]</LocalizationPair>
+  <LocalizationPair Name="%PlanetTypeArcticDescription">Icy-cold with hard-packed snows that last fell a million years past, this planet is a windswept, wintry graveyard. Those that hope to exploit this planet's natural wealth should steel themselves for hardship.
+
+5 [population] slots at Medium size
++2 [foodColored] per [population]
++1 [industryColored] per [population]
++7 [dustColored] per [population]
++10 [scienceColored] per [population]</LocalizationPair>
+
+  <LocalizationPair Name="%PlanetTypeAshDescription">Millennia of volcanic activity have coated the surface with layer upon layer of fine ash, leading to vast lakes of soft charcoal--and rich mineral deposits. Industry-heads love these worlds. Their workers? Not so much. Fierce winds blow the ash skywards, creating surreal blizzards, and terrible living conditions.
+
+4 [population] slots at Medium size
++1 [foodColored] per [population]
++12 [industryColored] per [population]
++6 [dustColored] per [population]
++1 [scienceColored] per [population]</LocalizationPair>
+  <LocalizationPair Name="%PlanetTypeSwampDescription">Favored by monsters and hermits, toxic worlds offer fetid bogs, thick mists, and decent yields of methane gas. Less widely known, however, is their capacity for producing incredible crops of funky, yet still edible, fungi, due to the perfect conditions of moisture and mulch.
+
+4 [population] slots at Medium size
++2 [foodColored] per [population]
++2 [industryColored] per [population]
++16 [dustColored] per [population]
++2 [scienceColored] per [population]</LocalizationPair>
+  <LocalizationPair Name="%PlanetTypeIceDescription">Water, the miracle molecule, proves itself once again a god among its chemical brethren on ice worlds. Once researched, a mix of hydroponic and cryogenic technologies enables these icy, unchanging wastelands to become super breadbaskets, capable of feeding trillions.
+
+4 [population] slots at Medium size
++1 [foodColored] per [population]
++1 [industryColored] per [population]
++6 [dustColored] per [population]
++12 [scienceColored] per [population]</LocalizationPair>
+
+  <LocalizationPair Name="%PlanetTypeLavaDescription">Though often unstable and not always pleasant to live on, the very substance of lava planets makes them a rich source of revenues and industry. Metals and unusual geologies are created in the heart of these roiling planets, and wealth and practical applications await those who harvest them.
+
+3 [population] slots at Medium size
++0 [foodColored] per [population]
++16 [industryColored] per [population]
++4 [dustColored] per [population]
++0 [scienceColored] per [population]</LocalizationPair>
+  <LocalizationPair Name="%PlanetTypeBarrenDescription">A harsh, unforgiving landscape of desolate plains and vast mountain ranges, the lack of water together with the freezing temperatures make this planet doubly difficult to exploit. But exploit it, species will. The world might lack atmosphere, literally, but as a place for research it is second to none.
+
+3 [population] slots at Medium size
++0 [foodColored] per [population]
++0 [industryColored] per [population]
++4 [dustColored] per [population]
++16 [scienceColored] per [population]</LocalizationPair>
+
+  <LocalizationPair Name="%PlanetTypeGasBurningDescription">In a different life, this planet would've leapt on the path to full starhood. A little closer to the igniting heat of a companion sun, a little more gravitation, a passing nebulae, and this place could've been a photon factory. Still, industry loves these planets and their furnace-like conditions.
+
+1 [population] slot at Medium or Large size
++0 [foodColored] per [population]
++30 [industryColored] per [population]
++0 [dustColored] per [population]
++0 [scienceColored] per [population]</LocalizationPair>
+  <LocalizationPair Name="%PlanetTypeGasHotDescription">Devoid of any life, this world is a scorching hellhole of fiery winds and molten lakes. Expect any residents to feel aggrieved at the hand life has dealt them, but as an industrial base it cannot be beaten.
+
+1 [population] slot at Medium or Large size
++0 [foodColored] per [population]
++15 [industryColored] per [population]
++15 [dustColored] per [population]
++0 [scienceColored] per [population]</LocalizationPair>
+  <LocalizationPair Name="%PlanetTypeGasWarmDescription">Incredible sunsets the brochure says, failing to mention the methane rain, toxic clouds, and a hundred other lethal aspects. Dust deposits are off the charts though, so fortunes can be made.
+
+1 [population] slot at Medium or Large size
++0 [foodColored] per [population]
++10 [industryColored] per [population]
++10 [dustColored] per [population]
++10 [scienceColored] per [population]</LocalizationPair>
+  <LocalizationPair Name="%PlanetTypeGasTemperateDescription">Occupying a Dust "goldilocks" zone, temperate gas worlds are an incredible source of the near-magical substance--if you've got the tech to survive on a surface that makes quicksand seem like a safe bet for walking on. Leave the kids at home if you visit.
+
+1 [population] slot at Medium or Large size
++0 [foodColored] per [population]
++0 [industryColored] per [population]
++30 [dustColored] per [population]
++0 [scienceColored] per [population]</LocalizationPair>
+  <LocalizationPair Name="%PlanetTypeGasColdDescription">Positively mild compared to their frozen gas siblings, these worlds are nonetheless only a hundred or so degrees above absolute zero, and contain all manner of weird and wonderful chemistry from rivers of liquid nitrogen to lakes of methane. Nerd heaven.
+
+1 [population] slot at Medium or Large size
++0 [foodColored] per [population]
++0 [industryColored] per [population]
++15 [dustColored] per [population]
++15 [scienceColored] per [population]</LocalizationPair>
+  <LocalizationPair Name="%PlanetTypeGasFrozenDescription">Utterly inhospitable, these planets are so cold that even the air has frozen, rendering them without even the most scant of atmospheres to cover their nakedness. Staying alive, never mind, living, is a huge challenge, but the scientific insights more than make up for the hardship.
+
+1 [population] slot at Medium or Large size
++0 [foodColored] per [population]
++0 [industryColored] per [population]
++0 [dustColored] per [population]
++30 [scienceColored] per [population]</LocalizationPair>
+
+</Datatable>

--- a/Endless Space Competitive Mod/Simulation/FactionTraits[Custom].xml
+++ b/Endless Space Competitive Mod/Simulation/FactionTraits[Custom].xml
@@ -1,55 +1,92 @@
 <Datatable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xsi:noNamespaceSchemaLocation="../Schemas/FactionTrait.xsd">
-  <!-- Starting Planets -->
-  <FactionTrait Name="FactionTraitHomePlanetPlanetTypeGasFrozen" SubCategory="HomePlanet" Hidden="true" Custom="true" Cost="-5" IgnoreForTraitsCount="true">
-    <SimulationDescriptorReference Name="FactionTraitHomePlanetPlanetTypeGasFrozen"/>
-  </FactionTrait>
+<!-- Vanilla Reference Reordered-->
+<!-- 
+    <FactionTrait Name="FactionTraitHomePlanetPlanetTypeAtoll"          SubCategory="HomePlanet"    Hidden="true"   Custom="true"     Cost="15" IgnoreForTraitsCount="true">
+        <SimulationDescriptorReference Name="FactionTraitHomePlanetPlanetTypeAtoll"/>
+    </FactionTrait>
+    <FactionTrait Name="FactionTraitHomePlanetPlanetTypeForest"         SubCategory="HomePlanet"    Hidden="true"   Custom="true"     Cost="15" IgnoreForTraitsCount="true">
+        <SimulationDescriptorReference Name="FactionTraitHomePlanetPlanetTypeForest"/>
+    </FactionTrait>
+    <FactionTrait Name="FactionTraitHomePlanetPlanetTypeTerran"         SubCategory="HomePlanet"    Hidden="true"   Custom="true"     Cost="15" IgnoreForTraitsCount="true">
+        <SimulationDescriptorReference Name="FactionTraitHomePlanetPlanetTypeTerran"/>
+    </FactionTrait>
+    <FactionTrait Name="FactionTraitHomePlanetPlanetTypeOcean"          SubCategory="HomePlanet"    Hidden="true"   Custom="true"     Cost="15" IgnoreForTraitsCount="true">
+        <SimulationDescriptorReference Name="FactionTraitHomePlanetPlanetTypeOcean"/>
+    </FactionTrait>
 
-  <FactionTrait Name="FactionTraitHomePlanetPlanetTypeBarren" SubCategory="HomePlanet" Hidden="true" Custom="true" Cost="0" IgnoreForTraitsCount="true">
-    <SimulationDescriptorReference Name="FactionTraitHomePlanetPlanetTypeBarren"/>
-  </FactionTrait>
+    <FactionTrait Name="FactionTraitHomePlanetPlanetTypeJungle"         SubCategory="HomePlanet"    Hidden="true"   Custom="true"     Cost="10" IgnoreForTraitsCount="true">
+        <SimulationDescriptorReference Name="FactionTraitHomePlanetPlanetTypeJungle"/>
+    </FactionTrait>
+    <FactionTrait Name="FactionTraitHomePlanetPlanetTypeBoreal"         SubCategory="HomePlanet"    Hidden="true"   Custom="true"     Cost="10" IgnoreForTraitsCount="true">
+        <SimulationDescriptorReference Name="FactionTraitHomePlanetPlanetTypeBoreal"/>
+    </FactionTrait>
 
-  <FactionTrait Name="FactionTraitHomePlanetPlanetTypeIce" SubCategory="HomePlanet" Hidden="true" Custom="true" Cost="-5" IgnoreForTraitsCount="true">
-    <SimulationDescriptorReference Name="FactionTraitHomePlanetPlanetTypeIce"/>
-  </FactionTrait>
+    <FactionTrait Name="FactionTraitHomePlanetPlanetTypeTropical"       SubCategory="HomePlanet"    Hidden="true"   Custom="true"     Cost="10" IgnoreForTraitsCount="true">
+        <SimulationDescriptorReference Name="FactionTraitHomePlanetPlanetTypeTropical"/>
+    </FactionTrait>
+    <FactionTrait Name="FactionTraitHomePlanetPlanetTypeMonsoon"        SubCategory="HomePlanet"    Hidden="true"   Custom="true"     Cost="10" IgnoreForTraitsCount="true">
+        <SimulationDescriptorReference Name="FactionTraitHomePlanetPlanetTypeMonsoon"/>
+    </FactionTrait>
+    <FactionTrait Name="FactionTraitHomePlanetPlanetTypeTundra"         SubCategory="HomePlanet"    Hidden="true"   Custom="true"     Cost="10" IgnoreForTraitsCount="true">
+        <SimulationDescriptorReference Name="FactionTraitHomePlanetPlanetTypeTundra"/>
+    </FactionTrait>
 
-  <FactionTrait Name="FactionTraitHomePlanetPlanetTypeGasCold" SubCategory="HomePlanet" Hidden="true" Custom="true" Cost="-5" IgnoreForTraitsCount="true">
-    <SimulationDescriptorReference Name="FactionTraitHomePlanetPlanetTypeGasCold"/>
-  </FactionTrait>
+    <FactionTrait Name="FactionTraitHomePlanetPlanetTypeVeldt"          SubCategory="HomePlanet"    Hidden="true"   Custom="true"     Cost="10" IgnoreForTraitsCount="true">
+        <SimulationDescriptorReference Name="FactionTraitHomePlanetPlanetTypeVeldt"/>
+    </FactionTrait>
+    <FactionTrait Name="FactionTraitHomePlanetPlanetTypeSteppes"        SubCategory="HomePlanet"    Hidden="true"   Custom="true"     Cost="10" IgnoreForTraitsCount="true">
+        <SimulationDescriptorReference Name="FactionTraitHomePlanetPlanetTypeSteppes"/>
+    </FactionTrait>
 
-  <FactionTrait Name="FactionTraitHomePlanetPlanetTypeArctic" SubCategory="HomePlanet" Hidden="true" Custom="true" Cost="0" IgnoreForTraitsCount="true">
-    <SimulationDescriptorReference Name="FactionTraitHomePlanetPlanetTypeArctic"/>
-  </FactionTrait>
-
-  <FactionTrait Name="FactionTraitHomePlanetPlanetTypeGasTemperate" SubCategory="HomePlanet" Hidden="true" Custom="true" Cost="-5" IgnoreForTraitsCount="true">
-    <SimulationDescriptorReference Name="FactionTraitHomePlanetPlanetTypeGasTemperate"/>
-  </FactionTrait>
-
-  <FactionTrait Name="FactionTraitHomePlanetPlanetTypeSwamp" SubCategory="HomePlanet" Hidden="true" Custom="true" Cost="0" IgnoreForTraitsCount="true">
-    <SimulationDescriptorReference Name="FactionTraitHomePlanetPlanetTypeSwamp"/>
-  </FactionTrait>
-
-  <FactionTrait Name="FactionTraitHomePlanetPlanetTypeGasWarm" SubCategory="HomePlanet" Hidden="true" Custom="true" Cost="-5" IgnoreForTraitsCount="true">
-    <SimulationDescriptorReference Name="FactionTraitHomePlanetPlanetTypeGasWarm"/>
-  </FactionTrait>
-
+    <FactionTrait Name="FactionTraitHomePlanetPlanetTypeArid"           SubCategory="HomePlanet"    Hidden="true"   Custom="true"     Cost="5"  IgnoreForTraitsCount="true">
+        <SimulationDescriptorReference Name="FactionTraitHomePlanetPlanetTypeArid"/>
+    </FactionTrait>
+    <FactionTrait Name="FactionTraitHomePlanetPlanetTypeSnow"           SubCategory="HomePlanet"    Hidden="true"   Custom="true"     Cost="5"  IgnoreForTraitsCount="true">
+        <SimulationDescriptorReference Name="FactionTraitHomePlanetPlanetTypeSnow"/>
+    </FactionTrait>
+-->
+  <!-- New Starting Planets-->
   <FactionTrait Name="FactionTraitHomePlanetPlanetTypeDesert" SubCategory="HomePlanet" Hidden="true" Custom="true" Cost="0" IgnoreForTraitsCount="true">
     <SimulationDescriptorReference Name="FactionTraitHomePlanetPlanetTypeDesert"/>
   </FactionTrait>
-
-  <FactionTrait Name="FactionTraitHomePlanetPlanetTypeGasHot" SubCategory="HomePlanet" Hidden="true" Custom="true" Cost="-5" IgnoreForTraitsCount="true">
-    <SimulationDescriptorReference Name="FactionTraitHomePlanetPlanetTypeGasHot"/>
+  <FactionTrait Name="FactionTraitHomePlanetPlanetTypeArctic" SubCategory="HomePlanet" Hidden="true" Custom="true" Cost="0" IgnoreForTraitsCount="true">
+    <SimulationDescriptorReference Name="FactionTraitHomePlanetPlanetTypeArctic"/>
   </FactionTrait>
 
   <FactionTrait Name="FactionTraitHomePlanetPlanetTypeAsh" SubCategory="HomePlanet" Hidden="true" Custom="true" Cost="0" IgnoreForTraitsCount="true">
     <SimulationDescriptorReference Name="FactionTraitHomePlanetPlanetTypeAsh"/>
   </FactionTrait>
+  <FactionTrait Name="FactionTraitHomePlanetPlanetTypeSwamp" SubCategory="HomePlanet" Hidden="true" Custom="true" Cost="0" IgnoreForTraitsCount="true">
+    <SimulationDescriptorReference Name="FactionTraitHomePlanetPlanetTypeSwamp"/>
+  </FactionTrait>
+  <FactionTrait Name="FactionTraitHomePlanetPlanetTypeIce" SubCategory="HomePlanet" Hidden="true" Custom="true" Cost="-5" IgnoreForTraitsCount="true">
+    <SimulationDescriptorReference Name="FactionTraitHomePlanetPlanetTypeIce"/>
+  </FactionTrait>
 
   <FactionTrait Name="FactionTraitHomePlanetPlanetTypeLava" SubCategory="HomePlanet" Hidden="true" Custom="true" Cost="-5" IgnoreForTraitsCount="true">
     <SimulationDescriptorReference Name="FactionTraitHomePlanetPlanetTypeLava"/>
   </FactionTrait>
+  <FactionTrait Name="FactionTraitHomePlanetPlanetTypeBarren" SubCategory="HomePlanet" Hidden="true" Custom="true" Cost="0" IgnoreForTraitsCount="true">
+    <SimulationDescriptorReference Name="FactionTraitHomePlanetPlanetTypeBarren"/>
+  </FactionTrait>
 
   <FactionTrait Name="FactionTraitHomePlanetPlanetTypeGasBurning" SubCategory="HomePlanet" Hidden="true" Custom="true" Cost="-5" IgnoreForTraitsCount="true">
     <SimulationDescriptorReference Name="FactionTraitHomePlanetPlanetTypeGasBurning"/>
+  </FactionTrait>
+  <FactionTrait Name="FactionTraitHomePlanetPlanetTypeGasHot" SubCategory="HomePlanet" Hidden="true" Custom="true" Cost="-5" IgnoreForTraitsCount="true">
+    <SimulationDescriptorReference Name="FactionTraitHomePlanetPlanetTypeGasHot"/>
+  </FactionTrait>
+  <FactionTrait Name="FactionTraitHomePlanetPlanetTypeGasWarm" SubCategory="HomePlanet" Hidden="true" Custom="true" Cost="-5" IgnoreForTraitsCount="true">
+    <SimulationDescriptorReference Name="FactionTraitHomePlanetPlanetTypeGasWarm"/>
+  </FactionTrait>
+  <FactionTrait Name="FactionTraitHomePlanetPlanetTypeGasTemperate" SubCategory="HomePlanet" Hidden="true" Custom="true" Cost="-5" IgnoreForTraitsCount="true">
+    <SimulationDescriptorReference Name="FactionTraitHomePlanetPlanetTypeGasTemperate"/>
+  </FactionTrait>
+  <FactionTrait Name="FactionTraitHomePlanetPlanetTypeGasCold" SubCategory="HomePlanet" Hidden="true" Custom="true" Cost="-5" IgnoreForTraitsCount="true">
+    <SimulationDescriptorReference Name="FactionTraitHomePlanetPlanetTypeGasCold"/>
+  </FactionTrait>
+  <FactionTrait Name="FactionTraitHomePlanetPlanetTypeGasFrozen" SubCategory="HomePlanet" Hidden="true" Custom="true" Cost="-5" IgnoreForTraitsCount="true">
+    <SimulationDescriptorReference Name="FactionTraitHomePlanetPlanetTypeGasFrozen"/>
   </FactionTrait>
 
   <!-- Starting Major Population -->

--- a/Endless Space Competitive Mod/Simulation/PopulationDefinitions.xml
+++ b/Endless Space Competitive Mod/Simulation/PopulationDefinitions.xml
@@ -227,7 +227,7 @@
     <Trait Name="PopulationModifiersTraitSheredynCount"/>
     <Trait Name="PopulationModifiersTraitSheredyn"/>
 
-    <!--+50 System manpower capacity-->
+    <!--+60 System manpower capacity-->
     <Trait Name="PopulationModifiersTraitPrimaryCustomDefense01"/>
     <!--+1 Influence-->
     <Trait Name="PopulationModifiersTraitPrimaryCustomPrestige00"/>
@@ -613,7 +613,7 @@
     <Trait Name="PopulationModifiersTraitHisshosCount"/>
     <Trait Name="PopulationModifiersTraitHisshos"/>
 
-    <!--+20 System manpower capacity-->
+    <!--+40 System manpower capacity-->
     <Trait Name="PopulationModifiersTraitPrimaryDefense"/>
     <!--+100 System manpower capacity on sterile-->
     <Trait Name="PopulationModifiersTraitSecondaryCustomDefenseOnMeager01"/>

--- a/Endless Space Competitive Mod/Simulation/SimulationDescriptors[FactionTraitsCustom].xml
+++ b/Endless Space Competitive Mod/Simulation/SimulationDescriptors[FactionTraitsCustom].xml
@@ -1,19 +1,35 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Datatable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xsi:noNamespaceSchemaLocation="../Schemas/Amplitude.Unity.Simulation.SimulationDescriptor.xsd">
+  <!-- Vanilla Reordered Homeworlds -->
+<!-- 
+  <SimulationDescriptor Name="FactionTraitHomePlanetPlanetTypeAtoll" Type="FactionTrait"/>
+  <SimulationDescriptor Name="FactionTraitHomePlanetPlanetTypeForest" Type="FactionTrait"/>
+  <SimulationDescriptor Name="FactionTraitHomePlanetPlanetTypeTerran" Type="FactionTrait"/>
+  <SimulationDescriptor Name="FactionTraitHomePlanetPlanetTypeOcean" Type="FactionTrait"/>
+  <SimulationDescriptor Name="FactionTraitHomePlanetPlanetTypeJungle" Type="FactionTrait"/>
+  <SimulationDescriptor Name="FactionTraitHomePlanetPlanetTypeBoreal" Type="FactionTrait"/>
+  <SimulationDescriptor Name="FactionTraitHomePlanetPlanetTypeTropical" Type="FactionTrait"/>
+  <SimulationDescriptor Name="FactionTraitHomePlanetPlanetTypeMonsoon" Type="FactionTrait"/>
+  <SimulationDescriptor Name="FactionTraitHomePlanetPlanetTypeTundra" Type="FactionTrait"/>
+  <SimulationDescriptor Name="FactionTraitHomePlanetPlanetTypeArid" Type="FactionTrait"/>
+  <SimulationDescriptor Name="FactionTraitHomePlanetPlanetTypeVeldt" Type="FactionTrait"/>
+  <SimulationDescriptor Name="FactionTraitHomePlanetPlanetTypeSteppes" Type="FactionTrait"/>
+  <SimulationDescriptor Name="FactionTraitHomePlanetPlanetTypeSnow" Type="FactionTrait"/>
+-->
   <!-- More Home Planets -->
-  <SimulationDescriptor Name="FactionTraitHomePlanetPlanetTypeGasFrozen" Type="FactionTrait"/>
-  <SimulationDescriptor Name="FactionTraitHomePlanetPlanetTypeBarren" Type="FactionTrait"/>
-  <SimulationDescriptor Name="FactionTraitHomePlanetPlanetTypeIce" Type="FactionTrait"/>
-  <SimulationDescriptor Name="FactionTraitHomePlanetPlanetTypeGasCold" Type="FactionTrait"/>
-  <SimulationDescriptor Name="FactionTraitHomePlanetPlanetTypeArctic" Type="FactionTrait"/>
-  <SimulationDescriptor Name="FactionTraitHomePlanetPlanetTypeGasTemperate" Type="FactionTrait"/>
-  <SimulationDescriptor Name="FactionTraitHomePlanetPlanetTypeSwamp" Type="FactionTrait"/>
-  <SimulationDescriptor Name="FactionTraitHomePlanetPlanetTypeGasWarm" Type="FactionTrait"/>
   <SimulationDescriptor Name="FactionTraitHomePlanetPlanetTypeDesert" Type="FactionTrait"/>
-  <SimulationDescriptor Name="FactionTraitHomePlanetPlanetTypeGasHot" Type="FactionTrait"/>
+  <SimulationDescriptor Name="FactionTraitHomePlanetPlanetTypeArctic" Type="FactionTrait"/>
   <SimulationDescriptor Name="FactionTraitHomePlanetPlanetTypeAsh" Type="FactionTrait"/>
+  <SimulationDescriptor Name="FactionTraitHomePlanetPlanetTypeSwamp" Type="FactionTrait"/>
+  <SimulationDescriptor Name="FactionTraitHomePlanetPlanetTypeIce" Type="FactionTrait"/>
   <SimulationDescriptor Name="FactionTraitHomePlanetPlanetTypeLava" Type="FactionTrait"/>
+  <SimulationDescriptor Name="FactionTraitHomePlanetPlanetTypeBarren" Type="FactionTrait"/>
   <SimulationDescriptor Name="FactionTraitHomePlanetPlanetTypeGasBurning" Type="FactionTrait"/>
+  <SimulationDescriptor Name="FactionTraitHomePlanetPlanetTypeGasHot" Type="FactionTrait"/>
+  <SimulationDescriptor Name="FactionTraitHomePlanetPlanetTypeGasWarm" Type="FactionTrait"/>
+  <SimulationDescriptor Name="FactionTraitHomePlanetPlanetTypeGasTemperate" Type="FactionTrait"/>
+  <SimulationDescriptor Name="FactionTraitHomePlanetPlanetTypeGasCold" Type="FactionTrait"/>
+  <SimulationDescriptor Name="FactionTraitHomePlanetPlanetTypeGasFrozen" Type="FactionTrait"/>
 
   <!-- Starting Major Faction -->
   <!--  Vanilla  -->

--- a/Endless Space Competitive Mod/Simulation/SimulationDescriptors[Planet].xml
+++ b/Endless Space Competitive Mod/Simulation/SimulationDescriptors[Planet].xml
@@ -274,25 +274,25 @@
     <Property Name="OwnedHugePlanets"                           BaseValue="1" />
 
     <Modifier TargetProperty="RawMaximumPopulation"     Value="5"       Operation="Addition" Path="ClassPlanet,!PlanetGameplayTypeGas"         TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="1"       Operation="Addition" Path="PlanetTypeAsh"       TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="1"       Operation="Addition" Path="PlanetTypeSwamp"     TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="1"       Operation="Addition" Path="PlanetTypeIce"       TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="2"       Operation="Addition" Path="PlanetTypeFake"      TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="5"       Operation="Addition" Path="PlanetTypeAtoll"     TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="5"       Operation="Addition" Path="PlanetTypeForest"    TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="5"       Operation="Addition" Path="PlanetTypeTerran"    TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="5"       Operation="Addition" Path="PlanetTypeOcean"     TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="4"       Operation="Addition" Path="PlanetTypeJungle"    TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="4"       Operation="Addition" Path="PlanetTypeBoreal"    TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="4"       Operation="Addition" Path="PlanetTypeTropical"  TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="4"       Operation="Addition" Path="PlanetTypeMonsoon"   TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="4"       Operation="Addition" Path="PlanetTypeTundra"    TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="4"       Operation="Addition" Path="PlanetTypeVeldt"     TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="4"       Operation="Addition" Path="PlanetTypeSteppes"   TooltipHidden="true"/>
     <Modifier TargetProperty="RawMaximumPopulation"     Value="2"       Operation="Addition" Path="PlanetTypeArid"      TooltipHidden="true"/>
     <Modifier TargetProperty="RawMaximumPopulation"     Value="2"       Operation="Addition" Path="PlanetTypeSnow"      TooltipHidden="true"/>
     <Modifier TargetProperty="RawMaximumPopulation"     Value="2"       Operation="Addition" Path="PlanetTypeDesert"    TooltipHidden="true"/>
     <Modifier TargetProperty="RawMaximumPopulation"     Value="2"       Operation="Addition" Path="PlanetTypeArctic"    TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="4"       Operation="Addition" Path="PlanetTypeBoreal"    TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="4"       Operation="Addition" Path="PlanetTypeJungle"    TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="4"       Operation="Addition" Path="PlanetTypeTundra"    TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="4"       Operation="Addition" Path="PlanetTypeTropical"  TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="4"       Operation="Addition" Path="PlanetTypeMonsoon"   TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="4"       Operation="Addition" Path="PlanetTypeVeldt"     TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="4"       Operation="Addition" Path="PlanetTypeSteppes"   TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="5"       Operation="Addition" Path="PlanetTypeTerran"    TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="5"       Operation="Addition" Path="PlanetTypeForest"    TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="5"       Operation="Addition" Path="PlanetTypeOcean"     TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="5"       Operation="Addition" Path="PlanetTypeAtoll"     TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="2"       Operation="Addition" Path="PlanetTypeFake"      TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="1"       Operation="Addition" Path="PlanetTypeAsh"       TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="1"       Operation="Addition" Path="PlanetTypeSwamp"     TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="1"       Operation="Addition" Path="PlanetTypeIce"       TooltipHidden="true"/>
 
     <Modifier TargetProperty="PlanetDepletionMax"       Value="130" Operation="Addition" Path="ClassPlanet" TooltipHidden="true"/>
     <Modifier TargetProperty="PlanetIsHuge"             Operation="Force"     Value="1"   Path="ClassPlanet/ClassPopulationPlanet"    TooltipHidden="true"/>
@@ -302,25 +302,25 @@
     <Property Name="OwnedLargePlanets"                           BaseValue="1" />
 
     <Modifier TargetProperty="RawMaximumPopulation"     Value="4"       Operation="Addition" Path="ClassPlanet,!PlanetGameplayTypeGas"         TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="1"       Operation="Addition" Path="PlanetTypeAsh"       TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="1"       Operation="Addition" Path="PlanetTypeSwamp"     TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="1"       Operation="Addition" Path="PlanetTypeIce"       TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="2"       Operation="Addition" Path="PlanetTypeFake"      TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="5"       Operation="Addition" Path="PlanetTypeAtoll"     TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="5"       Operation="Addition" Path="PlanetTypeForest"    TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="5"       Operation="Addition" Path="PlanetTypeTerran"    TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="5"       Operation="Addition" Path="PlanetTypeOcean"     TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="4"       Operation="Addition" Path="PlanetTypeJungle"    TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="4"       Operation="Addition" Path="PlanetTypeBoreal"    TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="4"       Operation="Addition" Path="PlanetTypeTropical"  TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="4"       Operation="Addition" Path="PlanetTypeMonsoon"   TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="4"       Operation="Addition" Path="PlanetTypeTundra"    TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="4"       Operation="Addition" Path="PlanetTypeVeldt"     TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="4"       Operation="Addition" Path="PlanetTypeSteppes"   TooltipHidden="true"/>
     <Modifier TargetProperty="RawMaximumPopulation"     Value="2"       Operation="Addition" Path="PlanetTypeArid"      TooltipHidden="true"/>
     <Modifier TargetProperty="RawMaximumPopulation"     Value="2"       Operation="Addition" Path="PlanetTypeSnow"      TooltipHidden="true"/>
     <Modifier TargetProperty="RawMaximumPopulation"     Value="2"       Operation="Addition" Path="PlanetTypeDesert"    TooltipHidden="true"/>
     <Modifier TargetProperty="RawMaximumPopulation"     Value="2"       Operation="Addition" Path="PlanetTypeArctic"    TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="4"       Operation="Addition" Path="PlanetTypeBoreal"    TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="4"       Operation="Addition" Path="PlanetTypeJungle"    TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="4"       Operation="Addition" Path="PlanetTypeTundra"    TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="4"       Operation="Addition" Path="PlanetTypeTropical"  TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="4"       Operation="Addition" Path="PlanetTypeMonsoon"   TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="4"       Operation="Addition" Path="PlanetTypeVeldt"     TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="4"       Operation="Addition" Path="PlanetTypeSteppes"   TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="5"       Operation="Addition" Path="PlanetTypeTerran"    TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="5"       Operation="Addition" Path="PlanetTypeForest"    TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="5"       Operation="Addition" Path="PlanetTypeOcean"     TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="5"       Operation="Addition" Path="PlanetTypeAtoll"     TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="2"       Operation="Addition" Path="PlanetTypeFake"      TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="1"       Operation="Addition" Path="PlanetTypeAsh"       TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="1"       Operation="Addition" Path="PlanetTypeSwamp"     TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="1"       Operation="Addition" Path="PlanetTypeIce"       TooltipHidden="true"/>
 
     <Modifier TargetProperty="PlanetDepletionMax"       Value="120" Operation="Addition" Path="ClassPlanet" TooltipHidden="true"/>
     <Modifier TargetProperty="PlanetIsLarge"            Operation="Force"     Value="1"   Path="ClassPlanet/ClassPopulationPlanet"    TooltipHidden="true"/>
@@ -328,25 +328,25 @@
 
   <SimulationDescriptor Name="PlanetSizeMedium" Type="PlanetSize" >
     <Modifier TargetProperty="RawMaximumPopulation"     Value="3"       Operation="Addition" Path="ClassPlanet,!PlanetGameplayTypeGas"         TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="1"       Operation="Addition" Path="PlanetTypeAsh"       TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="1"       Operation="Addition" Path="PlanetTypeSwamp"     TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="1"       Operation="Addition" Path="PlanetTypeIce"       TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="2"       Operation="Addition" Path="PlanetTypeFake"      TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="5"       Operation="Addition" Path="PlanetTypeAtoll"     TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="5"       Operation="Addition" Path="PlanetTypeForest"    TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="5"       Operation="Addition" Path="PlanetTypeTerran"    TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="5"       Operation="Addition" Path="PlanetTypeOcean"     TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="4"       Operation="Addition" Path="PlanetTypeJungle"    TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="4"       Operation="Addition" Path="PlanetTypeBoreal"    TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="4"       Operation="Addition" Path="PlanetTypeTropical"  TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="4"       Operation="Addition" Path="PlanetTypeMonsoon"   TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="4"       Operation="Addition" Path="PlanetTypeTundra"    TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="4"       Operation="Addition" Path="PlanetTypeVeldt"     TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="4"       Operation="Addition" Path="PlanetTypeSteppes"   TooltipHidden="true"/>
     <Modifier TargetProperty="RawMaximumPopulation"     Value="2"       Operation="Addition" Path="PlanetTypeArid"      TooltipHidden="true"/>
     <Modifier TargetProperty="RawMaximumPopulation"     Value="2"       Operation="Addition" Path="PlanetTypeSnow"      TooltipHidden="true"/>
     <Modifier TargetProperty="RawMaximumPopulation"     Value="2"       Operation="Addition" Path="PlanetTypeDesert"    TooltipHidden="true"/>
     <Modifier TargetProperty="RawMaximumPopulation"     Value="2"       Operation="Addition" Path="PlanetTypeArctic"    TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="4"       Operation="Addition" Path="PlanetTypeBoreal"    TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="4"       Operation="Addition" Path="PlanetTypeJungle"    TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="4"       Operation="Addition" Path="PlanetTypeTundra"    TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="4"       Operation="Addition" Path="PlanetTypeTropical"  TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="4"       Operation="Addition" Path="PlanetTypeMonsoon"   TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="4"       Operation="Addition" Path="PlanetTypeVeldt"     TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="4"       Operation="Addition" Path="PlanetTypeSteppes"   TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="5"       Operation="Addition" Path="PlanetTypeTerran"    TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="5"       Operation="Addition" Path="PlanetTypeForest"    TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="5"       Operation="Addition" Path="PlanetTypeOcean"     TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="5"       Operation="Addition" Path="PlanetTypeAtoll"     TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="2"       Operation="Addition" Path="PlanetTypeFake"      TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="1"       Operation="Addition" Path="PlanetTypeAsh"       TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="1"       Operation="Addition" Path="PlanetTypeSwamp"     TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="1"       Operation="Addition" Path="PlanetTypeIce"       TooltipHidden="true"/>
 
     <Modifier TargetProperty="PlanetDepletionMax"       Value="110" Operation="Addition" Path="ClassPlanet" TooltipHidden="true"/>
     <Modifier TargetProperty="PlanetIsMedium"           Operation="Force"     Value="1"   Path="ClassPlanet/ClassPopulationPlanet"    TooltipHidden="true"/>
@@ -354,25 +354,25 @@
 
   <SimulationDescriptor Name="PlanetSizeSmall" Type="PlanetSize" >
     <Modifier TargetProperty="RawMaximumPopulation"     Value="2"       Operation="Addition" Path="ClassPlanet,!PlanetGameplayTypeGas"         TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="2"       Operation="Addition" Path="PlanetTypeFake"      TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="5"       Operation="Addition" Path="PlanetTypeAtoll"     TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="5"       Operation="Addition" Path="PlanetTypeForest"    TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="5"       Operation="Addition" Path="PlanetTypeTerran"    TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="5"       Operation="Addition" Path="PlanetTypeOcean"     TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="4"       Operation="Addition" Path="PlanetTypeJungle"    TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="4"       Operation="Addition" Path="PlanetTypeBoreal"    TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="4"       Operation="Addition" Path="PlanetTypeTropical"  TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="4"       Operation="Addition" Path="PlanetTypeMonsoon"   TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="4"       Operation="Addition" Path="PlanetTypeTundra"    TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="4"       Operation="Addition" Path="PlanetTypeVeldt"     TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="4"       Operation="Addition" Path="PlanetTypeSteppes"   TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="2"       Operation="Addition" Path="PlanetTypeArid"      TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="2"       Operation="Addition" Path="PlanetTypeSnow"      TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="2"       Operation="Addition" Path="PlanetTypeDesert"    TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="2"       Operation="Addition" Path="PlanetTypeArctic"    TooltipHidden="true"/>
     <Modifier TargetProperty="RawMaximumPopulation"     Value="1"       Operation="Addition" Path="PlanetTypeAsh"       TooltipHidden="true"/>
     <Modifier TargetProperty="RawMaximumPopulation"     Value="1"       Operation="Addition" Path="PlanetTypeSwamp"     TooltipHidden="true"/>
     <Modifier TargetProperty="RawMaximumPopulation"     Value="1"       Operation="Addition" Path="PlanetTypeIce"       TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="2"       Operation="Addition" Path="PlanetTypeArid"      TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="2"       Operation="Addition" Path="PlanetTypeSnow"      TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="2"       Operation="Addition" Path="PlanetTypeFake"      TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="2"       Operation="Addition" Path="PlanetTypeDesert"    TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="2"       Operation="Addition" Path="PlanetTypeArctic"    TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="4"       Operation="Addition" Path="PlanetTypeBoreal"    TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="4"       Operation="Addition" Path="PlanetTypeJungle"    TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="4"       Operation="Addition" Path="PlanetTypeTundra"    TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="4"       Operation="Addition" Path="PlanetTypeTropical"  TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="4"       Operation="Addition" Path="PlanetTypeMonsoon"   TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="4"       Operation="Addition" Path="PlanetTypeVeldt"     TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="4"       Operation="Addition" Path="PlanetTypeSteppes"   TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="5"       Operation="Addition" Path="PlanetTypeTerran"    TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="5"       Operation="Addition" Path="PlanetTypeForest"    TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="5"       Operation="Addition" Path="PlanetTypeOcean"     TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="5"       Operation="Addition" Path="PlanetTypeAtoll"     TooltipHidden="true"/>
 
     <Modifier TargetProperty="PlanetDepletionMax"       Value="100" Operation="Addition" Path="ClassPlanet" TooltipHidden="true"/>
     <Modifier TargetProperty="PlanetIsSmall"            Operation="Force"     Value="1"   Path="ClassPlanet/ClassPopulationPlanet"    TooltipHidden="true"/>
@@ -380,24 +380,24 @@
 
   <SimulationDescriptor Name="PlanetSizeTiny" Type="PlanetSize" >
     <Modifier TargetProperty="RawMaximumPopulation"     Value="1"       Operation="Addition" Path="ClassPlanet,!PlanetGameplayTypeGas"         TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="1"       Operation="Addition" Path="PlanetTypeAsh"       TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="1"       Operation="Addition" Path="PlanetTypeSwamp"     TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="1"       Operation="Addition" Path="PlanetTypeIce"       TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="5"       Operation="Addition" Path="PlanetTypeAtoll"     TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="5"       Operation="Addition" Path="PlanetTypeForest"    TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="5"       Operation="Addition" Path="PlanetTypeTerran"    TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="5"       Operation="Addition" Path="PlanetTypeOcean"     TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="4"       Operation="Addition" Path="PlanetTypeJungle"    TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="4"       Operation="Addition" Path="PlanetTypeBoreal"    TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="4"       Operation="Addition" Path="PlanetTypeTropical"  TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="4"       Operation="Addition" Path="PlanetTypeMonsoon"   TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="4"       Operation="Addition" Path="PlanetTypeTundra"    TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="4"       Operation="Addition" Path="PlanetTypeVeldt"     TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="4"       Operation="Addition" Path="PlanetTypeSteppes"   TooltipHidden="true"/>
     <Modifier TargetProperty="RawMaximumPopulation"     Value="2"       Operation="Addition" Path="PlanetTypeArid"      TooltipHidden="true"/>
     <Modifier TargetProperty="RawMaximumPopulation"     Value="2"       Operation="Addition" Path="PlanetTypeSnow"      TooltipHidden="true"/>
     <Modifier TargetProperty="RawMaximumPopulation"     Value="2"       Operation="Addition" Path="PlanetTypeDesert"    TooltipHidden="true"/>
     <Modifier TargetProperty="RawMaximumPopulation"     Value="2"       Operation="Addition" Path="PlanetTypeArctic"    TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="4"       Operation="Addition" Path="PlanetTypeBoreal"    TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="4"       Operation="Addition" Path="PlanetTypeJungle"    TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="4"       Operation="Addition" Path="PlanetTypeTundra"    TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="4"       Operation="Addition" Path="PlanetTypeTropical"  TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="4"       Operation="Addition" Path="PlanetTypeMonsoon"   TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="4"       Operation="Addition" Path="PlanetTypeVeldt"     TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="4"       Operation="Addition" Path="PlanetTypeSteppes"   TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="5"       Operation="Addition" Path="PlanetTypeTerran"    TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="5"       Operation="Addition" Path="PlanetTypeForest"    TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="5"       Operation="Addition" Path="PlanetTypeOcean"     TooltipHidden="true"/>
-    <Modifier TargetProperty="RawMaximumPopulation"     Value="5"       Operation="Addition" Path="PlanetTypeAtoll"     TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="1"       Operation="Addition" Path="PlanetTypeAsh"       TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="1"       Operation="Addition" Path="PlanetTypeSwamp"     TooltipHidden="true"/>
+    <Modifier TargetProperty="RawMaximumPopulation"     Value="1"       Operation="Addition" Path="PlanetTypeIce"       TooltipHidden="true"/>
 
     <Modifier TargetProperty="PlanetDepletionMax"       Value="90" Operation="Addition" Path="ClassPlanet" TooltipHidden="true"/>
     <Modifier TargetProperty="PlanetIsTiny"             Operation="Force"     Value="1"   Path="ClassPlanet/ClassPopulationPlanet"    TooltipHidden="true"/>
@@ -414,14 +414,14 @@
       <Modifier TargetProperty="PlanetInitialPrestigePerPopulation"        Operation="Addition" Value="0" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <SimulationDescriptor Name="PlanetTypeOcean" Type="PlanetType" >
+  <SimulationDescriptor Name="PlanetTypeForest" Type="PlanetType" >
       <Property Name="PlanetClass" BaseValue="1" />
 
-      <Modifier TargetProperty="PlanetIsOcean"               Operation="Addition" Value="1" Path="ClassColonizedPlanet/ClassPopulation" TooltipHidden="true"/>
-      <Modifier TargetProperty="PlanetInitialFoodPerPopulation"            Operation="Addition" Value="8" TooltipHidden="true"/>
-      <Modifier TargetProperty="PlanetInitialIndustryPerPopulation"        Operation="Addition" Value="2"  TooltipHidden="true"/>
+      <Modifier TargetProperty="PlanetIsForest"               Operation="Addition" Value="1" Path="ClassColonizedPlanet/ClassPopulation" TooltipHidden="true"/>
+      <Modifier TargetProperty="PlanetInitialFoodPerPopulation"            Operation="Addition" Value="8"  TooltipHidden="true"/>
+      <Modifier TargetProperty="PlanetInitialIndustryPerPopulation"        Operation="Addition" Value="5"  TooltipHidden="true"/>
       <Modifier TargetProperty="PlanetInitialDustPerPopulation"            Operation="Addition" Value="4"  TooltipHidden="true"/>
-      <Modifier TargetProperty="PlanetInitialSciencePerPopulation"         Operation="Addition" Value="6"  TooltipHidden="true"/>
+      <Modifier TargetProperty="PlanetInitialSciencePerPopulation"         Operation="Addition" Value="3"  TooltipHidden="true"/>
       <Modifier TargetProperty="PlanetInitialPrestigePerPopulation"        Operation="Addition" Value="0"  TooltipHidden="true"/>
   </SimulationDescriptor>
 
@@ -436,55 +436,15 @@
     <Modifier TargetProperty="PlanetInitialPrestigePerPopulation"        Operation="Addition" Value="0" TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <SimulationDescriptor Name="PlanetTypeForest" Type="PlanetType" >
+  <SimulationDescriptor Name="PlanetTypeOcean" Type="PlanetType" >
       <Property Name="PlanetClass" BaseValue="1" />
 
-      <Modifier TargetProperty="PlanetIsForest"               Operation="Addition" Value="1" Path="ClassColonizedPlanet/ClassPopulation" TooltipHidden="true"/>
-      <Modifier TargetProperty="PlanetInitialFoodPerPopulation"            Operation="Addition" Value="8"  TooltipHidden="true"/>
-      <Modifier TargetProperty="PlanetInitialIndustryPerPopulation"        Operation="Addition" Value="5"  TooltipHidden="true"/>
+      <Modifier TargetProperty="PlanetIsOcean"               Operation="Addition" Value="1" Path="ClassColonizedPlanet/ClassPopulation" TooltipHidden="true"/>
+      <Modifier TargetProperty="PlanetInitialFoodPerPopulation"            Operation="Addition" Value="8" TooltipHidden="true"/>
+      <Modifier TargetProperty="PlanetInitialIndustryPerPopulation"        Operation="Addition" Value="2"  TooltipHidden="true"/>
       <Modifier TargetProperty="PlanetInitialDustPerPopulation"            Operation="Addition" Value="4"  TooltipHidden="true"/>
-      <Modifier TargetProperty="PlanetInitialSciencePerPopulation"         Operation="Addition" Value="3"  TooltipHidden="true"/>
+      <Modifier TargetProperty="PlanetInitialSciencePerPopulation"         Operation="Addition" Value="6"  TooltipHidden="true"/>
       <Modifier TargetProperty="PlanetInitialPrestigePerPopulation"        Operation="Addition" Value="0"  TooltipHidden="true"/>
-  </SimulationDescriptor>
-
-  <SimulationDescriptor Name="PlanetTypeSwamp" Type="PlanetType" >
-    <Property Name="PlanetClass" BaseValue="1" />
-
-    <Modifier TargetProperty="PlanetInitialFoodPerPopulation"            Operation="Addition" Value="2" TooltipHidden="true"/>
-    <Modifier TargetProperty="PlanetInitialIndustryPerPopulation"        Operation="Addition" Value="2"  TooltipHidden="true"/>
-    <Modifier TargetProperty="PlanetInitialDustPerPopulation"            Operation="Addition" Value="16"  TooltipHidden="true"/>
-    <Modifier TargetProperty="PlanetInitialSciencePerPopulation"         Operation="Addition" Value="2"  TooltipHidden="true"/>
-    <Modifier TargetProperty="PlanetInitialPrestigePerPopulation"        Operation="Addition" Value="0"  TooltipHidden="true"/>
-
-    <BinaryModifier     TargetProperty="Happiness"          Operation="Addition" Left="-5" BinaryOperation="Multiplication" Right="$(Population)" TooltipHidden="true"     />
-    <Modifier           TargetProperty="HappinessRaw"       Operation="Addition" Value="-5"  />
-    <Modifier           TargetProperty="PlanetIsSwamp"      Operation="Force"    Value="1" Path="ClassPlanet/ClassPopulationPlanet"    TooltipHidden="true"/>
-  </SimulationDescriptor>
-
-
-  <SimulationDescriptor Name="PlanetTypeMonsoon" Type="PlanetType" >
-    <Property Name="PlanetClass" BaseValue="2" />
-
-    <Modifier TargetProperty="PlanetInitialFoodPerPopulation"            Operation="Addition" Value="6" TooltipHidden="true" />
-    <Modifier TargetProperty="PlanetInitialIndustryPerPopulation"        Operation="Addition" Value="2" TooltipHidden="true" />
-    <Modifier TargetProperty="PlanetInitialDustPerPopulation"            Operation="Addition" Value="10" TooltipHidden="true" />
-    <Modifier TargetProperty="PlanetInitialSciencePerPopulation"         Operation="Addition" Value="2" TooltipHidden="true" />
-    <Modifier TargetProperty="PlanetInitialPrestigePerPopulation"        Operation="Addition" Value="0" TooltipHidden="true" />
-
-    <BinaryModifier     TargetProperty="Happiness"          Operation="Addition" Left="-1" BinaryOperation="Multiplication" Right="$(Population)" TooltipHidden="true"     />
-    <Modifier           TargetProperty="HappinessRaw"       Operation="Addition" Value="-1"  />
-    <Modifier           TargetProperty="PlanetIsMonsoon"    Operation="Force"    Value="1" Path="ClassPlanet/ClassPopulationPlanet"    TooltipHidden="true"/>
-  </SimulationDescriptor>
-
-  <SimulationDescriptor Name="PlanetTypeBoreal" Type="PlanetType" >
-      <Property Name="PlanetClass" BaseValue="2" />
-
-      <Modifier TargetProperty="PlanetIsBoreal"    Operation="Force"    Value="1" Path="ClassPlanet/ClassPopulationPlanet"    TooltipHidden="true"/>
-      <Modifier TargetProperty="PlanetInitialFoodPerPopulation"            Operation="Addition" Value="7" TooltipHidden="true"/>
-      <Modifier TargetProperty="PlanetInitialIndustryPerPopulation"        Operation="Addition" Value="0" TooltipHidden="true"/>
-      <Modifier TargetProperty="PlanetInitialDustPerPopulation"            Operation="Addition" Value="5" TooltipHidden="true"/>
-      <Modifier TargetProperty="PlanetInitialSciencePerPopulation"         Operation="Addition" Value="8" TooltipHidden="true"/>
-      <Modifier TargetProperty="PlanetInitialPrestigePerPopulation"        Operation="Addition" Value="0" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="PlanetTypeJungle" Type="PlanetType" >
@@ -498,32 +458,15 @@
       <Modifier TargetProperty="PlanetInitialPrestigePerPopulation"        Operation="Addition" Value="0"  TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <SimulationDescriptor Name="PlanetTypeSteppes" Type="PlanetType" >
-    <Property Name="PlanetClass" BaseValue="2" />
+  <SimulationDescriptor Name="PlanetTypeBoreal" Type="PlanetType" >
+      <Property Name="PlanetClass" BaseValue="2" />
 
-    <Modifier TargetProperty="PlanetInitialFoodPerPopulation"            Operation="Addition" Value="4"  TooltipHidden="true"    />
-    <Modifier TargetProperty="PlanetInitialIndustryPerPopulation"        Operation="Addition" Value="1"  TooltipHidden="true"    />
-    <Modifier TargetProperty="PlanetInitialDustPerPopulation"            Operation="Addition" Value="12"  TooltipHidden="true"    />
-    <Modifier TargetProperty="PlanetInitialSciencePerPopulation"         Operation="Addition" Value="3"  TooltipHidden="true"    />
-    <Modifier TargetProperty="PlanetInitialPrestigePerPopulation"        Operation="Addition" Value="0"  TooltipHidden="true"    />
-
-    <BinaryModifier     TargetProperty="Happiness"          Operation="Addition" Left="-1" BinaryOperation="Multiplication" Right="$(Population)" TooltipHidden="true"     />
-    <Modifier           TargetProperty="HappinessRaw"       Operation="Addition" Value="-1"  />
-    <Modifier           TargetProperty="PlanetIsSteppes"    Operation="Force"    Value="1" Path="ClassPlanet/ClassPopulationPlanet"    TooltipHidden="true"/>
-  </SimulationDescriptor>
-
-  <SimulationDescriptor Name="PlanetTypeVeldt" Type="PlanetType" >
-    <Property Name="PlanetClass" BaseValue="2" />
-
-    <Modifier TargetProperty="PlanetInitialFoodPerPopulation"            Operation="Addition" Value="4"  TooltipHidden="true"/>
-    <Modifier TargetProperty="PlanetInitialIndustryPerPopulation"        Operation="Addition" Value="3"  TooltipHidden="true"/>
-    <Modifier TargetProperty="PlanetInitialDustPerPopulation"            Operation="Addition" Value="12"  TooltipHidden="true"/>
-    <Modifier TargetProperty="PlanetInitialSciencePerPopulation"         Operation="Addition" Value="1"  TooltipHidden="true"/>
-    <Modifier TargetProperty="PlanetInitialPrestigePerPopulation"        Operation="Addition" Value="0"  TooltipHidden="true"/>
-
-    <BinaryModifier     TargetProperty="Happiness"          Operation="Addition" Left="-1" BinaryOperation="Multiplication" Right="$(Population)" TooltipHidden="true"     />
-    <Modifier           TargetProperty="HappinessRaw"       Operation="Addition" Value="-1"  />
-    <Modifier           TargetProperty="PlanetIsVeldt"      Operation="Force"    Value="1" Path="ClassPlanet/ClassPopulationPlanet"    TooltipHidden="true"/>
+      <Modifier TargetProperty="PlanetIsBoreal"    Operation="Force"    Value="1" Path="ClassPlanet/ClassPopulationPlanet"    TooltipHidden="true"/>
+      <Modifier TargetProperty="PlanetInitialFoodPerPopulation"            Operation="Addition" Value="7" TooltipHidden="true"/>
+      <Modifier TargetProperty="PlanetInitialIndustryPerPopulation"        Operation="Addition" Value="0" TooltipHidden="true"/>
+      <Modifier TargetProperty="PlanetInitialDustPerPopulation"            Operation="Addition" Value="5" TooltipHidden="true"/>
+      <Modifier TargetProperty="PlanetInitialSciencePerPopulation"         Operation="Addition" Value="8" TooltipHidden="true"/>
+      <Modifier TargetProperty="PlanetInitialPrestigePerPopulation"        Operation="Addition" Value="0" TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="PlanetTypeTropical" Type="PlanetType" >
@@ -540,6 +483,20 @@
     <Modifier           TargetProperty="PlanetIsTropical"   Operation="Force"    Value="1" Path="ClassPlanet/ClassPopulationPlanet"    TooltipHidden="true"/>
   </SimulationDescriptor>
 
+  <SimulationDescriptor Name="PlanetTypeMonsoon" Type="PlanetType" >
+    <Property Name="PlanetClass" BaseValue="2" />
+
+    <Modifier TargetProperty="PlanetInitialFoodPerPopulation"            Operation="Addition" Value="6" TooltipHidden="true" />
+    <Modifier TargetProperty="PlanetInitialIndustryPerPopulation"        Operation="Addition" Value="2" TooltipHidden="true" />
+    <Modifier TargetProperty="PlanetInitialDustPerPopulation"            Operation="Addition" Value="10" TooltipHidden="true" />
+    <Modifier TargetProperty="PlanetInitialSciencePerPopulation"         Operation="Addition" Value="2" TooltipHidden="true" />
+    <Modifier TargetProperty="PlanetInitialPrestigePerPopulation"        Operation="Addition" Value="0" TooltipHidden="true" />
+
+    <BinaryModifier     TargetProperty="Happiness"          Operation="Addition" Left="-1" BinaryOperation="Multiplication" Right="$(Population)" TooltipHidden="true"     />
+    <Modifier           TargetProperty="HappinessRaw"       Operation="Addition" Value="-1"  />
+    <Modifier           TargetProperty="PlanetIsMonsoon"    Operation="Force"    Value="1" Path="ClassPlanet/ClassPopulationPlanet"    TooltipHidden="true"/>
+  </SimulationDescriptor>
+
   <SimulationDescriptor Name="PlanetTypeTundra" Type="PlanetType" >
     <Property Name="PlanetClass" BaseValue="2" />
 
@@ -554,20 +511,48 @@
     <Modifier           TargetProperty="PlanetIsTundra"     Operation="Force"    Value="1" Path="ClassPlanet/ClassPopulationPlanet"    TooltipHidden="true"/>
   </SimulationDescriptor>
 
+  <SimulationDescriptor Name="PlanetTypeVeldt" Type="PlanetType" >
+    <Property Name="PlanetClass" BaseValue="2" />
+
+    <Modifier TargetProperty="PlanetInitialFoodPerPopulation"            Operation="Addition" Value="4"  TooltipHidden="true"/>
+    <Modifier TargetProperty="PlanetInitialIndustryPerPopulation"        Operation="Addition" Value="3"  TooltipHidden="true"/>
+    <Modifier TargetProperty="PlanetInitialDustPerPopulation"            Operation="Addition" Value="12"  TooltipHidden="true"/>
+    <Modifier TargetProperty="PlanetInitialSciencePerPopulation"         Operation="Addition" Value="1"  TooltipHidden="true"/>
+    <Modifier TargetProperty="PlanetInitialPrestigePerPopulation"        Operation="Addition" Value="0"  TooltipHidden="true"/>
+
+    <BinaryModifier     TargetProperty="Happiness"          Operation="Addition" Left="-1" BinaryOperation="Multiplication" Right="$(Population)" TooltipHidden="true"     />
+    <Modifier           TargetProperty="HappinessRaw"       Operation="Addition" Value="-1"  />
+    <Modifier           TargetProperty="PlanetIsVeldt"      Operation="Force"    Value="1" Path="ClassPlanet/ClassPopulationPlanet"    TooltipHidden="true"/>
+  </SimulationDescriptor>
+
+  <SimulationDescriptor Name="PlanetTypeSteppes" Type="PlanetType" >
+    <Property Name="PlanetClass" BaseValue="2" />
+
+    <Modifier TargetProperty="PlanetInitialFoodPerPopulation"            Operation="Addition" Value="4"  TooltipHidden="true"    />
+    <Modifier TargetProperty="PlanetInitialIndustryPerPopulation"        Operation="Addition" Value="1"  TooltipHidden="true"    />
+    <Modifier TargetProperty="PlanetInitialDustPerPopulation"            Operation="Addition" Value="12"  TooltipHidden="true"    />
+    <Modifier TargetProperty="PlanetInitialSciencePerPopulation"         Operation="Addition" Value="3"  TooltipHidden="true"    />
+    <Modifier TargetProperty="PlanetInitialPrestigePerPopulation"        Operation="Addition" Value="0"  TooltipHidden="true"    />
+
+    <BinaryModifier     TargetProperty="Happiness"          Operation="Addition" Left="-1" BinaryOperation="Multiplication" Right="$(Population)" TooltipHidden="true"     />
+    <Modifier           TargetProperty="HappinessRaw"       Operation="Addition" Value="-1"  />
+    <Modifier           TargetProperty="PlanetIsSteppes"    Operation="Force"    Value="1" Path="ClassPlanet/ClassPopulationPlanet"    TooltipHidden="true"/>
+  </SimulationDescriptor>
+
   <!-- CLASS 3 -->
-  <SimulationDescriptor Name="PlanetTypeArctic" Type="PlanetType" >
+
+  <SimulationDescriptor Name="PlanetTypeArid" Type="PlanetType" >
     <Property Name="PlanetClass" BaseValue="3" />
 
-    <Modifier TargetProperty="PlanetInitialFoodPerPopulation"            Operation="Addition" Value="2"  TooltipHidden="true" />
-    <Modifier TargetProperty="PlanetInitialIndustryPerPopulation"        Operation="Addition" Value="1"  TooltipHidden="true" />
-    <Modifier TargetProperty="PlanetInitialDustPerPopulation"            Operation="Addition" Value="7"  TooltipHidden="true" />
-    <Modifier TargetProperty="PlanetInitialSciencePerPopulation"         Operation="Addition" Value="10"  TooltipHidden="true" />
-    <Modifier TargetProperty="PlanetInitialPrestigePerPopulation"        Operation="Addition" Value="0"  TooltipHidden="true" />
+    <Modifier TargetProperty="PlanetInitialFoodPerPopulation"            Operation="Addition" Value="4"  TooltipHidden="true"/>
+    <Modifier TargetProperty="PlanetInitialIndustryPerPopulation"        Operation="Addition" Value="8"  TooltipHidden="true"/>
+    <Modifier TargetProperty="PlanetInitialDustPerPopulation"            Operation="Addition" Value="4" TooltipHidden="true"/>
+    <Modifier TargetProperty="PlanetInitialSciencePerPopulation"         Operation="Addition" Value="2"  TooltipHidden="true"/>
+    <Modifier TargetProperty="PlanetInitialPrestigePerPopulation"        Operation="Addition" Value="0"  TooltipHidden="true"/>
 
-
-    <BinaryModifier     TargetProperty="Happiness"          Operation="Addition" Left="-3" BinaryOperation="Multiplication" Right="$(Population)"  TooltipHidden="true"    />
+    <BinaryModifier     TargetProperty="Happiness"          Operation="Addition" Left="-3" BinaryOperation="Multiplication" Right="$(Population)" TooltipHidden="true"   />
     <Modifier           TargetProperty="HappinessRaw"       Operation="Addition" Value="-3"  />
-    <Modifier           TargetProperty="PlanetIsArctic"     Operation="Force"    Value="1" Path="ClassPlanet/ClassPopulationPlanet"    TooltipHidden="true"/>
+    <Modifier           TargetProperty="PlanetIsArid"       Operation="Force"    Value="1" Path="ClassPlanet/ClassPopulationPlanet"    TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="PlanetTypeSnow" Type="PlanetType" >
@@ -584,20 +569,6 @@
     <Modifier           TargetProperty="PlanetIsSnow"       Operation="Force"    Value="1" Path="ClassPlanet/ClassPopulationPlanet"    TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <SimulationDescriptor Name="PlanetTypeArid" Type="PlanetType" >
-    <Property Name="PlanetClass" BaseValue="3" />
-
-    <Modifier TargetProperty="PlanetInitialFoodPerPopulation"            Operation="Addition" Value="4"  TooltipHidden="true"/>
-    <Modifier TargetProperty="PlanetInitialIndustryPerPopulation"        Operation="Addition" Value="8"  TooltipHidden="true"/>
-    <Modifier TargetProperty="PlanetInitialDustPerPopulation"            Operation="Addition" Value="4" TooltipHidden="true"/>
-    <Modifier TargetProperty="PlanetInitialSciencePerPopulation"         Operation="Addition" Value="2"  TooltipHidden="true"/>
-    <Modifier TargetProperty="PlanetInitialPrestigePerPopulation"        Operation="Addition" Value="0"  TooltipHidden="true"/>
-
-    <BinaryModifier     TargetProperty="Happiness"          Operation="Addition" Left="-3" BinaryOperation="Multiplication" Right="$(Population)" TooltipHidden="true"   />
-    <Modifier           TargetProperty="HappinessRaw"       Operation="Addition" Value="-3"  />
-    <Modifier           TargetProperty="PlanetIsArid"       Operation="Force"    Value="1" Path="ClassPlanet/ClassPopulationPlanet"    TooltipHidden="true"/>
-  </SimulationDescriptor>
-
   <SimulationDescriptor Name="PlanetTypeDesert" Type="PlanetType">
     <Property Name="PlanetClass" BaseValue="3" />
 
@@ -610,6 +581,20 @@
     <BinaryModifier     TargetProperty="Happiness"          Operation="Addition" Left="-3" BinaryOperation="Multiplication" Right="$(Population)" TooltipHidden="true"     />
     <Modifier           TargetProperty="HappinessRaw"       Operation="Addition" Value="-3"  />
     <Modifier           TargetProperty="PlanetIsDesert"     Operation="Force"    Value="1" Path="ClassPlanet/ClassPopulationPlanet"    TooltipHidden="true"/>
+  </SimulationDescriptor>
+
+  <SimulationDescriptor Name="PlanetTypeArctic" Type="PlanetType" >
+    <Property Name="PlanetClass" BaseValue="3" />
+
+    <Modifier TargetProperty="PlanetInitialFoodPerPopulation"            Operation="Addition" Value="2"  TooltipHidden="true" />
+    <Modifier TargetProperty="PlanetInitialIndustryPerPopulation"        Operation="Addition" Value="1"  TooltipHidden="true" />
+    <Modifier TargetProperty="PlanetInitialDustPerPopulation"            Operation="Addition" Value="7"  TooltipHidden="true" />
+    <Modifier TargetProperty="PlanetInitialSciencePerPopulation"         Operation="Addition" Value="10"  TooltipHidden="true" />
+    <Modifier TargetProperty="PlanetInitialPrestigePerPopulation"        Operation="Addition" Value="0"  TooltipHidden="true" />
+
+    <BinaryModifier     TargetProperty="Happiness"          Operation="Addition" Left="-3" BinaryOperation="Multiplication" Right="$(Population)"  TooltipHidden="true"    />
+    <Modifier           TargetProperty="HappinessRaw"       Operation="Addition" Value="-3"  />
+    <Modifier           TargetProperty="PlanetIsArctic"     Operation="Force"    Value="1" Path="ClassPlanet/ClassPopulationPlanet"    TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <!-- CLASS 4-->
@@ -628,6 +613,20 @@
     <Modifier           TargetProperty="PlanetIsAsh"        Operation="Force"    Value="1" Path="ClassPlanet/ClassPopulationPlanet"    TooltipHidden="true"/>
   </SimulationDescriptor>
 
+  <SimulationDescriptor Name="PlanetTypeSwamp" Type="PlanetType" >
+    <Property Name="PlanetClass" BaseValue="1" />
+
+    <Modifier TargetProperty="PlanetInitialFoodPerPopulation"            Operation="Addition" Value="2" TooltipHidden="true"/>
+    <Modifier TargetProperty="PlanetInitialIndustryPerPopulation"        Operation="Addition" Value="2"  TooltipHidden="true"/>
+    <Modifier TargetProperty="PlanetInitialDustPerPopulation"            Operation="Addition" Value="16"  TooltipHidden="true"/>
+    <Modifier TargetProperty="PlanetInitialSciencePerPopulation"         Operation="Addition" Value="2"  TooltipHidden="true"/>
+    <Modifier TargetProperty="PlanetInitialPrestigePerPopulation"        Operation="Addition" Value="0"  TooltipHidden="true"/>
+
+    <BinaryModifier     TargetProperty="Happiness"          Operation="Addition" Left="-5" BinaryOperation="Multiplication" Right="$(Population)" TooltipHidden="true"     />
+    <Modifier           TargetProperty="HappinessRaw"       Operation="Addition" Value="-5"  />
+    <Modifier           TargetProperty="PlanetIsSwamp"      Operation="Force"    Value="1" Path="ClassPlanet/ClassPopulationPlanet"    TooltipHidden="true"/>
+  </SimulationDescriptor>
+
   <SimulationDescriptor Name="PlanetTypeIce" Type="PlanetType" >
     <Property Name="PlanetClass" BaseValue="2" />
 
@@ -640,20 +639,6 @@
     <BinaryModifier     TargetProperty="Happiness"          Operation="Addition" Left="-5" BinaryOperation="Multiplication" Right="$(Population)" TooltipHidden="true"     />
     <Modifier           TargetProperty="HappinessRaw"       Operation="Addition" Value="-5"  />
     <Modifier           TargetProperty="PlanetIsIce"        Operation="Force"    Value="1" Path="ClassPlanet/ClassPopulationPlanet"    TooltipHidden="true"/>
-  </SimulationDescriptor>
-
-  <SimulationDescriptor Name="PlanetTypeBarren" Type="PlanetType" >
-    <Property Name="PlanetClass" BaseValue="4" />
-
-    <Modifier TargetProperty="PlanetInitialFoodPerPopulation"            Operation="Addition" Value="0"  TooltipHidden="true" />
-    <Modifier TargetProperty="PlanetInitialIndustryPerPopulation"        Operation="Addition" Value="0"  TooltipHidden="true" />
-    <Modifier TargetProperty="PlanetInitialDustPerPopulation"            Operation="Addition" Value="4"  TooltipHidden="true" />
-    <Modifier TargetProperty="PlanetInitialSciencePerPopulation"         Operation="Addition" Value="16" TooltipHidden="true" />
-    <Modifier TargetProperty="PlanetInitialPrestigePerPopulation"        Operation="Addition" Value="0"  TooltipHidden="true" />
-
-    <BinaryModifier     TargetProperty="Happiness"          Operation="Addition" Left="-8" BinaryOperation="Multiplication" Right="$(Population)" TooltipHidden="true"     />
-    <Modifier           TargetProperty="HappinessRaw"       Operation="Addition" Value="-8"  />
-    <Modifier           TargetProperty="PlanetIsBarren"     Operation="Force"    Value="1" Path="ClassPlanet/ClassPopulationPlanet"    TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="PlanetTypeLava" Type="PlanetType" >
@@ -670,62 +655,33 @@
     <Modifier           TargetProperty="PlanetIsLava"       Operation="Force"    Value="1" Path="ClassPlanet/ClassPopulationPlanet"    TooltipHidden="true"/>
   </SimulationDescriptor>
 
+  <SimulationDescriptor Name="PlanetTypeBarren" Type="PlanetType" >
+    <Property Name="PlanetClass" BaseValue="4" />
+
+    <Modifier TargetProperty="PlanetInitialFoodPerPopulation"            Operation="Addition" Value="0"  TooltipHidden="true" />
+    <Modifier TargetProperty="PlanetInitialIndustryPerPopulation"        Operation="Addition" Value="0"  TooltipHidden="true" />
+    <Modifier TargetProperty="PlanetInitialDustPerPopulation"            Operation="Addition" Value="4"  TooltipHidden="true" />
+    <Modifier TargetProperty="PlanetInitialSciencePerPopulation"         Operation="Addition" Value="16" TooltipHidden="true" />
+    <Modifier TargetProperty="PlanetInitialPrestigePerPopulation"        Operation="Addition" Value="0"  TooltipHidden="true" />
+
+    <BinaryModifier     TargetProperty="Happiness"          Operation="Addition" Left="-8" BinaryOperation="Multiplication" Right="$(Population)" TooltipHidden="true"     />
+    <Modifier           TargetProperty="HappinessRaw"       Operation="Addition" Value="-8"  />
+    <Modifier           TargetProperty="PlanetIsBarren"     Operation="Force"    Value="1" Path="ClassPlanet/ClassPopulationPlanet"    TooltipHidden="true"/>
+  </SimulationDescriptor>
 
   <!-- GAS PLANETS -->
-  <SimulationDescriptor Name="PlanetTypeGasFrozen" Type="PlanetType" >
+  <SimulationDescriptor Name="PlanetTypeGasBurning" Type="PlanetType" >
     <Property Name="PlanetClass" BaseValue="4" />
 
     <Modifier TargetProperty="PlanetInitialFoodPerPopulation"            Operation="Addition" Value="0"  TooltipHidden="true"/>
-    <Modifier TargetProperty="PlanetInitialIndustryPerPopulation"        Operation="Addition" Value="0"  TooltipHidden="true"/>
+    <Modifier TargetProperty="PlanetInitialIndustryPerPopulation"        Operation="Addition" Value="30" TooltipHidden="true"/>
     <Modifier TargetProperty="PlanetInitialDustPerPopulation"            Operation="Addition" Value="0"  TooltipHidden="true"/>
-    <Modifier TargetProperty="PlanetInitialSciencePerPopulation"         Operation="Addition" Value="30" TooltipHidden="true" />
+    <Modifier TargetProperty="PlanetInitialSciencePerPopulation"         Operation="Addition" Value="0"  TooltipHidden="true"/>
     <Modifier TargetProperty="PlanetInitialPrestigePerPopulation"        Operation="Addition" Value="0"  TooltipHidden="true"/>
 
     <BinaryModifier     TargetProperty="Happiness"          Operation="Addition" Left="-5" BinaryOperation="Multiplication" Right="$(Population)" TooltipHidden="true"     />
     <Modifier           TargetProperty="HappinessRaw"       Operation="Addition" Value="-5"  />
-    <Modifier           TargetProperty="PlanetIsGasFrozen"  Operation="Force"    Value="1" Path="ClassPlanet/ClassPopulationPlanet"    TooltipHidden="true"/>
-  </SimulationDescriptor>
-
-  <SimulationDescriptor Name="PlanetTypeGasCold" Type="PlanetType" >
-    <Property Name="PlanetClass" BaseValue="4" />
-
-    <Modifier TargetProperty="PlanetInitialFoodPerPopulation"            Operation="Addition" Value="0"  TooltipHidden="true"/>
-    <Modifier TargetProperty="PlanetInitialIndustryPerPopulation"        Operation="Addition" Value="0"  TooltipHidden="true"/>
-    <Modifier TargetProperty="PlanetInitialDustPerPopulation"            Operation="Addition" Value="15"  TooltipHidden="true"/>
-    <Modifier TargetProperty="PlanetInitialSciencePerPopulation"         Operation="Addition" Value="15" TooltipHidden="true" />
-    <Modifier TargetProperty="PlanetInitialPrestigePerPopulation"        Operation="Addition" Value="0"  TooltipHidden="true"/>
-
-    <BinaryModifier     TargetProperty="Happiness"          Operation="Addition" Left="-5" BinaryOperation="Multiplication" Right="$(Population)" TooltipHidden="true"     />
-    <Modifier           TargetProperty="HappinessRaw"       Operation="Addition" Value="-5"  />
-    <Modifier           TargetProperty="PlanetIsGasCold"    Operation="Force"    Value="1" Path="ClassPlanet/ClassPopulationPlanet"    TooltipHidden="true"/>
-  </SimulationDescriptor>
-
-  <SimulationDescriptor Name="PlanetTypeGasTemperate" Type="PlanetType" >
-    <Property Name="PlanetClass" BaseValue="4" />
-
-    <Modifier TargetProperty="PlanetInitialFoodPerPopulation"            Operation="Addition" Value="0"  TooltipHidden="true"/>
-    <Modifier TargetProperty="PlanetInitialIndustryPerPopulation"        Operation="Addition" Value="0"  TooltipHidden="true"/>
-    <Modifier TargetProperty="PlanetInitialDustPerPopulation"            Operation="Addition" Value="30" TooltipHidden="true"    />
-    <Modifier TargetProperty="PlanetInitialSciencePerPopulation"         Operation="Addition" Value="0"  TooltipHidden="true"    />
-    <Modifier TargetProperty="PlanetInitialPrestigePerPopulation"        Operation="Addition" Value="0"  TooltipHidden="true"    />
-
-    <BinaryModifier     TargetProperty="Happiness"          Operation="Addition" Left="-5" BinaryOperation="Multiplication" Right="$(Population)" TooltipHidden="true"     />
-    <Modifier           TargetProperty="HappinessRaw"       Operation="Addition" Value="-5"  />
-    <Modifier         TargetProperty="PlanetIsGasTemperate" Operation="Force"    Value="1" Path="ClassPlanet/ClassPopulationPlanet"    TooltipHidden="true"/>
-  </SimulationDescriptor>
-
-  <SimulationDescriptor Name="PlanetTypeGasWarm" Type="PlanetType" >
-    <Property Name="PlanetClass" BaseValue="4" />
-
-    <Modifier TargetProperty="PlanetInitialFoodPerPopulation"            Operation="Addition" Value="0"  TooltipHidden="true"/>
-    <Modifier TargetProperty="PlanetInitialIndustryPerPopulation"        Operation="Addition" Value="10"  TooltipHidden="true"/>
-    <Modifier TargetProperty="PlanetInitialDustPerPopulation"            Operation="Addition" Value="10" TooltipHidden="true" />
-    <Modifier TargetProperty="PlanetInitialSciencePerPopulation"         Operation="Addition" Value="10"  TooltipHidden="true"/>
-    <Modifier TargetProperty="PlanetInitialPrestigePerPopulation"        Operation="Addition" Value="0"  TooltipHidden="true"/>
-
-    <BinaryModifier     TargetProperty="Happiness"          Operation="Addition" Left="-5" BinaryOperation="Multiplication" Right="$(Population)" TooltipHidden="true"     />
-    <Modifier           TargetProperty="HappinessRaw"       Operation="Addition" Value="-5"  />
-    <Modifier           TargetProperty="PlanetIsGasWarm"    Operation="Force"    Value="1" Path="ClassPlanet/ClassPopulationPlanet"    TooltipHidden="true"/>
+    <Modifier           TargetProperty="PlanetIsGasHot"     Operation="Force"    Value="1" Path="ClassPlanet/ClassPopulationPlanet"    TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="PlanetTypeGasHot" Type="PlanetType" >
@@ -742,18 +698,60 @@
     <Modifier           TargetProperty="PlanetIsHot"        Operation="Force"    Value="1" Path="ClassPlanet/ClassPopulationPlanet"    TooltipHidden="true"/>
   </SimulationDescriptor>
 
-  <SimulationDescriptor Name="PlanetTypeGasBurning" Type="PlanetType" >
+  <SimulationDescriptor Name="PlanetTypeGasWarm" Type="PlanetType" >
     <Property Name="PlanetClass" BaseValue="4" />
 
     <Modifier TargetProperty="PlanetInitialFoodPerPopulation"            Operation="Addition" Value="0"  TooltipHidden="true"/>
-    <Modifier TargetProperty="PlanetInitialIndustryPerPopulation"        Operation="Addition" Value="30" TooltipHidden="true"/>
-    <Modifier TargetProperty="PlanetInitialDustPerPopulation"            Operation="Addition" Value="0"  TooltipHidden="true"/>
-    <Modifier TargetProperty="PlanetInitialSciencePerPopulation"         Operation="Addition" Value="0"  TooltipHidden="true"/>
+    <Modifier TargetProperty="PlanetInitialIndustryPerPopulation"        Operation="Addition" Value="10"  TooltipHidden="true"/>
+    <Modifier TargetProperty="PlanetInitialDustPerPopulation"            Operation="Addition" Value="10" TooltipHidden="true" />
+    <Modifier TargetProperty="PlanetInitialSciencePerPopulation"         Operation="Addition" Value="10"  TooltipHidden="true"/>
     <Modifier TargetProperty="PlanetInitialPrestigePerPopulation"        Operation="Addition" Value="0"  TooltipHidden="true"/>
 
     <BinaryModifier     TargetProperty="Happiness"          Operation="Addition" Left="-5" BinaryOperation="Multiplication" Right="$(Population)" TooltipHidden="true"     />
     <Modifier           TargetProperty="HappinessRaw"       Operation="Addition" Value="-5"  />
-    <Modifier           TargetProperty="PlanetIsGasHot"     Operation="Force"    Value="1" Path="ClassPlanet/ClassPopulationPlanet"    TooltipHidden="true"/>
+    <Modifier           TargetProperty="PlanetIsGasWarm"    Operation="Force"    Value="1" Path="ClassPlanet/ClassPopulationPlanet"    TooltipHidden="true"/>
+  </SimulationDescriptor>
+
+  <SimulationDescriptor Name="PlanetTypeGasTemperate" Type="PlanetType" >
+    <Property Name="PlanetClass" BaseValue="4" />
+
+    <Modifier TargetProperty="PlanetInitialFoodPerPopulation"            Operation="Addition" Value="0"  TooltipHidden="true"/>
+    <Modifier TargetProperty="PlanetInitialIndustryPerPopulation"        Operation="Addition" Value="0"  TooltipHidden="true"/>
+    <Modifier TargetProperty="PlanetInitialDustPerPopulation"            Operation="Addition" Value="30" TooltipHidden="true"    />
+    <Modifier TargetProperty="PlanetInitialSciencePerPopulation"         Operation="Addition" Value="0"  TooltipHidden="true"    />
+    <Modifier TargetProperty="PlanetInitialPrestigePerPopulation"        Operation="Addition" Value="0"  TooltipHidden="true"    />
+
+    <BinaryModifier     TargetProperty="Happiness"          Operation="Addition" Left="-5" BinaryOperation="Multiplication" Right="$(Population)" TooltipHidden="true"     />
+    <Modifier           TargetProperty="HappinessRaw"       Operation="Addition" Value="-5"  />
+    <Modifier         TargetProperty="PlanetIsGasTemperate" Operation="Force"    Value="1" Path="ClassPlanet/ClassPopulationPlanet"    TooltipHidden="true"/>
+  </SimulationDescriptor>
+
+  <SimulationDescriptor Name="PlanetTypeGasCold" Type="PlanetType" >
+    <Property Name="PlanetClass" BaseValue="4" />
+
+    <Modifier TargetProperty="PlanetInitialFoodPerPopulation"            Operation="Addition" Value="0"  TooltipHidden="true"/>
+    <Modifier TargetProperty="PlanetInitialIndustryPerPopulation"        Operation="Addition" Value="0"  TooltipHidden="true"/>
+    <Modifier TargetProperty="PlanetInitialDustPerPopulation"            Operation="Addition" Value="15"  TooltipHidden="true"/>
+    <Modifier TargetProperty="PlanetInitialSciencePerPopulation"         Operation="Addition" Value="15" TooltipHidden="true" />
+    <Modifier TargetProperty="PlanetInitialPrestigePerPopulation"        Operation="Addition" Value="0"  TooltipHidden="true"/>
+
+    <BinaryModifier     TargetProperty="Happiness"          Operation="Addition" Left="-5" BinaryOperation="Multiplication" Right="$(Population)" TooltipHidden="true"     />
+    <Modifier           TargetProperty="HappinessRaw"       Operation="Addition" Value="-5"  />
+    <Modifier           TargetProperty="PlanetIsGasCold"    Operation="Force"    Value="1" Path="ClassPlanet/ClassPopulationPlanet"    TooltipHidden="true"/>
+  </SimulationDescriptor>
+
+  <SimulationDescriptor Name="PlanetTypeGasFrozen" Type="PlanetType" >
+    <Property Name="PlanetClass" BaseValue="4" />
+
+    <Modifier TargetProperty="PlanetInitialFoodPerPopulation"            Operation="Addition" Value="0"  TooltipHidden="true"/>
+    <Modifier TargetProperty="PlanetInitialIndustryPerPopulation"        Operation="Addition" Value="0"  TooltipHidden="true"/>
+    <Modifier TargetProperty="PlanetInitialDustPerPopulation"            Operation="Addition" Value="0"  TooltipHidden="true"/>
+    <Modifier TargetProperty="PlanetInitialSciencePerPopulation"         Operation="Addition" Value="30" TooltipHidden="true" />
+    <Modifier TargetProperty="PlanetInitialPrestigePerPopulation"        Operation="Addition" Value="0"  TooltipHidden="true"/>
+
+    <BinaryModifier     TargetProperty="Happiness"          Operation="Addition" Left="-5" BinaryOperation="Multiplication" Right="$(Population)" TooltipHidden="true"     />
+    <Modifier           TargetProperty="HappinessRaw"       Operation="Addition" Value="-5"  />
+    <Modifier           TargetProperty="PlanetIsGasFrozen"  Operation="Force"    Value="1" Path="ClassPlanet/ClassPopulationPlanet"    TooltipHidden="true"/>
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="PlanetDepletionMalus" Type="PlanetDepletion">
@@ -799,6 +797,7 @@
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="SlotTypeAnomaly" Type="PlanetAnomaly"/>
+  <!-- Sets Flags for LawEffectP04L04_ESG -->
   <SimulationDescriptor Name="PlanetStatusTerraformed" Type="PlanetStatus">
     <Modifier TargetProperty="TerraformedPlanets" Operation="Addition" Value="1" Path="./ClassColonizedStarSystem" TooltipHidden="true"/>
     <Modifier TargetProperty="TerraformedHotPlanets" Operation="Addition" Value="1" Path="ClassPlanet,PlanetGameplayTypeHot/./ClassColonizedStarSystem" TooltipHidden="true"/>

--- a/Endless Space Competitive Mod/Simulation/Traits/PopulationModifiersTraits[7_Military].xml
+++ b/Endless Space Competitive Mod/Simulation/Traits/PopulationModifiersTraits[7_Military].xml
@@ -2,14 +2,14 @@
 <Datatable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xsi:noNamespaceSchemaLocation="../../Schemas/PopulationModifiersTrait.xsd">
   <!-- Primary -->
   <!-- Empire Manpower -->
-  <!-- +1 EmpireManpower -->
+  <!-- +3 EmpireManpower -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryCustomEmpireManpower00" SubCategory="Primary" ShowInCustom="true" Cost="5">
     <Modifiers>
       <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomEmpireManpower00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +1 EmpireManpower per Population-->
+        <!-- +3 EmpireManpower per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitPrimaryCustomEmpireManpower00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -24,14 +24,14 @@
     </AssimilatedModifiers>
   </PopulationModifiersTrait>
 
-  <!-- +2 EmpireManpower -->
+  <!-- +6 EmpireManpower -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryCustomEmpireManpower01" SubCategory="Primary" ShowInCustom="true" Cost="10">
     <Modifiers>
       <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomEmpireManpower01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +2 EmpireManpower per Population-->
+        <!-- +6 EmpireManpower per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitPrimaryCustomEmpireManpower01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -46,14 +46,14 @@
     </AssimilatedModifiers>
   </PopulationModifiersTrait>
 
-  <!-- +3 EmpireManpower -->
+  <!-- +9 EmpireManpower -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryCustomEmpireManpower02" SubCategory="Primary" ShowInCustom="true" Cost="15">
     <Modifiers>
       <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomEmpireManpower02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +3 EmpireManpower per Population-->
+        <!-- +9 EmpireManpower per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitPrimaryCustomEmpireManpower02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -69,14 +69,14 @@
   </PopulationModifiersTrait>
 
   <!-- Bombardment Damage -->
-  <!-- +25 GroundBattleBombardmentAttackerDamages -->
+  <!-- +50 GroundBattleBombardmentAttackerDamages -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryCustomGroundBattleBombardmentAttackerDamages00" SubCategory="Primary" ShowInCustom="true" Cost="5">
     <Modifiers>
       <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomGroundBattleBombardmentAttackerDamages00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +25 GroundBattleBombardmentAttackerDamages per Population-->
+        <!-- +50 GroundBattleBombardmentAttackerDamages per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitPrimaryCustomGroundBattleBombardmentAttackerDamages00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -91,7 +91,7 @@
     </AssimilatedModifiers>
   </PopulationModifiersTrait>
 
-  <!-- +50 GroundBattleBombardmentAttackerDamages -->
+  <!-- +100 GroundBattleBombardmentAttackerDamages -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryCustomGroundBattleBombardmentAttackerDamages01" SubCategory="Primary" ShowInCustom="true" Cost="10">
     <Modifiers>
       <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
@@ -113,7 +113,7 @@
     </AssimilatedModifiers>
   </PopulationModifiersTrait>
 
-  <!-- +75 GroundBattleBombardmentAttackerDamages -->
+  <!-- +150 GroundBattleBombardmentAttackerDamages -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryCustomGroundBattleBombardmentAttackerDamages02" SubCategory="Primary" ShowInCustom="true" Cost="15">
     <Modifiers>
       <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
@@ -136,14 +136,14 @@
   </PopulationModifiersTrait>
 
   <!-- Defense -->
-  <!-- +25 Defense -->
+  <!-- +30 Defense -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryCustomDefense00" SubCategory="Primary" ShowInCustom="true" Cost="5">
     <Modifiers>
       <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomSystemManpower00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +25 Defense per Population-->
+        <!-- +30 Defense per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitPrimaryCustomDefense00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -158,14 +158,14 @@
     </AssimilatedModifiers>
   </PopulationModifiersTrait>
 
-  <!-- +50 Defense -->
+  <!-- +60 Defense -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryCustomDefense01" SubCategory="Primary" ShowInCustom="true" Cost="10">
     <Modifiers>
       <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomSystemManpower01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +50 Defense per Population-->
+        <!-- +60 Defense per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitPrimaryCustomDefense01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -180,14 +180,14 @@
     </AssimilatedModifiers>
   </PopulationModifiersTrait>
 
-  <!-- +75 Defense -->
+  <!-- +90 Defense -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitPrimaryCustomDefense02" SubCategory="Primary" ShowInCustom="true" Cost="15">
     <Modifiers>
       <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomSystemManpower02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +75 Defense per Population-->
+        <!-- +90 Defense per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitPrimaryCustomDefense02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -201,16 +201,17 @@
       </Modifier>
     </AssimilatedModifiers>
   </PopulationModifiersTrait>
+
   <!-- Secondary -->
   <!-- Empire Manpower -->
-  <!-- +1 EmpireManpower -->
+  <!-- +3 EmpireManpower (Same as Primary) -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpower00" SubCategory="Secondary" ShowInCustom="false" Cost="5">
     <Modifiers>
       <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitPrimaryCustomEmpireManpower00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +1 EmpireManpower per Population-->
+        <!-- +3 EmpireManpower per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitPrimaryCustomEmpireManpower00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -227,7 +228,7 @@
 
 
   <!-- EmpireManpower On Cold -->
-  <!-- +2 EmpireManpowerOnCold -->
+  <!-- +3 EmpireManpowerOnCold -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnCold00" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>PlanetGameplayTypeCold,BonusPopulationEmpireManpower</Tags>
     <Modifiers>
@@ -235,34 +236,11 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnCold00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +2 EmpireManpowerOnCold per Population-->
+        <!-- +3 EmpireManpowerOnCold per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnCold00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnCold00"/>
-      </Modifier>
-    </Modifiers>
-
-    <AssimilatedModifiers>
-      <Modifier Class="ClassPopulationPlanet">
-        <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnCold00"/>
-      </Modifier>
-    </AssimilatedModifiers>
-  </PopulationModifiersTrait>
-
-  <!-- +4 EmpireManpowerOnCold -->
-  <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnCold01" SubCategory="Secondary" ShowInCustom="true" Cost="10">
-    <Tags>PlanetGameplayTypeCold,BonusPopulationEmpireManpower</Tags>
-    <Modifiers>
-      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
-        <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnCold01"/>
-      </Modifier>
-      <Modifier Class="ClassPopulationPlanet">
-        <!-- +4 EmpireManpowerOnCold per Population-->
-        <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnCold01"/>
-      </Modifier>
-      <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
-        <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnCold01"/>
       </Modifier>
     </Modifiers>
 
@@ -274,6 +252,29 @@
   </PopulationModifiersTrait>
 
   <!-- +6 EmpireManpowerOnCold -->
+  <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnCold01" SubCategory="Secondary" ShowInCustom="true" Cost="10">
+    <Tags>PlanetGameplayTypeCold,BonusPopulationEmpireManpower</Tags>
+    <Modifiers>
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
+        <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnCold01"/>
+      </Modifier>
+      <Modifier Class="ClassPopulationPlanet">
+        <!-- +6 EmpireManpowerOnCold per Population-->
+        <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnCold01"/>
+      </Modifier>
+      <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
+        <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnCold01"/>
+      </Modifier>
+    </Modifiers>
+
+    <AssimilatedModifiers>
+      <Modifier Class="ClassPopulationPlanet">
+        <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnCold00"/>
+      </Modifier>
+    </AssimilatedModifiers>
+  </PopulationModifiersTrait>
+
+  <!-- +9 EmpireManpowerOnCold -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnCold02" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>PlanetGameplayTypeCold,BonusPopulationEmpireManpower</Tags>
     <Modifiers>
@@ -281,7 +282,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnCold02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +6 EmpireManpowerOnCold per Population-->
+        <!-- +9 EmpireManpowerOnCold per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnCold02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -297,7 +298,7 @@
   </PopulationModifiersTrait>
 
   <!-- EmpireManpower On Temperate -->
-  <!-- +2 EmpireManpowerOnTemperate -->
+  <!-- +3 EmpireManpowerOnTemperate -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnTemperate00" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>PlanetGameplayTypeTemperate,BonusPopulationEmpireManpower</Tags>
     <Modifiers>
@@ -305,34 +306,11 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnTemperate00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +2 EmpireManpowerOnTemperate per Population-->
+        <!-- +3 EmpireManpowerOnTemperate per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnTemperate00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnTemperate00"/>
-      </Modifier>
-    </Modifiers>
-
-    <AssimilatedModifiers>
-      <Modifier Class="ClassPopulationPlanet">
-        <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnTemperate00"/>
-      </Modifier>
-    </AssimilatedModifiers>
-  </PopulationModifiersTrait>
-
-  <!-- +4 EmpireManpowerOnTemperate -->
-  <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnTemperate01" SubCategory="Secondary" ShowInCustom="true" Cost="10">
-    <Tags>PlanetGameplayTypeTemperate,BonusPopulationEmpireManpower</Tags>
-    <Modifiers>
-      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
-        <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnTemperate01"/>
-      </Modifier>
-      <Modifier Class="ClassPopulationPlanet">
-        <!-- +4 EmpireManpowerOnTemperate per Population-->
-        <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnTemperate01"/>
-      </Modifier>
-      <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
-        <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnTemperate01"/>
       </Modifier>
     </Modifiers>
 
@@ -344,6 +322,29 @@
   </PopulationModifiersTrait>
 
   <!-- +6 EmpireManpowerOnTemperate -->
+  <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnTemperate01" SubCategory="Secondary" ShowInCustom="true" Cost="10">
+    <Tags>PlanetGameplayTypeTemperate,BonusPopulationEmpireManpower</Tags>
+    <Modifiers>
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
+        <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnTemperate01"/>
+      </Modifier>
+      <Modifier Class="ClassPopulationPlanet">
+        <!-- +6 EmpireManpowerOnTemperate per Population-->
+        <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnTemperate01"/>
+      </Modifier>
+      <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
+        <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnTemperate01"/>
+      </Modifier>
+    </Modifiers>
+
+    <AssimilatedModifiers>
+      <Modifier Class="ClassPopulationPlanet">
+        <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnTemperate00"/>
+      </Modifier>
+    </AssimilatedModifiers>
+  </PopulationModifiersTrait>
+
+  <!-- +9 EmpireManpowerOnTemperate -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnTemperate02" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>PlanetGameplayTypeTemperate,BonusPopulationEmpireManpower</Tags>
     <Modifiers>
@@ -351,7 +352,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnTemperate02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +6 EmpireManpowerOnTemperate per Population-->
+        <!-- +9 EmpireManpowerOnTemperate per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnTemperate02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -367,7 +368,7 @@
   </PopulationModifiersTrait>
 
   <!-- EmpireManpower On Hot -->
-  <!-- +2 EmpireManpowerOnHot -->
+  <!-- +3 EmpireManpowerOnHot -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnHot00" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>PlanetGameplayTypeHot,BonusPopulationEmpireManpower</Tags>
     <Modifiers>
@@ -375,34 +376,11 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnHot00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +2 EmpireManpowerOnHot per Population-->
+        <!-- +3 EmpireManpowerOnHot per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnHot00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnHot00"/>
-      </Modifier>
-    </Modifiers>
-
-    <AssimilatedModifiers>
-      <Modifier Class="ClassPopulationPlanet">
-        <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnHot00"/>
-      </Modifier>
-    </AssimilatedModifiers>
-  </PopulationModifiersTrait>
-
-  <!-- +4 EmpireManpowerOnHot -->
-  <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnHot01" SubCategory="Secondary" ShowInCustom="true" Cost="10">
-    <Tags>PlanetGameplayTypeHot,BonusPopulationEmpireManpower</Tags>
-    <Modifiers>
-      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
-        <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnHot01"/>
-      </Modifier>
-      <Modifier Class="ClassPopulationPlanet">
-        <!-- +4 EmpireManpowerOnHot per Population-->
-        <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnHot01"/>
-      </Modifier>
-      <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
-        <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnHot01"/>
       </Modifier>
     </Modifiers>
 
@@ -414,6 +392,29 @@
   </PopulationModifiersTrait>
 
   <!-- +6 EmpireManpowerOnHot -->
+  <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnHot01" SubCategory="Secondary" ShowInCustom="true" Cost="10">
+    <Tags>PlanetGameplayTypeHot,BonusPopulationEmpireManpower</Tags>
+    <Modifiers>
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
+        <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnHot01"/>
+      </Modifier>
+      <Modifier Class="ClassPopulationPlanet">
+        <!-- +6 EmpireManpowerOnHot per Population-->
+        <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnHot01"/>
+      </Modifier>
+      <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
+        <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnHot01"/>
+      </Modifier>
+    </Modifiers>
+
+    <AssimilatedModifiers>
+      <Modifier Class="ClassPopulationPlanet">
+        <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnHot00"/>
+      </Modifier>
+    </AssimilatedModifiers>
+  </PopulationModifiersTrait>
+
+  <!-- +9 EmpireManpowerOnHot -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnHot02" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>PlanetGameplayTypeHot,BonusPopulationEmpireManpower</Tags>
     <Modifiers>
@@ -421,7 +422,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnHot02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +6 EmpireManpowerOnHot per Population-->
+        <!-- +9 EmpireManpowerOnHot per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnHot02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -437,7 +438,7 @@
   </PopulationModifiersTrait>
 
   <!-- EmpireManpower On Teeming -->
-  <!-- +2 EmpireManpowerOnTeeming -->
+  <!-- +3 EmpireManpowerOnTeeming -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnTeeming00" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>PlanetGameplayTypeTeeming,BonusPopulationEmpireManpower</Tags>
     <Modifiers>
@@ -445,34 +446,11 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnTeeming00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +2 EmpireManpowerOnTeeming per Population-->
+        <!-- +3 EmpireManpowerOnTeeming per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnTeeming00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnTeeming00"/>
-      </Modifier>
-    </Modifiers>
-
-    <AssimilatedModifiers>
-      <Modifier Class="ClassPopulationPlanet">
-        <SimulationDescriptorReference Name="ClassPopulationAssimilatedSecondaryCustomEmpireManpowerOnTeeming00"/>
-      </Modifier>
-    </AssimilatedModifiers>
-  </PopulationModifiersTrait>
-
-  <!-- +4 EmpireManpowerOnTeeming -->
-  <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnTeeming01" SubCategory="Secondary" ShowInCustom="true" Cost="10">
-    <Tags>PlanetGameplayTypeTeeming,BonusPopulationEmpireManpower</Tags>
-    <Modifiers>
-      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
-        <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnTeeming01"/>
-      </Modifier>
-      <Modifier Class="ClassPopulationPlanet">
-        <!-- +4 EmpireManpowerOnTeeming per Population-->
-        <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnTeeming01"/>
-      </Modifier>
-      <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
-        <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnTeeming01"/>
       </Modifier>
     </Modifiers>
 
@@ -484,6 +462,29 @@
   </PopulationModifiersTrait>
 
   <!-- +6 EmpireManpowerOnTeeming -->
+  <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnTeeming01" SubCategory="Secondary" ShowInCustom="true" Cost="10">
+    <Tags>PlanetGameplayTypeTeeming,BonusPopulationEmpireManpower</Tags>
+    <Modifiers>
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
+        <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnTeeming01"/>
+      </Modifier>
+      <Modifier Class="ClassPopulationPlanet">
+        <!-- +6 EmpireManpowerOnTeeming per Population-->
+        <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnTeeming01"/>
+      </Modifier>
+      <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
+        <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnTeeming01"/>
+      </Modifier>
+    </Modifiers>
+
+    <AssimilatedModifiers>
+      <Modifier Class="ClassPopulationPlanet">
+        <SimulationDescriptorReference Name="ClassPopulationAssimilatedSecondaryCustomEmpireManpowerOnTeeming00"/>
+      </Modifier>
+    </AssimilatedModifiers>
+  </PopulationModifiersTrait>
+
+  <!-- +9 EmpireManpowerOnTeeming -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnTeeming02" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>PlanetGameplayTypeTeeming,BonusPopulationEmpireManpower</Tags>
     <Modifiers>
@@ -491,7 +492,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnTeeming02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +6 EmpireManpowerOnTeeming per Population-->
+        <!-- +9 EmpireManpowerOnTeeming per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnTeeming02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -507,7 +508,7 @@
   </PopulationModifiersTrait>
 
   <!-- EmpireManpower On Meager -->
-  <!-- +2 EmpireManpowerOnMeager -->
+  <!-- +3 EmpireManpowerOnMeager -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnMeager00" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>PlanetGameplayTypeMeager,BonusPopulationEmpireManpower</Tags>
     <Modifiers>
@@ -515,34 +516,11 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnMeager00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +2 EmpireManpowerOnMeager per Population-->
+        <!-- +3 EmpireManpowerOnMeager per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnMeager00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnMeager00"/>
-      </Modifier>
-    </Modifiers>
-
-    <AssimilatedModifiers>
-      <Modifier Class="ClassPopulationPlanet">
-        <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnMeager00"/>
-      </Modifier>
-    </AssimilatedModifiers>
-  </PopulationModifiersTrait>
-
-  <!-- +4 EmpireManpowerOnMeager -->
-  <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnMeager01" SubCategory="Secondary" ShowInCustom="true" Cost="10">
-    <Tags>PlanetGameplayTypeMeager,BonusPopulationEmpireManpower</Tags>
-    <Modifiers>
-      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
-        <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnMeager01"/>
-      </Modifier>
-      <Modifier Class="ClassPopulationPlanet">
-        <!-- +4 EmpireManpowerOnMeager per Population-->
-        <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnMeager01"/>
-      </Modifier>
-      <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
-        <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnMeager01"/>
       </Modifier>
     </Modifiers>
 
@@ -554,6 +532,29 @@
   </PopulationModifiersTrait>
 
   <!-- +6 EmpireManpowerOnMeager -->
+  <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnMeager01" SubCategory="Secondary" ShowInCustom="true" Cost="10">
+    <Tags>PlanetGameplayTypeMeager,BonusPopulationEmpireManpower</Tags>
+    <Modifiers>
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
+        <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnMeager01"/>
+      </Modifier>
+      <Modifier Class="ClassPopulationPlanet">
+        <!-- +6 EmpireManpowerOnMeager per Population-->
+        <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnMeager01"/>
+      </Modifier>
+      <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
+        <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnMeager01"/>
+      </Modifier>
+    </Modifiers>
+
+    <AssimilatedModifiers>
+      <Modifier Class="ClassPopulationPlanet">
+        <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnMeager00"/>
+      </Modifier>
+    </AssimilatedModifiers>
+  </PopulationModifiersTrait>
+
+  <!-- +9 EmpireManpowerOnMeager -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnMeager02" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>PlanetGameplayTypeMeager,BonusPopulationEmpireManpower</Tags>
     <Modifiers>
@@ -561,7 +562,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnMeager02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +6 EmpireManpowerOnMeager per Population-->
+        <!-- +9 EmpireManpowerOnMeager per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnMeager02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -576,7 +577,7 @@
     </AssimilatedModifiers>
   </PopulationModifiersTrait>
 
-  <!-- +3 EmpireManpowerOnGas -->
+  <!-- +6 EmpireManpowerOnGas -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnGas00" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>PlanetGameplayTypeGas,BonusPopulationEmpireManpower</Tags>
     <Modifiers>
@@ -584,7 +585,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnGas00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +3 EmpireManpowerOnGas per Population-->
+        <!-- +6 EmpireManpowerOnGas per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnGas00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -599,7 +600,7 @@
     </AssimilatedModifiers>
   </PopulationModifiersTrait>
 
-  <!-- +6 EmpireManpowerOnGas -->
+  <!-- +12 EmpireManpowerOnGas -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnGas01" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetGameplayTypeGas,BonusPopulationEmpireManpower</Tags>
     <Modifiers>
@@ -607,7 +608,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnGas01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +6 EmpireManpowerOnGas per Population-->
+        <!-- +12 EmpireManpowerOnGas per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnGas01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -622,7 +623,7 @@
     </AssimilatedModifiers>
   </PopulationModifiersTrait>
 
-  <!-- +10 EmpireManpowerOnGas -->
+  <!-- +18 EmpireManpowerOnGas -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnGas02" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>PlanetGameplayTypeGas,BonusPopulationEmpireManpower</Tags>
     <Modifiers>
@@ -630,7 +631,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnGas02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +10 EmpireManpowerOnGas per Population-->
+        <!-- +18 EmpireManpowerOnGas per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnGas02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -646,7 +647,7 @@
   </PopulationModifiersTrait>
 
   <!-- EmpireManpower On Happy -->
-  <!-- +2 EmpireManpowerOnHappy -->
+  <!-- +3 EmpireManpowerOnHappy -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnHappy00" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>HappinessStatusStarSystem3,BonusPopulationEmpireManpower</Tags>
     <Modifiers>
@@ -654,34 +655,11 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnHappy00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +2 EmpireManpowerOnHappy per Population-->
+        <!-- +3 EmpireManpowerOnHappy per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnHappy00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnHappy00"/>
-      </Modifier>
-    </Modifiers>
-
-    <AssimilatedModifiers>
-      <Modifier Class="ClassPopulationPlanet">
-        <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnHappy00"/>
-      </Modifier>
-    </AssimilatedModifiers>
-  </PopulationModifiersTrait>
-
-  <!-- +4 EmpireManpowerOnHappy -->
-  <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnHappy01" SubCategory="Secondary" ShowInCustom="true" Cost="10">
-    <Tags>HappinessStatusStarSystem3,BonusPopulationEmpireManpower</Tags>
-    <Modifiers>
-      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
-        <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnHappy01"/>
-      </Modifier>
-      <Modifier Class="ClassPopulationPlanet">
-        <!-- +4 EmpireManpowerOnHappy per Population-->
-        <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnHappy01"/>
-      </Modifier>
-      <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
-        <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnHappy01"/>
       </Modifier>
     </Modifiers>
 
@@ -693,6 +671,29 @@
   </PopulationModifiersTrait>
 
   <!-- +6 EmpireManpowerOnHappy -->
+  <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnHappy01" SubCategory="Secondary" ShowInCustom="true" Cost="10">
+    <Tags>HappinessStatusStarSystem3,BonusPopulationEmpireManpower</Tags>
+    <Modifiers>
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
+        <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnHappy01"/>
+      </Modifier>
+      <Modifier Class="ClassPopulationPlanet">
+        <!-- +6 EmpireManpowerOnHappy per Population-->
+        <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnHappy01"/>
+      </Modifier>
+      <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
+        <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnHappy01"/>
+      </Modifier>
+    </Modifiers>
+
+    <AssimilatedModifiers>
+      <Modifier Class="ClassPopulationPlanet">
+        <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnHappy00"/>
+      </Modifier>
+    </AssimilatedModifiers>
+  </PopulationModifiersTrait>
+
+  <!-- +9 EmpireManpowerOnHappy -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnHappy02" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>HappinessStatusStarSystem3,BonusPopulationEmpireManpower</Tags>
     <Modifiers>
@@ -700,7 +701,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnHappy02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +6 EmpireManpowerOnHappy per Population-->
+        <!-- +9 EmpireManpowerOnHappy per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnHappy02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -716,7 +717,7 @@
   </PopulationModifiersTrait>
 
   <!-- EmpireManpower On Tiny -->
-  <!-- +1 EmpireManpowerOnTiny -->
+  <!-- +3 EmpireManpowerOnTiny -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnTiny00" SubCategory="Secondary" ShowInCustom="false" Cost="5">
     <Tags>PlanetSizeTiny,BonusPopulationEmpireManpower</Tags>
     <Modifiers>
@@ -724,7 +725,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnTiny00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +1 EmpireManpowerOnTiny per Population-->
+        <!-- +3 EmpireManpowerOnTiny per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnTiny00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -739,7 +740,7 @@
     </AssimilatedModifiers>
   </PopulationModifiersTrait>
 
-  <!-- +2 EmpireManpowerOnTiny -->
+  <!-- +6 EmpireManpowerOnTiny -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnTiny01" SubCategory="Secondary" ShowInCustom="false" Cost="10">
     <Tags>PlanetSizeTiny,BonusPopulationEmpireManpower</Tags>
     <Modifiers>
@@ -747,7 +748,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnTiny01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +2 EmpireManpowerOnTiny per Population-->
+        <!-- +6 EmpireManpowerOnTiny per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnTiny01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -762,7 +763,7 @@
     </AssimilatedModifiers>
   </PopulationModifiersTrait>
 
-  <!-- +3 EmpireManpowerOnTiny -->
+  <!-- +9 EmpireManpowerOnTiny -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnTiny02" SubCategory="Secondary" ShowInCustom="false" Cost="15">
     <Tags>PlanetSizeTiny,BonusPopulationEmpireManpower</Tags>
     <Modifiers>
@@ -770,7 +771,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnTiny02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +3 EmpireManpowerOnTiny per Population-->
+        <!-- +9 EmpireManpowerOnTiny per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnTiny02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -786,7 +787,7 @@
   </PopulationModifiersTrait>
 
   <!-- EmpireManpower On Small -->
-  <!-- +1 EmpireManpowerOnSmall -->
+  <!-- +3 EmpireManpowerOnSmall -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnSmall00" SubCategory="Secondary" ShowInCustom="false" Cost="5">
     <Tags>PlanetSizeSmall,BonusPopulationEmpireManpower</Tags>
     <Modifiers>
@@ -794,7 +795,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnSmall00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +1 EmpireManpowerOnSmall per Population-->
+        <!-- +3 EmpireManpowerOnSmall per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnSmall00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -809,7 +810,7 @@
     </AssimilatedModifiers>
   </PopulationModifiersTrait>
 
-  <!-- +2 EmpireManpowerOnSmall -->
+  <!-- +6 EmpireManpowerOnSmall -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnSmall01" SubCategory="Secondary" ShowInCustom="false" Cost="10">
     <Tags>PlanetSizeSmall,BonusPopulationEmpireManpower</Tags>
     <Modifiers>
@@ -817,7 +818,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnSmall01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +2 EmpireManpowerOnSmall per Population-->
+        <!-- +6 EmpireManpowerOnSmall per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnSmall01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -832,7 +833,7 @@
     </AssimilatedModifiers>
   </PopulationModifiersTrait>
 
-  <!-- +3 EmpireManpowerOnSmall -->
+  <!-- +9 EmpireManpowerOnSmall -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnSmall02" SubCategory="Secondary" ShowInCustom="false" Cost="15">
     <Tags>PlanetSizeSmall,BonusPopulationEmpireManpower</Tags>
     <Modifiers>
@@ -840,7 +841,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnSmall02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +3 EmpireManpowerOnSmall per Population-->
+        <!-- +9 EmpireManpowerOnSmall per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnSmall02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -856,7 +857,7 @@
   </PopulationModifiersTrait>
 
   <!-- EmpireManpower On Medium -->
-  <!-- +1 EmpireManpowerOnMedium -->
+  <!-- +3 EmpireManpowerOnMedium -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnMedium00" SubCategory="Secondary" ShowInCustom="false" Cost="5">
     <Tags>PlanetSizeMedium,BonusPopulationEmpireManpower</Tags>
     <Modifiers>
@@ -864,7 +865,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnMedium00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +1 EmpireManpowerOnMedium per Population-->
+        <!-- +3 EmpireManpowerOnMedium per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnMedium00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -879,7 +880,7 @@
     </AssimilatedModifiers>
   </PopulationModifiersTrait>
 
-  <!-- +2 EmpireManpowerOnMedium -->
+  <!-- +6 EmpireManpowerOnMedium -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnMedium01" SubCategory="Secondary" ShowInCustom="false" Cost="10">
     <Tags>PlanetSizeMedium,BonusPopulationEmpireManpower</Tags>
     <Modifiers>
@@ -887,7 +888,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnMedium01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +2 EmpireManpowerOnMedium per Population-->
+        <!-- +6 EmpireManpowerOnMedium per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnMedium01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -902,7 +903,7 @@
     </AssimilatedModifiers>
   </PopulationModifiersTrait>
 
-  <!-- +3 EmpireManpowerOnMedium -->
+  <!-- +9 EmpireManpowerOnMedium -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnMedium02" SubCategory="Secondary" ShowInCustom="false" Cost="15">
     <Tags>PlanetSizeMedium,BonusPopulationEmpireManpower</Tags>
     <Modifiers>
@@ -910,7 +911,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnMedium02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +3 EmpireManpowerOnMedium per Population-->
+        <!-- +9 EmpireManpowerOnMedium per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnMedium02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -926,7 +927,7 @@
   </PopulationModifiersTrait>
 
   <!-- EmpireManpower On Large -->
-  <!-- +1 EmpireManpowerOnLarge -->
+  <!-- +3 EmpireManpowerOnLarge -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnLarge00" SubCategory="Secondary" ShowInCustom="false" Cost="5">
     <Tags>PlanetSizeLarge,BonusPopulationEmpireManpower</Tags>
     <Modifiers>
@@ -934,7 +935,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnLarge00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +1 EmpireManpowerOnLarge per Population-->
+        <!-- +3 EmpireManpowerOnLarge per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnLarge00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -949,7 +950,7 @@
     </AssimilatedModifiers>
   </PopulationModifiersTrait>
 
-  <!-- +2 EmpireManpowerOnLarge -->
+  <!-- +6 EmpireManpowerOnLarge -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnLarge01" SubCategory="Secondary" ShowInCustom="false" Cost="10">
     <Tags>PlanetSizeLarge,BonusPopulationEmpireManpower</Tags>
     <Modifiers>
@@ -957,7 +958,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnLarge01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +2 EmpireManpowerOnLarge per Population-->
+        <!-- +6 EmpireManpowerOnLarge per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnLarge01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -972,7 +973,7 @@
     </AssimilatedModifiers>
   </PopulationModifiersTrait>
 
-  <!-- +3 EmpireManpowerOnLarge -->
+  <!-- +9 EmpireManpowerOnLarge -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnLarge02" SubCategory="Secondary" ShowInCustom="false" Cost="15">
     <Tags>PlanetSizeLarge,BonusPopulationEmpireManpower</Tags>
     <Modifiers>
@@ -980,7 +981,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnLarge02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +3 EmpireManpowerOnLarge per Population-->
+        <!-- +9 EmpireManpowerOnLarge per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnLarge02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -996,7 +997,7 @@
   </PopulationModifiersTrait>
 
   <!-- EmpireManpower On Huge -->
-  <!-- +1 EmpireManpowerOnHuge -->
+  <!-- +3 EmpireManpowerOnHuge -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnHuge00" SubCategory="Secondary" ShowInCustom="false" Cost="5">
     <Tags>PlanetSizeHuge,BonusPopulationEmpireManpower</Tags>
     <Modifiers>
@@ -1004,7 +1005,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnHuge00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +1 EmpireManpowerOnHuge per Population-->
+        <!-- +3 EmpireManpowerOnHuge per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnHuge00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -1019,7 +1020,7 @@
     </AssimilatedModifiers>
   </PopulationModifiersTrait>
 
-  <!-- +2 EmpireManpowerOnHuge -->
+  <!-- +6 EmpireManpowerOnHuge -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnHuge01" SubCategory="Secondary" ShowInCustom="false" Cost="10">
     <Tags>PlanetSizeHuge,BonusPopulationEmpireManpower</Tags>
     <Modifiers>
@@ -1027,7 +1028,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnHuge01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +2 EmpireManpowerOnHuge per Population-->
+        <!-- +6 EmpireManpowerOnHuge per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnHuge01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -1042,7 +1043,7 @@
     </AssimilatedModifiers>
   </PopulationModifiersTrait>
 
-  <!-- +3 EmpireManpowerOnHuge -->
+  <!-- +9 EmpireManpowerOnHuge -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnHuge02" SubCategory="Secondary" ShowInCustom="false" Cost="15">
     <Tags>PlanetSizeHuge,BonusPopulationEmpireManpower</Tags>
     <Modifiers>
@@ -1050,7 +1051,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnHuge02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +3 EmpireManpowerOnHuge per Population-->
+        <!-- +9 EmpireManpowerOnHuge per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnHuge02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -1066,7 +1067,7 @@
   </PopulationModifiersTrait>
   
   <!-- EmpireManpower on Strategic -->
-  <!-- +2 EmpireManpowerOnStrategic -->
+  <!-- +6 EmpireManpowerOnStrategic -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnStrategic00" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>HappinessStatusStarSystem3,BonusPopulationEmpireManpower</Tags>
     <Modifiers>
@@ -1074,7 +1075,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnStrategic00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +2 EmpireManpowerOnStrategic per Population-->
+        <!-- +6 EmpireManpowerOnStrategic per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnStrategic00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -1090,7 +1091,7 @@
   </PopulationModifiersTrait>
 
   <!-- EmpireManpower on Anomaly -->
-  <!-- +5 EmpireManpowerOnAnomaly -->
+  <!-- +12 EmpireManpowerOnAnomaly -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnAnomaly00" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetAnomaly,BonusPopulationEmpireManpower</Tags>
     <Modifiers>
@@ -1098,7 +1099,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnAnomaly00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +5 EmpireManpowerOnAnomaly per Population-->
+        <!-- +12 EmpireManpowerOnAnomaly per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnAnomaly00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -1114,7 +1115,7 @@
   </PopulationModifiersTrait>
 
   <!-- EmpireManpower per Minor Faction -->
-  <!-- +2 EmpireManpowerPerMinorFaction -->
+  <!-- +1 EmpireManpowerPerMinorFaction -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerPerMinorFaction00" SubCategory="Secondary" ShowInCustom="true" Cost="20">
     <Modifiers>
       <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
@@ -1137,7 +1138,7 @@
   </PopulationModifiersTrait>
 
   <!-- EmpireManpower per Backdoor -->
-  <!-- +2 EmpireManpowerPerBackdoor -->
+  <!-- +1 EmpireManpowerPerBackdoor -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerPerBackdoor00" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Modifiers>
       <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
@@ -1159,7 +1160,7 @@
     </AssimilatedModifiers>
   </PopulationModifiersTrait>
 
-  <!-- EmpireManpower per Temple -->
+  <!-- +6 EmpireManpower per Temple -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerPerTemple00" SubCategory="Primary" ShowInCustom="true" Cost="5">
     <Modifiers>
       <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
@@ -1180,7 +1181,7 @@
     </AssimilatedModifiers>
   </PopulationModifiersTrait>
 
-  <!-- EmpireManpower per System Level -->
+  <!-- +3 EmpireManpower per System Level -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerPerSystemLevel00" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Modifiers>
       <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
@@ -1202,7 +1203,7 @@
   </PopulationModifiersTrait>
 
   <!-- EmpireManpower on Luxury -->
-  <!-- +2 EmpireManpowerOnLuxury -->
+  <!-- +6 EmpireManpowerOnLuxury -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomEmpireManpowerOnLuxury00" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>HappinessStatusStarSystem3,BonusPopulationEmpireManpower</Tags>
     <Modifiers>
@@ -1210,7 +1211,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnLuxury00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +2 EmpireManpowerOnLuxury per Population-->
+        <!-- +6 EmpireManpowerOnLuxury per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerOnLuxury00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -1226,7 +1227,7 @@
   </PopulationModifiersTrait>
 
   <!-- GroundBattleBombardmentAttackerDamages On Cold -->
-  <!-- +25 GroundBattleBombardmentAttackerDamagesOnCold -->
+  <!-- +50 GroundBattleBombardmentAttackerDamagesOnCold -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnCold00" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>PlanetGameplayTypeCold,BonusPopulationGroundBattleBombardmentAttackerDamages</Tags>
     <Modifiers>
@@ -1234,7 +1235,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnCold00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +25 GroundBattleBombardmentAttackerDamagesOnCold per Population-->
+        <!-- +50 GroundBattleBombardmentAttackerDamagesOnCold per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnCold00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -1249,7 +1250,7 @@
     </AssimilatedModifiers>
   </PopulationModifiersTrait>
 
-  <!-- +50 GroundBattleBombardmentAttackerDamagesOnCold -->
+  <!-- +100 GroundBattleBombardmentAttackerDamagesOnCold -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnCold01" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetGameplayTypeCold,BonusPopulationGroundBattleBombardmentAttackerDamages</Tags>
     <Modifiers>
@@ -1257,7 +1258,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnCold01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +50 GroundBattleBombardmentAttackerDamagesOnCold per Population-->
+        <!-- +100 GroundBattleBombardmentAttackerDamagesOnCold per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnCold01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -1272,7 +1273,7 @@
     </AssimilatedModifiers>
   </PopulationModifiersTrait>
 
-  <!-- +75 GroundBattleBombardmentAttackerDamagesOnCold -->
+  <!-- +150 GroundBattleBombardmentAttackerDamagesOnCold -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnCold02" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>PlanetGameplayTypeCold,BonusPopulationGroundBattleBombardmentAttackerDamages</Tags>
     <Modifiers>
@@ -1280,7 +1281,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnCold02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +75 GroundBattleBombardmentAttackerDamagesOnCold per Population-->
+        <!-- +150 GroundBattleBombardmentAttackerDamagesOnCold per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnCold02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -1296,7 +1297,7 @@
   </PopulationModifiersTrait>
 
   <!-- GroundBattleBombardmentAttackerDamages On Temperate -->
-  <!-- +25 GroundBattleBombardmentAttackerDamagesOnTemperate -->
+  <!-- +50 GroundBattleBombardmentAttackerDamagesOnTemperate -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnTemperate00" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>PlanetGameplayTypeTemperate,BonusPopulationGroundBattleBombardmentAttackerDamages</Tags>
     <Modifiers>
@@ -1304,7 +1305,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnTemperate00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +25 GroundBattleBombardmentAttackerDamagesOnTemperate per Population-->
+        <!-- +50 GroundBattleBombardmentAttackerDamagesOnTemperate per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnTemperate00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -1319,7 +1320,7 @@
     </AssimilatedModifiers>
   </PopulationModifiersTrait>
 
-  <!-- +50 GroundBattleBombardmentAttackerDamagesOnTemperate -->
+  <!-- +100 GroundBattleBombardmentAttackerDamagesOnTemperate -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnTemperate01" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetGameplayTypeTemperate,BonusPopulationGroundBattleBombardmentAttackerDamages</Tags>
     <Modifiers>
@@ -1327,7 +1328,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnTemperate01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +50 GroundBattleBombardmentAttackerDamagesOnTemperate per Population-->
+        <!-- +100 GroundBattleBombardmentAttackerDamagesOnTemperate per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnTemperate01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -1342,7 +1343,7 @@
     </AssimilatedModifiers>
   </PopulationModifiersTrait>
 
-  <!-- +75 GroundBattleBombardmentAttackerDamagesOnTemperate -->
+  <!-- +150 GroundBattleBombardmentAttackerDamagesOnTemperate -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnTemperate02" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>PlanetGameplayTypeTemperate,BonusPopulationGroundBattleBombardmentAttackerDamages</Tags>
     <Modifiers>
@@ -1350,7 +1351,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnTemperate02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +75 GroundBattleBombardmentAttackerDamagesOnTemperate per Population-->
+        <!-- +150 GroundBattleBombardmentAttackerDamagesOnTemperate per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnTemperate02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -1366,7 +1367,7 @@
   </PopulationModifiersTrait>
 
   <!-- GroundBattleBombardmentAttackerDamages On Hot -->
-  <!-- +25 GroundBattleBombardmentAttackerDamagesOnHot -->
+  <!-- +50 GroundBattleBombardmentAttackerDamagesOnHot -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnHot00" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>PlanetGameplayTypeHot,BonusPopulationGroundBattleBombardmentAttackerDamages</Tags>
     <Modifiers>
@@ -1374,7 +1375,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnHot00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +25 GroundBattleBombardmentAttackerDamagesOnHot per Population-->
+        <!-- +50 GroundBattleBombardmentAttackerDamagesOnHot per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnHot00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -1389,7 +1390,7 @@
     </AssimilatedModifiers>
   </PopulationModifiersTrait>
 
-  <!-- +50 GroundBattleBombardmentAttackerDamagesOnHot -->
+  <!-- +100 GroundBattleBombardmentAttackerDamagesOnHot -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnHot01" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetGameplayTypeHot,BonusPopulationGroundBattleBombardmentAttackerDamages</Tags>
     <Modifiers>
@@ -1397,7 +1398,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnHot01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +50 GroundBattleBombardmentAttackerDamagesOnHot per Population-->
+        <!-- +100 GroundBattleBombardmentAttackerDamagesOnHot per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnHot01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -1412,7 +1413,7 @@
     </AssimilatedModifiers>
   </PopulationModifiersTrait>
 
-  <!-- +75 GroundBattleBombardmentAttackerDamagesOnHot -->
+  <!-- +150 GroundBattleBombardmentAttackerDamagesOnHot -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnHot02" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>PlanetGameplayTypeHot,BonusPopulationGroundBattleBombardmentAttackerDamages</Tags>
     <Modifiers>
@@ -1420,7 +1421,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnHot02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +75 GroundBattleBombardmentAttackerDamagesOnHot per Population-->
+        <!-- +150 GroundBattleBombardmentAttackerDamagesOnHot per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnHot02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -1436,7 +1437,7 @@
   </PopulationModifiersTrait>
 
   <!-- GroundBattleBombardmentAttackerDamages On Teeming -->
-  <!-- +25 GroundBattleBombardmentAttackerDamagesOnTeeming -->
+  <!-- +50 GroundBattleBombardmentAttackerDamagesOnTeeming -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnTeeming00" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>PlanetGameplayTypeTeeming,BonusPopulationGroundBattleBombardmentAttackerDamages</Tags>
     <Modifiers>
@@ -1444,7 +1445,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnTeeming00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +25 GroundBattleBombardmentAttackerDamagesOnTeeming per Population-->
+        <!-- +50 GroundBattleBombardmentAttackerDamagesOnTeeming per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnTeeming00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -1459,7 +1460,7 @@
     </AssimilatedModifiers>
   </PopulationModifiersTrait>
 
-  <!-- +50 GroundBattleBombardmentAttackerDamagesOnTeeming -->
+  <!-- +100 GroundBattleBombardmentAttackerDamagesOnTeeming -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnTeeming01" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetGameplayTypeTeeming,BonusPopulationGroundBattleBombardmentAttackerDamages</Tags>
     <Modifiers>
@@ -1467,7 +1468,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnTeeming01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +50 GroundBattleBombardmentAttackerDamagesOnTeeming per Population-->
+        <!-- +100 GroundBattleBombardmentAttackerDamagesOnTeeming per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnTeeming01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -1482,7 +1483,7 @@
     </AssimilatedModifiers>
   </PopulationModifiersTrait>
 
-  <!-- +75 GroundBattleBombardmentAttackerDamagesOnTeeming -->
+  <!-- +150 GroundBattleBombardmentAttackerDamagesOnTeeming -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnTeeming02" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>PlanetGameplayTypeTeeming,BonusPopulationGroundBattleBombardmentAttackerDamages</Tags>
     <Modifiers>
@@ -1490,7 +1491,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnTeeming02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +75 GroundBattleBombardmentAttackerDamagesOnTeeming per Population-->
+        <!-- +150 GroundBattleBombardmentAttackerDamagesOnTeeming per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnTeeming02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -1506,7 +1507,7 @@
   </PopulationModifiersTrait>
 
   <!-- GroundBattleBombardmentAttackerDamages On Meager -->
-  <!-- +25 GroundBattleBombardmentAttackerDamagesOnMeager -->
+  <!-- +50 GroundBattleBombardmentAttackerDamagesOnMeager -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnMeager00" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>PlanetGameplayTypeMeager,BonusPopulationGroundBattleBombardmentAttackerDamages</Tags>
     <Modifiers>
@@ -1514,7 +1515,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnMeager00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +25 GroundBattleBombardmentAttackerDamagesOnMeager per Population-->
+        <!-- +50 GroundBattleBombardmentAttackerDamagesOnMeager per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnMeager00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -1529,7 +1530,7 @@
     </AssimilatedModifiers>
   </PopulationModifiersTrait>
 
-  <!-- +50 GroundBattleBombardmentAttackerDamagesOnMeager -->
+  <!-- +100 GroundBattleBombardmentAttackerDamagesOnMeager -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnMeager01" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetGameplayTypeMeager,BonusPopulationGroundBattleBombardmentAttackerDamages</Tags>
     <Modifiers>
@@ -1537,7 +1538,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnMeager01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +50 GroundBattleBombardmentAttackerDamagesOnMeager per Population-->
+        <!-- +100 GroundBattleBombardmentAttackerDamagesOnMeager per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnMeager01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -1552,7 +1553,7 @@
     </AssimilatedModifiers>
   </PopulationModifiersTrait>
 
-  <!-- +75 GroundBattleBombardmentAttackerDamagesOnMeager -->
+  <!-- +150 GroundBattleBombardmentAttackerDamagesOnMeager -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnMeager02" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>PlanetGameplayTypeMeager,BonusPopulationGroundBattleBombardmentAttackerDamages</Tags>
     <Modifiers>
@@ -1560,7 +1561,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnMeager02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +75 GroundBattleBombardmentAttackerDamagesOnMeager per Population-->
+        <!-- +150 GroundBattleBombardmentAttackerDamagesOnMeager per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnMeager02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -1575,7 +1576,7 @@
     </AssimilatedModifiers>
   </PopulationModifiersTrait>
 
-  <!-- +50 GroundBattleBombardmentAttackerDamagesOnGas -->
+  <!-- +100 GroundBattleBombardmentAttackerDamagesOnGas -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnGas00" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>PlanetGameplayTypeGas,BonusPopulationGroundBattleBombardmentAttackerDamages</Tags>
     <Modifiers>
@@ -1583,7 +1584,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnGas00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +50 GroundBattleBombardmentAttackerDamagesOnGas per Population-->
+        <!-- +100 GroundBattleBombardmentAttackerDamagesOnGas per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnGas00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -1598,7 +1599,7 @@
     </AssimilatedModifiers>
   </PopulationModifiersTrait>
 
-  <!-- +75 GroundBattleBombardmentAttackerDamagesOnGas -->
+  <!-- +150 GroundBattleBombardmentAttackerDamagesOnGas -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnGas01" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetGameplayTypeGas,BonusPopulationGroundBattleBombardmentAttackerDamages</Tags>
     <Modifiers>
@@ -1606,7 +1607,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnGas01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +75 GroundBattleBombardmentAttackerDamagesOnGas per Population-->
+        <!-- +150 GroundBattleBombardmentAttackerDamagesOnGas per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnGas01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -1621,7 +1622,7 @@
     </AssimilatedModifiers>
   </PopulationModifiersTrait>
 
-  <!-- +100 GroundBattleBombardmentAttackerDamagesOnGas -->
+  <!-- +200 GroundBattleBombardmentAttackerDamagesOnGas -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnGas02" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>PlanetGameplayTypeGas,BonusPopulationGroundBattleBombardmentAttackerDamages</Tags>
     <Modifiers>
@@ -1629,7 +1630,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnGas02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +75 GroundBattleBombardmentAttackerDamagesOnGas per Population-->
+        <!-- +200 GroundBattleBombardmentAttackerDamagesOnGas per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnGas02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -1645,7 +1646,7 @@
   </PopulationModifiersTrait>
 
   <!-- GroundBattleBombardmentAttackerDamages On Happy -->
-  <!-- +25 GroundBattleBombardmentAttackerDamagesOnHappy -->
+  <!-- +50 GroundBattleBombardmentAttackerDamagesOnHappy -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnHappy00" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>HappinessStatusStarSystem3,BonusPopulationGroundBattleBombardmentAttackerDamages</Tags>
     <Modifiers>
@@ -1653,7 +1654,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnHappy00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +25 GroundBattleBombardmentAttackerDamagesOnHappy per Population-->
+        <!-- +50 GroundBattleBombardmentAttackerDamagesOnHappy per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnHappy00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -1668,7 +1669,7 @@
     </AssimilatedModifiers>
   </PopulationModifiersTrait>
 
-  <!-- +50 GroundBattleBombardmentAttackerDamagesOnHappy -->
+  <!-- +100 GroundBattleBombardmentAttackerDamagesOnHappy -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnHappy01" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>HappinessStatusStarSystem3,BonusPopulationGroundBattleBombardmentAttackerDamages</Tags>
     <Modifiers>
@@ -1676,7 +1677,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnHappy01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +50 GroundBattleBombardmentAttackerDamagesOnHappy per Population-->
+        <!-- +100 GroundBattleBombardmentAttackerDamagesOnHappy per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnHappy01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -1691,7 +1692,7 @@
     </AssimilatedModifiers>
   </PopulationModifiersTrait>
 
-  <!-- +75 GroundBattleBombardmentAttackerDamagesOnHappy -->
+  <!-- +150 GroundBattleBombardmentAttackerDamagesOnHappy -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnHappy02" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>HappinessStatusStarSystem3,BonusPopulationGroundBattleBombardmentAttackerDamages</Tags>
     <Modifiers>
@@ -1699,7 +1700,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnHappy02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +75 GroundBattleBombardmentAttackerDamagesOnHappy per Population-->
+        <!-- +150 GroundBattleBombardmentAttackerDamagesOnHappy per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnHappy02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -2065,7 +2066,7 @@
   </PopulationModifiersTrait>
 
   <!-- GroundBattleBombardmentAttackerDamages on Strategic -->
-  <!-- +25 GroundBattleBombardmentAttackerDamagesOnStrategic -->
+  <!-- +50 GroundBattleBombardmentAttackerDamagesOnStrategic -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnStrategic00" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>HappinessStatusStarSystem3,BonusPopulationGroundBattleBombardmentAttackerDamages</Tags>
     <Modifiers>
@@ -2073,7 +2074,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnStrategic00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +25 GroundBattleBombardmentAttackerDamagesOnStrategic per Population-->
+        <!-- +50 GroundBattleBombardmentAttackerDamagesOnStrategic per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnStrategic00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -2088,39 +2089,15 @@
     </AssimilatedModifiers>
   </PopulationModifiersTrait>
 
-  <!-- GroundBattleBombardmentAttackerDamages on Anomaly -->
-  <!-- +75 GroundBattleBombardmentAttackerDamagesOnAnomaly -->
-  <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnAnomaly00" SubCategory="Secondary" ShowInCustom="true" Cost="10">
-    <Tags>PlanetAnomaly,BonusPopulationGroundBattleBombardmentAttackerDamages</Tags>
-    <Modifiers>
-      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
-        <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnAnomaly00"/>
-      </Modifier>
-      <Modifier Class="ClassPopulationPlanet">
-        <!-- +75 GroundBattleBombardmentAttackerDamagesOnAnomaly per Population-->
-        <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnAnomaly00"/>
-      </Modifier>
-      <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
-        <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnAnomaly00"/>
-      </Modifier>
-    </Modifiers>
-
-    <AssimilatedModifiers>
-      <Modifier Class="ClassPopulationPlanet">
-        <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnAnomaly00"/>
-      </Modifier>
-    </AssimilatedModifiers>
-  </PopulationModifiersTrait>
-
   <!-- GroundBattleBombardmentAttackerDamages per Minor Faction -->
-  <!-- +25 GroundBattleBombardmentAttackerDamagesPerMinorFaction -->
+  <!-- +50 GroundBattleBombardmentAttackerDamagesPerMinorFaction -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesPerMinorFaction00" SubCategory="Secondary" ShowInCustom="true" Cost="20">
     <Modifiers>
       <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesPerMinorFaction00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +25 GroundBattleBombardmentAttackerDamagesPerMinorFaction per Population-->
+        <!-- +50 GroundBattleBombardmentAttackerDamagesPerMinorFaction per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesPerMinorFaction00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -2136,14 +2113,14 @@
   </PopulationModifiersTrait>
 
   <!-- GroundBattleBombardmentAttackerDamages per Backdoor -->
-  <!-- +25 GroundBattleBombardmentAttackerDamagesPerBackdoor -->
+  <!-- +50 GroundBattleBombardmentAttackerDamagesPerBackdoor -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesPerBackdoor00" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Modifiers>
       <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesPerBackdoor00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +25 GroundBattleBombardmentAttackerDamagesPerBackdoor per Population-->
+        <!-- +50 GroundBattleBombardmentAttackerDamagesPerBackdoor per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesPerBackdoor00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -2158,7 +2135,7 @@
     </AssimilatedModifiers>
   </PopulationModifiersTrait>
 
-  <!-- GroundBattleBombardmentAttackerDamages per Temple -->
+  <!-- +100 then +150 GroundBattleBombardmentAttackerDamages per Temple -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesPerTemple00" SubCategory="Primary" ShowInCustom="true" Cost="5">
     <Modifiers>
       <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
@@ -2179,7 +2156,7 @@
     </AssimilatedModifiers>
   </PopulationModifiersTrait>
 
-  <!-- GroundBattleBombardmentAttackerDamages per System Level -->
+  <!-- +30 GroundBattleBombardmentAttackerDamages per System Level -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesPerSystemLevel00" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Modifiers>
       <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
@@ -2201,7 +2178,7 @@
   </PopulationModifiersTrait>
 
   <!-- GroundBattleBombardmentAttackerDamages on Luxury -->
-  <!-- +2 GroundBattleBombardmentAttackerDamagesOnLuxury -->
+  <!-- +100 GroundBattleBombardmentAttackerDamagesOnLuxury -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnLuxury00" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>HappinessStatusStarSystem3,BonusPopulationGroundBattleBombardmentAttackerDamages</Tags>
     <Modifiers>
@@ -2224,8 +2201,32 @@
     </AssimilatedModifiers>
   </PopulationModifiersTrait>
 
+  <!-- GroundBattleBombardmentAttackerDamages on Anomaly -->
+  <!-- +150 GroundBattleBombardmentAttackerDamagesOnAnomaly -->
+  <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnAnomaly00" SubCategory="Secondary" ShowInCustom="true" Cost="10">
+    <Tags>PlanetAnomaly,BonusPopulationGroundBattleBombardmentAttackerDamages</Tags>
+    <Modifiers>
+      <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
+        <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnAnomaly00"/>
+      </Modifier>
+      <Modifier Class="ClassPopulationPlanet">
+        <!-- +150 GroundBattleBombardmentAttackerDamagesOnAnomaly per Population-->
+        <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnAnomaly00"/>
+      </Modifier>
+      <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
+        <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnAnomaly00"/>
+      </Modifier>
+    </Modifiers>
+
+    <AssimilatedModifiers>
+      <Modifier Class="ClassPopulationPlanet">
+        <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomGroundBattleBombardmentAttackerDamagesOnAnomaly00"/>
+      </Modifier>
+    </AssimilatedModifiers>
+  </PopulationModifiersTrait>
+
   <!-- Defense On Cold -->
-  <!-- +25 DefenseOnCold -->
+  <!-- +50 DefenseOnCold -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnCold00" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>PlanetGameplayTypeCold,BonusPopulationDefense</Tags>
     <Modifiers>
@@ -2233,7 +2234,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnCold00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +25 DefenseOnCold per Population-->
+        <!-- +50 DefenseOnCold per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnCold00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -2248,7 +2249,7 @@
     </AssimilatedModifiers>
   </PopulationModifiersTrait>
 
-  <!-- +50 DefenseOnCold -->
+  <!-- +100 DefenseOnCold -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnCold01" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetGameplayTypeCold,BonusPopulationDefense</Tags>
     <Modifiers>
@@ -2256,7 +2257,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnCold01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +50 DefenseOnCold per Population-->
+        <!-- +100 DefenseOnCold per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnCold01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -2271,7 +2272,7 @@
     </AssimilatedModifiers>
   </PopulationModifiersTrait>
 
-  <!-- +75 DefenseOnCold -->
+  <!-- +150 DefenseOnCold -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnCold02" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>PlanetGameplayTypeCold,BonusPopulationDefense</Tags>
     <Modifiers>
@@ -2279,7 +2280,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnCold02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +75 DefenseOnCold per Population-->
+        <!-- +150 DefenseOnCold per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnCold02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -2295,7 +2296,7 @@
   </PopulationModifiersTrait>
 
   <!-- Defense On Temperate -->
-  <!-- +25 DefenseOnTemperate -->
+  <!-- +50 DefenseOnTemperate -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnTemperate00" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>PlanetGameplayTypeTemperate,BonusPopulationDefense</Tags>
     <Modifiers>
@@ -2303,7 +2304,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnTemperate00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +25 DefenseOnTemperate per Population-->
+        <!-- +50 DefenseOnTemperate per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnTemperate00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -2318,7 +2319,7 @@
     </AssimilatedModifiers>
   </PopulationModifiersTrait>
 
-  <!-- +50 DefenseOnTemperate -->
+  <!-- +100 DefenseOnTemperate -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnTemperate01" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetGameplayTypeTemperate,BonusPopulationDefense</Tags>
     <Modifiers>
@@ -2326,7 +2327,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnTemperate01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +50 DefenseOnTemperate per Population-->
+        <!-- +100 DefenseOnTemperate per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnTemperate01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -2341,7 +2342,7 @@
     </AssimilatedModifiers>
   </PopulationModifiersTrait>
 
-  <!-- +75 DefenseOnTemperate -->
+  <!-- +150 DefenseOnTemperate -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnTemperate02" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>PlanetGameplayTypeTemperate,BonusPopulationDefense</Tags>
     <Modifiers>
@@ -2349,7 +2350,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnTemperate02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +75 DefenseOnTemperate per Population-->
+        <!-- +150 DefenseOnTemperate per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnTemperate02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -2365,7 +2366,7 @@
   </PopulationModifiersTrait>
 
   <!-- Defense On Hot -->
-  <!-- +25 DefenseOnHot -->
+  <!-- +50 DefenseOnHot -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnHot00" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>PlanetGameplayTypeHot,BonusPopulationDefense</Tags>
     <Modifiers>
@@ -2373,7 +2374,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnHot00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +25 DefenseOnHot per Population-->
+        <!-- +50 DefenseOnHot per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnHot00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -2388,7 +2389,7 @@
     </AssimilatedModifiers>
   </PopulationModifiersTrait>
 
-  <!-- +50 DefenseOnHot -->
+  <!-- +100 DefenseOnHot -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnHot01" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetGameplayTypeHot,BonusPopulationDefense</Tags>
     <Modifiers>
@@ -2396,7 +2397,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnHot01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +50 DefenseOnHot per Population-->
+        <!-- +100 DefenseOnHot per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnHot01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -2411,7 +2412,7 @@
     </AssimilatedModifiers>
   </PopulationModifiersTrait>
 
-  <!-- +75 DefenseOnHot -->
+  <!-- +150 DefenseOnHot -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnHot02" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>PlanetGameplayTypeHot,BonusPopulationDefense</Tags>
     <Modifiers>
@@ -2419,7 +2420,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnHot02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +75 DefenseOnHot per Population-->
+        <!-- +150 DefenseOnHot per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnHot02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -2435,7 +2436,7 @@
   </PopulationModifiersTrait>
 
   <!-- Defense On Teeming -->
-  <!-- +25 DefenseOnTeeming -->
+  <!-- +50 DefenseOnTeeming -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnTeeming00" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>PlanetGameplayTypeTeeming,BonusPopulationDefense</Tags>
     <Modifiers>
@@ -2443,7 +2444,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnTeeming00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +25 DefenseOnTeeming per Population-->
+        <!-- +50 DefenseOnTeeming per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnTeeming00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -2458,7 +2459,7 @@
     </AssimilatedModifiers>
   </PopulationModifiersTrait>
 
-  <!-- +50 DefenseOnTeeming -->
+  <!-- +100 DefenseOnTeeming -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnTeeming01" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetGameplayTypeTeeming,BonusPopulationDefense</Tags>
     <Modifiers>
@@ -2466,7 +2467,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnTeeming01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +50 DefenseOnTeeming per Population-->
+        <!-- +100 DefenseOnTeeming per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnTeeming01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -2481,7 +2482,7 @@
     </AssimilatedModifiers>
   </PopulationModifiersTrait>
 
-  <!-- +75 DefenseOnTeeming -->
+  <!-- +150 DefenseOnTeeming -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnTeeming02" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>PlanetGameplayTypeTeeming,BonusPopulationDefense</Tags>
     <Modifiers>
@@ -2489,7 +2490,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnTeeming02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +75 DefenseOnTeeming per Population-->
+        <!-- +150 DefenseOnTeeming per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnTeeming02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -2505,7 +2506,7 @@
   </PopulationModifiersTrait>
 
   <!-- Defense On Meager -->
-  <!-- +25 DefenseOnMeager -->
+  <!-- +100 DefenseOnMeager -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnMeager00" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>PlanetGameplayTypeMeager,BonusPopulationDefense</Tags>
     <Modifiers>
@@ -2513,7 +2514,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnMeager00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +25 DefenseOnMeager per Population-->
+        <!-- +100 DefenseOnMeager per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnMeager00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -2528,7 +2529,7 @@
     </AssimilatedModifiers>
   </PopulationModifiersTrait>
 
-  <!-- +50 DefenseOnMeager -->
+  <!-- +100 DefenseOnMeager -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnMeager01" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetGameplayTypeMeager,BonusPopulationDefense</Tags>
     <Modifiers>
@@ -2536,7 +2537,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnMeager01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +50 DefenseOnMeager per Population-->
+        <!-- +100 DefenseOnMeager per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnMeager01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -2551,7 +2552,7 @@
     </AssimilatedModifiers>
   </PopulationModifiersTrait>
 
-  <!-- +75 DefenseOnMeager -->
+  <!-- +150 DefenseOnMeager -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnMeager02" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>PlanetGameplayTypeMeager,BonusPopulationDefense</Tags>
     <Modifiers>
@@ -2559,7 +2560,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnMeager02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +75 DefenseOnMeager per Population-->
+        <!-- +150 DefenseOnMeager per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnMeager02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -2574,7 +2575,7 @@
     </AssimilatedModifiers>
   </PopulationModifiersTrait>
 
-  <!-- +50 DefenseOnGas -->
+  <!-- +100 DefenseOnGas -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnGas00" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>PlanetGameplayTypeGas,BonusPopulationDefense</Tags>
     <Modifiers>
@@ -2582,7 +2583,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnGas00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +50 DefenseOnGas per Population-->
+        <!-- +100 DefenseOnGas per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnGas00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -2597,7 +2598,7 @@
     </AssimilatedModifiers>
   </PopulationModifiersTrait>
 
-  <!-- +75 DefenseOnGas -->
+  <!-- +150 DefenseOnGas -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnGas01" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetGameplayTypeGas,BonusPopulationDefense</Tags>
     <Modifiers>
@@ -2605,7 +2606,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnGas01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +75 DefenseOnGas per Population-->
+        <!-- +150 DefenseOnGas per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnGas01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -2620,7 +2621,7 @@
     </AssimilatedModifiers>
   </PopulationModifiersTrait>
 
-  <!-- +100 DefenseOnGas -->
+  <!-- +200 DefenseOnGas -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnGas02" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>PlanetGameplayTypeGas,BonusPopulationDefense</Tags>
     <Modifiers>
@@ -2628,7 +2629,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnGas02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +75 DefenseOnGas per Population-->
+        <!-- +200 DefenseOnGas per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnGas02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -2644,7 +2645,7 @@
   </PopulationModifiersTrait>
 
   <!-- Defense On Happy -->
-  <!-- +25 DefenseOnHappy -->
+  <!-- +50 DefenseOnHappy -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnHappy00" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>HappinessStatusStarSystem3,BonusPopulationDefense</Tags>
     <Modifiers>
@@ -2652,7 +2653,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnHappy00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +25 DefenseOnHappy per Population-->
+        <!-- +50 DefenseOnHappy per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnHappy00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -2667,7 +2668,7 @@
     </AssimilatedModifiers>
   </PopulationModifiersTrait>
 
-  <!-- +50 DefenseOnHappy -->
+  <!-- +100 DefenseOnHappy -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnHappy01" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>HappinessStatusStarSystem3,BonusPopulationDefense</Tags>
     <Modifiers>
@@ -2675,7 +2676,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnHappy01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +50 DefenseOnHappy per Population-->
+        <!-- +100 DefenseOnHappy per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnHappy01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -2690,7 +2691,7 @@
     </AssimilatedModifiers>
   </PopulationModifiersTrait>
 
-  <!-- +75 DefenseOnHappy -->
+  <!-- +150 DefenseOnHappy -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnHappy02" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>HappinessStatusStarSystem3,BonusPopulationDefense</Tags>
     <Modifiers>
@@ -2698,7 +2699,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnHappy02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +75 DefenseOnHappy per Population-->
+        <!-- +150 DefenseOnHappy per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnHappy02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -2714,7 +2715,7 @@
   </PopulationModifiersTrait>
 
   <!-- Defense On Tiny -->
-  <!-- +1 DefenseOnTiny -->
+  <!-- +5 DefenseOnTiny -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnTiny00" SubCategory="Secondary" ShowInCustom="false" Cost="5">
     <Tags>PlanetSizeTiny,BonusPopulationDefense</Tags>
     <Modifiers>
@@ -2722,7 +2723,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnTiny00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +1 DefenseOnTiny per Population-->
+        <!-- +5 DefenseOnTiny per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnTiny00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -2737,7 +2738,7 @@
     </AssimilatedModifiers>
   </PopulationModifiersTrait>
 
-  <!-- +2 DefenseOnTiny -->
+  <!-- +10 DefenseOnTiny -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnTiny01" SubCategory="Secondary" ShowInCustom="false" Cost="10">
     <Tags>PlanetSizeTiny,BonusPopulationDefense</Tags>
     <Modifiers>
@@ -2745,7 +2746,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnTiny01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +2 DefenseOnTiny per Population-->
+        <!-- +10 DefenseOnTiny per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnTiny01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -2760,7 +2761,7 @@
     </AssimilatedModifiers>
   </PopulationModifiersTrait>
 
-  <!-- +3 DefenseOnTiny -->
+  <!-- +15 DefenseOnTiny -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnTiny02" SubCategory="Secondary" ShowInCustom="false" Cost="15">
     <Tags>PlanetSizeTiny,BonusPopulationDefense</Tags>
     <Modifiers>
@@ -2768,7 +2769,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnTiny02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +3 DefenseOnTiny per Population-->
+        <!-- +15 DefenseOnTiny per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnTiny02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -2784,7 +2785,7 @@
   </PopulationModifiersTrait>
 
   <!-- Defense On Small -->
-  <!-- +1 DefenseOnSmall -->
+  <!-- +5 DefenseOnSmall -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnSmall00" SubCategory="Secondary" ShowInCustom="false" Cost="5">
     <Tags>PlanetSizeSmall,BonusPopulationDefense</Tags>
     <Modifiers>
@@ -2792,7 +2793,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnSmall00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +1 DefenseOnSmall per Population-->
+        <!-- +5 DefenseOnSmall per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnSmall00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -2807,7 +2808,7 @@
     </AssimilatedModifiers>
   </PopulationModifiersTrait>
 
-  <!-- +2 DefenseOnSmall -->
+  <!-- +10 DefenseOnSmall -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnSmall01" SubCategory="Secondary" ShowInCustom="false" Cost="10">
     <Tags>PlanetSizeSmall,BonusPopulationDefense</Tags>
     <Modifiers>
@@ -2815,7 +2816,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnSmall01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +2 DefenseOnSmall per Population-->
+        <!-- +10 DefenseOnSmall per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnSmall01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -2830,7 +2831,7 @@
     </AssimilatedModifiers>
   </PopulationModifiersTrait>
 
-  <!-- +3 DefenseOnSmall -->
+  <!-- +15 DefenseOnSmall -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnSmall02" SubCategory="Secondary" ShowInCustom="false" Cost="15">
     <Tags>PlanetSizeSmall,BonusPopulationDefense</Tags>
     <Modifiers>
@@ -2838,7 +2839,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnSmall02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +3 DefenseOnSmall per Population-->
+        <!-- +15 DefenseOnSmall per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnSmall02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -2854,7 +2855,7 @@
   </PopulationModifiersTrait>
 
   <!-- Defense On Medium -->
-  <!-- +1 DefenseOnMedium -->
+  <!-- +5 DefenseOnMedium -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnMedium00" SubCategory="Secondary" ShowInCustom="false" Cost="5">
     <Tags>PlanetSizeMedium,BonusPopulationDefense</Tags>
     <Modifiers>
@@ -2862,7 +2863,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnMedium00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +1 DefenseOnMedium per Population-->
+        <!-- +5 DefenseOnMedium per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnMedium00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -2877,7 +2878,7 @@
     </AssimilatedModifiers>
   </PopulationModifiersTrait>
 
-  <!-- +2 DefenseOnMedium -->
+  <!-- +10 DefenseOnMedium -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnMedium01" SubCategory="Secondary" ShowInCustom="false" Cost="10">
     <Tags>PlanetSizeMedium,BonusPopulationDefense</Tags>
     <Modifiers>
@@ -2885,7 +2886,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnMedium01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +2 DefenseOnMedium per Population-->
+        <!-- +10 DefenseOnMedium per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnMedium01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -2900,7 +2901,7 @@
     </AssimilatedModifiers>
   </PopulationModifiersTrait>
 
-  <!-- +3 DefenseOnMedium -->
+  <!-- +15 DefenseOnMedium -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnMedium02" SubCategory="Secondary" ShowInCustom="false" Cost="15">
     <Tags>PlanetSizeMedium,BonusPopulationDefense</Tags>
     <Modifiers>
@@ -2908,7 +2909,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnMedium02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +3 DefenseOnMedium per Population-->
+        <!-- +15 DefenseOnMedium per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnMedium02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -2924,7 +2925,7 @@
   </PopulationModifiersTrait>
 
   <!-- Defense On Large -->
-  <!-- +1 DefenseOnLarge -->
+  <!-- +5 DefenseOnLarge -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnLarge00" SubCategory="Secondary" ShowInCustom="false" Cost="5">
     <Tags>PlanetSizeLarge,BonusPopulationDefense</Tags>
     <Modifiers>
@@ -2932,7 +2933,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnLarge00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +1 DefenseOnLarge per Population-->
+        <!-- +5 DefenseOnLarge per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnLarge00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -2947,7 +2948,7 @@
     </AssimilatedModifiers>
   </PopulationModifiersTrait>
 
-  <!-- +2 DefenseOnLarge -->
+  <!-- +10 DefenseOnLarge -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnLarge01" SubCategory="Secondary" ShowInCustom="false" Cost="10">
     <Tags>PlanetSizeLarge,BonusPopulationDefense</Tags>
     <Modifiers>
@@ -2955,7 +2956,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnLarge01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +2 DefenseOnLarge per Population-->
+        <!-- +10 DefenseOnLarge per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnLarge01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -2970,7 +2971,7 @@
     </AssimilatedModifiers>
   </PopulationModifiersTrait>
 
-  <!-- +3 DefenseOnLarge -->
+  <!-- +15 DefenseOnLarge -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnLarge02" SubCategory="Secondary" ShowInCustom="false" Cost="15">
     <Tags>PlanetSizeLarge,BonusPopulationDefense</Tags>
     <Modifiers>
@@ -2978,7 +2979,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnLarge02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +3 DefenseOnLarge per Population-->
+        <!-- +15 DefenseOnLarge per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnLarge02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -2994,7 +2995,7 @@
   </PopulationModifiersTrait>
 
   <!-- Defense On Huge -->
-  <!-- +1 DefenseOnHuge -->
+  <!-- +5 DefenseOnHuge -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnHuge00" SubCategory="Secondary" ShowInCustom="false" Cost="5">
     <Tags>PlanetSizeHuge,BonusPopulationDefense</Tags>
     <Modifiers>
@@ -3002,7 +3003,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnHuge00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +1 DefenseOnHuge per Population-->
+        <!-- +5 DefenseOnHuge per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnHuge00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -3017,7 +3018,7 @@
     </AssimilatedModifiers>
   </PopulationModifiersTrait>
 
-  <!-- +2 DefenseOnHuge -->
+  <!-- +10 DefenseOnHuge -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnHuge01" SubCategory="Secondary" ShowInCustom="false" Cost="10">
     <Tags>PlanetSizeHuge,BonusPopulationDefense</Tags>
     <Modifiers>
@@ -3025,7 +3026,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnHuge01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +2 DefenseOnHuge per Population-->
+        <!-- +10 DefenseOnHuge per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnHuge01"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -3040,7 +3041,7 @@
     </AssimilatedModifiers>
   </PopulationModifiersTrait>
 
-  <!-- +3 DefenseOnHuge -->
+  <!-- +15 DefenseOnHuge -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnHuge02" SubCategory="Secondary" ShowInCustom="false" Cost="15">
     <Tags>PlanetSizeHuge,BonusPopulationDefense</Tags>
     <Modifiers>
@@ -3048,7 +3049,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnHuge02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +3 DefenseOnHuge per Population-->
+        <!-- +15 DefenseOnHuge per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnHuge02"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -3064,7 +3065,7 @@
   </PopulationModifiersTrait>
 
   <!-- Defense on Strategic -->
-  <!-- +25 DefenseOnStrategic -->
+  <!-- +100 DefenseOnStrategic -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnStrategic00" SubCategory="Secondary" ShowInCustom="true" Cost="5">
     <Tags>HappinessStatusStarSystem3,BonusPopulationDefense</Tags>
     <Modifiers>
@@ -3072,7 +3073,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnStrategic00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +25 DefenseOnStrategic per Population-->
+        <!-- +100 DefenseOnStrategic per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnStrategic00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -3088,7 +3089,7 @@
   </PopulationModifiersTrait>
 
   <!-- Defense on Anomaly -->
-  <!-- +75 DefenseOnAnomaly -->
+  <!-- +100 then +150 DefenseOnAnomaly -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnAnomaly00" SubCategory="Secondary" ShowInCustom="true" Cost="10">
     <Tags>PlanetAnomaly,BonusPopulationDefense</Tags>
     <Modifiers>
@@ -3096,7 +3097,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnAnomaly00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +75 DefenseOnAnomaly per Population-->
+        <!-- +100 then +150 DefenseOnAnomaly per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnAnomaly00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -3112,14 +3113,14 @@
   </PopulationModifiersTrait>
 
   <!-- Defense per Minor Faction -->
-  <!-- +25 DefensePerMinorFaction -->
+  <!-- +50 DefensePerMinorFaction -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefensePerMinorFaction00" SubCategory="Secondary" ShowInCustom="true" Cost="20">
     <Modifiers>
       <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomDefensePerMinorFaction00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +25 DefensePerMinorFaction per Population-->
+        <!-- +50 DefensePerMinorFaction per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefensePerMinorFaction00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -3135,14 +3136,14 @@
   </PopulationModifiersTrait>
 
   <!-- Defense per Backdoor -->
-  <!-- +25 DefensePerBackdoor -->
+  <!-- +50 DefensePerBackdoor -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefensePerBackdoor00" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Modifiers>
       <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerPerBackdoor00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +25 DefensePerBackdoor per Population-->
+        <!-- +50 DefensePerBackdoor per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefensePerBackdoor00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">
@@ -3157,7 +3158,7 @@
     </AssimilatedModifiers>
   </PopulationModifiersTrait>
 
-  <!-- Defense per Temple -->
+  <!-- +10 Defense per Temple -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefensePerTemple00" SubCategory="Primary" ShowInCustom="true" Cost="5">
     <Modifiers>
       <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
@@ -3178,7 +3179,7 @@
     </AssimilatedModifiers>
   </PopulationModifiersTrait>
 
-  <!-- Defense per System Level -->
+  <!-- +5 Defense per System Level -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefensePerSystemLevel00" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Modifiers>
       <Modifier Class="ClassPopulationPlanet" DisplayWhenBoostedOnly="true">
@@ -3200,7 +3201,7 @@
   </PopulationModifiersTrait>
 
   <!-- Defense on Luxury -->
-  <!-- +2 DefenseOnLuxury -->
+  <!-- +10 DefenseOnLuxury -->
   <PopulationModifiersTrait Name="PopulationModifiersTraitSecondaryCustomDefenseOnLuxury00" SubCategory="Secondary" ShowInCustom="true" Cost="15">
     <Tags>HappinessStatusStarSystem3,BonusPopulationDefense</Tags>
     <Modifiers>
@@ -3208,7 +3209,7 @@
         <SimulationDescriptorReference Name="WithPopulationPlanetModifiersTraitSecondaryCustomSystemManpowerOnLuxury00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet">
-        <!-- +2 DefenseOnLuxury per Population-->
+        <!-- +10 DefenseOnLuxury per Population-->
         <SimulationDescriptorReference Name="ClassPopulationPlanetModifiersTraitSecondaryCustomDefenseOnLuxury00"/>
       </Modifier>
       <Modifier Class="ClassPopulationPlanet" SuperPopulationOnly="true">

--- a/Endless Space Competitive Mod/Simulation/Traits/SimulationDescriptors[7_Military].xml
+++ b/Endless Space Competitive Mod/Simulation/Traits/SimulationDescriptors[7_Military].xml
@@ -45,7 +45,7 @@
   </SimulationDescriptor>
 
   <!-- SystemManpower -->
-  <!-- +5 SystemManpower -->
+  <!--Removed +5 SystemManpower -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitPrimaryCustomSystemManpower00" Type="WithPopulationPlanet">
 	<Modifier       TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Value="5"   Path="FAKEFORGUI/./ClassPopulation"/>
 	<BinaryModifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Left="5"    BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
@@ -59,7 +59,7 @@
     <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="5" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +10 SystemManpower -->
+  <!--Removed +10 SystemManpower -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitPrimaryCustomSystemManpower01" Type="WithPopulationPlanet">
 	<Modifier       TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Value="10"  Path="FAKEFORGUI/./ClassPopulation"/>
 	<BinaryModifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Left="10"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
@@ -69,7 +69,7 @@
     <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="10" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- +15 SystemManpower -->
+  <!--Removed +15 SystemManpower -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitPrimaryCustomSystemManpower02" Type="WithPopulationPlanet">
 	<Modifier       TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Value="15"  Path="FAKEFORGUI/./ClassPopulation"/>
 	<BinaryModifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Left="15"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
@@ -777,6 +777,7 @@
   <SimulationDescriptor Name="ClassPopulationAssimilatedSecondaryCustomEmpireManpowerPerMinorFaction00" Type="ClassPopulationAssimilated">
     <Modifier TargetProperty="BonusPopulationEmpireManpower" Operation="Addition" Value="5" Path="ClassPopulation"/>
   </SimulationDescriptor>
+
   <!-- EmpireManpower per Backdoor -->
   <!-- +1 EmpireManpowerPerBackdoor -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomEmpireManpowerPerBackdoor00" Type="WithPopulationPlanet">
@@ -1445,7 +1446,7 @@
     <Modifier TargetProperty="BonusPopulationSystemManpower" Operation="Addition" Value="5" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- SystemManpower per Temple -->
+  <!-- +10 SystemManpower per Temple -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitPrimaryCustomSystemManpowerPerTemple00" Type="WithPopulationPlanet">
     <Modifier       TargetProperty="BonusPopulationSystemManpower" Operation="Addition"    Value="10"  Path="FAKEFORGUI/./PlanetWithTemple"/>
     <BinaryModifier TargetProperty="PopulationAuxValue0"		   Operation="Addition"    Left="10"   BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
@@ -2098,7 +2099,7 @@
     <Modifier TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition" Value="50" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
-  <!-- GroundBattleBombardmentAttackerDamages per Temple -->
+  <!-- +100 then +150 GroundBattleBombardmentAttackerDamages per Temple -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitPrimaryCustomGroundBattleBombardmentAttackerDamagesPerTemple00" Type="WithPopulationPlanet">
     <Modifier       TargetProperty="BonusPopulationGroundBattleBombardmentAttackerDamages" Operation="Addition"    Value="150" Path="FAKEFORGUI/./PlanetWithTemple"/>
     <BinaryModifier TargetProperty="PopulationAuxValue0"								   Operation="Addition"    Left="150"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
@@ -2180,7 +2181,7 @@
   </SimulationDescriptor>
 
   <SimulationDescriptor Name="ClassPopulationAssimilatedSecondaryCustomDefenseOnTemperate00" Type="ClassPopulationAssimilated">
-    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="05" Path="ClassPopulation"/>
+    <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="50" Path="ClassPopulation"/>
   </SimulationDescriptor>
 
   <!-- +100 DefenseOnTemperate -->
@@ -2706,7 +2707,7 @@
   </SimulationDescriptor>
 
   <!-- Defense on Anomaly -->
-  <!-- +150 DefenseOnAnomaly -->
+  <!-- +100 then 150 DefenseOnAnomaly -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDefenseOnAnomaly00" Type="WithPopulationPlanet">
     <Modifier       TargetProperty="BonusPopulationDefense" Operation="Addition"    Value="100" Path="FAKEFORGUI/./PlanetAnomaly"/>
     <BinaryModifier TargetProperty="PopulationAuxValue1"	Operation="Addition"    Left="100"  BinaryOperation="Multiplication" Right="$(PopulationIsBoosted)" TooltipHidden="true"/>
@@ -2736,6 +2737,7 @@
   <SimulationDescriptor Name="ClassPopulationAssimilatedSecondaryCustomDefensePerMinorFaction00" Type="ClassPopulationAssimilated">
     <Modifier TargetProperty="BonusPopulationDefense" Operation="Addition" Value="50" Path="ClassPopulation"/>
   </SimulationDescriptor>
+
   <!-- Defense per Backdoor -->
   <!-- +50 DefensePerBackdoor -->
   <SimulationDescriptor Name="WithPopulationPlanetModifiersTraitSecondaryCustomDefensePerBackdoor00" Type="WithPopulationPlanet">


### PR DESCRIPTION
Custom homeworld localization bug work-around. Rearranged sim desc planets into the correct FIDS planet order, added comments and consistent spacing

Comments only, mostly as a reminder to go through the rest of them: pop Military traits: Fixed typo on +50 Temperate defense, comments adjusted for manpower tweaks, made order and spacing more consistent spacing, and finished missing annotations
Some Pop Def comments were incorrect. Only a few were verified.