### PR TITLE
Fix icon paths for QuestUnfallen98/99

### DIFF
--- a/Endless Space Competitive Mod/GUI/GUIElements[EmpireImprovements].xml
+++ b/Endless Space Competitive Mod/GUI/GUIElements[EmpireImprovements].xml
@@ -640,8 +640,8 @@
     <Title>%EmpireImprovementQuestUnfallen98Title</Title>
     <Description>%EmpireImprovementQuestUnfallen98Description</Description>
     <Icons>
-      <Icon Size="Small" Path="Textures\Modules\Quest\EmpireImprovementPopulationSlotIncreaseSmall.png" />
-      <Icon Size="Large" Path="Textures\Modules\Quest\EmpireImprovementPopulationSlotIncreaseLarge.png" />
+      <Icon Size="Small" Path="Textures\EmpireImprovements\EmpireImprovementPopulationSlotIncreaseSmall.png" />
+      <Icon Size="Large" Path="Textures\EmpireImprovements\EmpireImprovementPopulationSlotIncreaseLarge.png" />
     </Icons>
   </ExtendedGuiElement>
 
@@ -649,8 +649,8 @@
     <Title>%EmpireImprovementQuestUnfallen99Title</Title>
     <Description>%EmpireImprovementQuestUnfallen99Description</Description>
     <Icons>
-      <Icon Size="Small" Path="Textures\Modules\Quest\EmpireImprovementUnfallenScienceSmall.png" />
-      <Icon Size="Large" Path="Textures\Modules\Quest\EmpireImprovementUnfallenScienceLarge.png" />
+      <Icon Size="Small" Path="Textures\EmpireImprovements\EmpireImprovementUnfallenScienceSmall.png" />
+      <Icon Size="Large" Path="Textures\EmpireImprovements\EmpireImprovementUnfallenScienceLarge.png" />
     </Icons>
   </ExtendedGuiElement>
 


### PR DESCRIPTION
Fixes a couple of broken icons (they already exist, but in a different directory)