### PR TITLE
Additional quest counters

### DIFF
--- a/Endless Space Competitive Mod/Quests/QuestDefinitions[GlobalCoop].xml
+++ b/Endless Space Competitive Mod/Quests/QuestDefinitions[GlobalCoop].xml
@@ -461,9 +461,9 @@
       <LocalizationVar Source="$Amount05"           LocalizationKey="$Amount05Name"/>
       <LocalizationVar Source="$Amount06"           LocalizationKey="$Amount06Name"/>
       <InterpretedVar VarName="$Objective0Val" Target="$(Empire)">
-        <Expression>((Count(Context, @'ClassEmpire/ClassColonizedStarSystem,HappinessStatusStarSystem3') + Count(Context, @'ClassEmpire/ClassColonizedStarSystem,HappinessStatusStarSystem4')) + Count(Context, @'ClassEmpire/ClassColonizedStarSystem,ObedienceStatusStarSystem3')) + Count(Context, @'ClassEmpire/ClassColonizedStarSystem,ObedienceStatusStarSystem4')</Expression>
+        <Expression>Count(Context, @'ClassEmpire/ClassColonizedStarSystem,HappinessStatusStarSystem3') + Count(Context, @'ClassEmpire/ClassColonizedStarSystem,HappinessStatusStarSystem4') + Count(Context, @'ClassEmpire/ClassColonizedStarSystem,ObedienceStatusStarSystem3') + Count(Context, @'ClassEmpire/ClassColonizedStarSystem,ObedienceStatusStarSystem4')</Expression>
       </InterpretedVar>
-      <Var VarName="$Objective0Expr" StringValue="((Count(Context, @'ClassEmpire/ClassColonizedStarSystem,HappinessStatusStarSystem3') + Count(Context, @'ClassEmpire/ClassColonizedStarSystem,HappinessStatusStarSystem4')) + Count(Context, @'ClassEmpire/ClassColonizedStarSystem,ObedienceStatusStarSystem3')) + Count(Context, @'ClassEmpire/ClassColonizedStarSystem,ObedienceStatusStarSystem4')"/>
+      <Var VarName="$Objective0Expr" StringValue="Count(Context, @'ClassEmpire/ClassColonizedStarSystem,HappinessStatusStarSystem3') + Count(Context, @'ClassEmpire/ClassColonizedStarSystem,HappinessStatusStarSystem4') + Count(Context, @'ClassEmpire/ClassColonizedStarSystem,ObedienceStatusStarSystem3') + Count(Context, @'ClassEmpire/ClassColonizedStarSystem,ObedienceStatusStarSystem4')"/>
     </Vars>
 
     <!--============ PREREQUISITES ============-->

--- a/Endless Space Competitive Mod/Quests/QuestDefinitions[GlobalCoop].xml
+++ b/Endless Space Competitive Mod/Quests/QuestDefinitions[GlobalCoop].xml
@@ -432,8 +432,6 @@
       <!--OBJECTIVE 1-->
       <Var VarName="$Amount01" IntValue="70"/>
       <Var VarName="$Amount02" IntValue="2"/>
-      <Var VarName="$Expression01" StringValue="(Count(Context, @'ClassEmpire/ClassColonizedStarSystem,HappinessStatusStarSystem3') + Count(Context, @'ClassEmpire/ClassColonizedStarSystem,HappinessStatusStarSystem4') + Count(Context, @'ClassEmpire/ClassColonizedStarSystem,ObedienceStatusStarSystem3') + Count(Context, @'ClassEmpire/ClassColonizedStarSystem,ObedienceStatusStarSystem4')) ge 2"/>
-
       <!--OBJECTIVE 2-->
       <InterpretedVar VarName="$Amount03" Target="$(Empire)">
         <Expression>Max(0,(Count(Context, @'ClassEmpire/ClassSenate/ClassLaw,LawPolitics04')))</Expression>

--- a/Endless Space Competitive Mod/Quests/QuestDefinitions[GlobalCoop].xml
+++ b/Endless Space Competitive Mod/Quests/QuestDefinitions[GlobalCoop].xml
@@ -462,6 +462,10 @@
       <LocalizationVar Source="$Amount04"           LocalizationKey="$Amount04Name"/>
       <LocalizationVar Source="$Amount05"           LocalizationKey="$Amount05Name"/>
       <LocalizationVar Source="$Amount06"           LocalizationKey="$Amount06Name"/>
+      <InterpretedVar VarName="$Objective0Val" Target="$(Empire)">
+        <Expression>((Count(Context, @'ClassEmpire/ClassColonizedStarSystem,HappinessStatusStarSystem3') + Count(Context, @'ClassEmpire/ClassColonizedStarSystem,HappinessStatusStarSystem4')) + Count(Context, @'ClassEmpire/ClassColonizedStarSystem,ObedienceStatusStarSystem3')) + Count(Context, @'ClassEmpire/ClassColonizedStarSystem,ObedienceStatusStarSystem4')</Expression>
+      </InterpretedVar>
+      <Var VarName="$Objective0Expr" StringValue="((Count(Context, @'ClassEmpire/ClassColonizedStarSystem,HappinessStatusStarSystem3') + Count(Context, @'ClassEmpire/ClassColonizedStarSystem,HappinessStatusStarSystem4')) + Count(Context, @'ClassEmpire/ClassColonizedStarSystem,ObedienceStatusStarSystem3')) + Count(Context, @'ClassEmpire/ClassColonizedStarSystem,ObedienceStatusStarSystem4')"/>
     </Vars>
 
     <!--============ PREREQUISITES ============-->
@@ -481,14 +485,14 @@
 
         <!--============ OBJECTIVE SET 0 - Reach Happy in 2 systems ============-->
         <ObjectiveSet>
-          <Objective Name="Objective0">
+          <Objective Name="Objective0" StartValue="$Objective0Val" EndValue="$Amount02">
             <AIHint Category="Minimal" MinAutoResolutionTurn="45" MaxAutoResolutionTurn="60" AutoResolutionProbability="1"/>
             <Sequence>
               <Decorator_BeginTurn>
-                <Condition_CheckInterpreter>
+                <Condition_IsProgressionComplete>
                   <Input_Context VarName="$CurrentEmpire"/>
-                  <Input_Expression VarName="$Expression01"/>
-                </Condition_CheckInterpreter>
+                  <Input_Expression VarName="$Objective0Expr"/>
+                </Condition_IsProgressionComplete>
               </Decorator_BeginTurn>
               <Action_ChooseOutcome Name="Outcome1"/>
             </Sequence>

--- a/Endless Space Competitive Mod/Quests/QuestDefinitions[Population].xml
+++ b/Endless Space Competitive Mod/Quests/QuestDefinitions[Population].xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Datatable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xsi:noNamespaceSchemaLocation="../Schemas/QuestDefinition.xsd">
 
     <!--           POPULATION QUEST 07       -->
@@ -169,6 +169,798 @@
                     </Objective>
                 </ObjectiveSet>
                 <Reward Droplist="DroplistPrestigeEra4" Picks="1"/>
+            </Step>
+        </Steps>
+    </QuestDefinition>
+
+
+
+    <!--           POPULATION QUEST 02       -->
+    <!--            Those darn Kids        -->
+
+   <QuestDefinition Name="PopulationQuest02" Category="PopulationQuest" SubCategory="Population" MinimumTurn="40" TriggeringProbability="1">
+       
+        <!--============ TAGS ============-->
+        <Tags>BeginTurn</Tags>
+
+
+        <QuestContextSolo/>
+
+
+        <RepetitionRules  NumberOfOccurrencesPerGame="0"
+                          NumberOfOccurrencesPerEmpire="1"
+                          NumberOfConcurrentInstances="0"/>
+
+        <!--============ VARIABLES ============-->
+        <Vars>
+
+            <Var VarName="$CurrentEmpire">
+                <From Source="$Empire"/>
+            </Var>
+            <!--Select a first Colonized System (state colony) with some Sophons inside-->
+            <Var VarName="$SophonsSystems01">
+                <Any>
+                    <From Source="$CurrentEmpire.$ColonizedStarSystems">
+                        <Where>
+                            <PathPrerequisite Flags="Prerequisite">//ClassPopulation,ClassPopulationStarSystem,ClassPopulationStarSystemAffinitySophonsCount</PathPrerequisite>
+                            <PathPrerequisite Flags="Prerequisite" Inverted="true">ClassColonizedStarSystem,ColonizedStarSystemStateOutpost</PathPrerequisite>
+                        </Where>
+                    </From>
+                </Any>
+            </Var>
+            <Var VarName="$SophonsSystem01Location">
+                <From Source="$SophonsSystems01.$StarSystem"/>
+            </Var>
+            <!--Find its Hangar-->
+            <Var VarName="$HangarOfSophonsSystem01">
+                <From Source="$SophonsSystems01.$Hangar"></From>
+            </Var>
+            <!--Select another System where there are some Sophons inside-->
+            <Var VarName="$SophonsSystems02">
+                <Any>
+                    <From Source="$CurrentEmpire.$ColonizedStarSystems">
+                        <Where>
+                            <PathPrerequisite Flags="Prerequisite">//ClassPopulation,ClassPopulationStarSystem,ClassPopulationStarSystemAffinitySophonsCount</PathPrerequisite>
+                            <PathPrerequisite Flags="Prerequisite" Inverted="true">ClassColonizedStarSystem,ColonizedStarSystemStateOutpost</PathPrerequisite>
+                            <IsNot EntityVarName="$SophonsSystems01"/>
+                        </Where>
+
+                    </From>
+                </Any>
+            </Var>
+            <Var VarName="$SophonsSystem02Location">
+                <From Source="$SophonsSystems02.$StarSystem"/>
+            </Var>
+            <!--Find its Hangar-->
+            <Var VarName="$HangarOfSophonsSystem02">
+                <From Source="$SophonsSystems02.$Hangar"></From>
+            </Var>
+
+            <!--How many ships we need-->
+            <Var VarName="$Amount01" IntValue="3"/>
+            <Var VarName="$Amount02" IntValue="2"/>
+
+            <!--Define the Timer-->           
+            <!--Define the type of Buildings we need-->
+            <Var VarName="$ScienceBuildings" StringValue="SubCategoryScience"/>
+            <!--Define the type of Buildings we DON'T want-->
+
+
+            <Var VarName="$Expression01" StringValue="Property(Context, @'ClassEmpire/ClassPopulationEmpire,ClassPopulationEmpireAffinitySophonsCount', PopulationCount, true) lt 1"/>
+            <Var VarName="$Expression02" StringValue="Count(SophonsSystems01, @'ClassColonizedStarSystem/ClassGarrison/ClassShip,ShipForBattle,!ShipRoleHero') ge 2"/>           
+            
+            <Var VarName="$Timer"/>
+            <InterpretedVar VarName="$Duration" Target="$(Empire)">
+                <Expression>Property(Context, @../ClassEmpire, GameSpeedMultiplier, true)*16</Expression>
+            </InterpretedVar>
+            
+            <LocalizationVar LocalizationKey="$SystemName01" Source="$SophonsSystem01Location"/>
+            <LocalizationVar LocalizationKey="$SystemName02" Source="$SophonsSystem02Location"/>
+            <LocalizationVar LocalizationKey="$Amount01Name" Source="$Amount01"/>
+            <LocalizationVar LocalizationKey="$Amount02Name" Source="$Amount02"/>
+
+        </Vars>
+
+        <!--============ PREREQUISITES ============-->
+
+        <Prerequisites Target="$(Empire)">
+            <PathPrerequisite Flags="Prerequisite" Inverted="true">EmpireTypeMajor,AffinityGameplayMajorHisshos</PathPrerequisite>           
+            <InterpreterPrerequisite Flags="Prerequisite">Count(Context, @'ClassEmpire/ColonizedStarSystemStateColony/ClassPopulation,ClassPopulationStarSystemAffinitySophonsCount') ge 2</InterpreterPrerequisite>
+        </Prerequisites>
+
+        <!--============ STEPS ============-->
+        <Steps>
+            <!--Let's choose-->
+            <Step Name="Step1">
+                <!--============ STEP 1 - Choose ============-->
+
+                <Choice DefaultChoiceIndex="0">
+                    <ChoiceItem ObjectiveSetIndex="0"/>
+                    <ChoiceItem ObjectiveSetIndex="1">
+                         <Prerequisites Target="$(Empire)">
+                            <PathPrerequisite Flags="Prerequisite" Inverted="true">../ClassEmpire,EmpireTypeMajor,AffinityGameplayMajorHisshos</PathPrerequisite>
+                             <PathPrerequisite Flags="Prerequisite" Inverted="true">../ClassEmpire,EmpireTypeMajor,AffinityGameplayUmbralChoir</PathPrerequisite>
+                        </Prerequisites>
+                    </ChoiceItem>
+                    <ChoiceItem ObjectiveSetIndex="2">
+                        <Prerequisites Target="$(Empire)">
+                            <PathPrerequisite Flags="Prerequisite">../ClassEmpire,EmpireTypeMajor,AffinityGameplayMajorHisshos</PathPrerequisite>
+                        </Prerequisites>
+                    </ChoiceItem>
+                </Choice>
+
+                <!--============ Build a Science Building ============-->
+                <ObjectiveSet ObjectiveComposition="All">
+                    <StartActions>
+                        <Action_StartTimer>
+                            <Input_Duration VarName="$Duration"/>
+                            <Output_Timer VarName="$Timer"/>
+                        </Action_StartTimer>
+                    </StartActions>
+                    <Objective Name="C1Step1_Objective1" StartValue="0" EndValue="$Amount01">
+                        <!-- TODO -->
+                        <AIHint Category="Minimal" MinAutoResolutionTurn="10" MaxAutoResolutionTurn="12" AutoResolutionProbability="0.5" />
+                        <Parallel CompletionPolicy="First">
+                     
+                            <Sequence>
+                                <Loop>
+                                    <Decorator_ConstructionCompleted Initiator="Empire" ProgressionIncrement="1">
+                                        <Input_ConstructionSubCategory VarName="$ScienceBuildings"/>
+                                        <Input_ValidType>Building</Input_ValidType>
+                                    </Decorator_ConstructionCompleted>
+                                    <Input_Count VarName="$Amount01"/>
+                                </Loop>
+                            </Sequence>
+                            
+                            <Sequence>
+                                <Decorator_BeginTurn>
+                                    <Condition_TimerEnded>
+                                        <Input_Timer VarName="$Timer"/>
+                                    </Condition_TimerEnded>
+                                </Decorator_BeginTurn>
+                                <Action_Fail/>
+                            </Sequence>                       
+                      
+                    <!--If there is no Sophons he/she fails-->                          
+                            <Sequence>
+                                <Decorator_BeginTurn>
+                                    <Condition_CheckInterpreter>
+                                        <Input_Context VarName="$CurrentEmpire"/>
+                                        <Input_Expression VarName="$Expression01"/>
+                                    </Condition_CheckInterpreter>
+                                </Decorator_BeginTurn>
+                                <Action_Fail/>
+                            </Sequence>       
+                            
+                        </Parallel>
+                    </Objective>
+                    <Reward Droplist="DroplistPopulation03" Picks="1"/>
+                </ObjectiveSet>
+
+                <!--============ STEP 2 - Call the Police ============-->
+                <ObjectiveSet ObjectiveComposition="All">
+                    <StartActions>
+                        <Action_StartTimer>
+                            <Input_Duration VarName="$Duration"/>
+                            <Output_Timer VarName="$Timer"/>
+                        </Action_StartTimer>
+                    </StartActions>
+                    <Objective Name="C2Step1_Objective1">
+
+
+                        <!-- TODO -->
+                        <AIHint Category="Minimal" MinAutoResolutionTurn="10" MaxAutoResolutionTurn="10" AutoResolutionProbability="0.5" />
+                        <Parallel CompletionPolicy="First">
+                           
+                            <Sequence>
+                                <!--Fill 2 Hangars of Sophons System with 2 Ships each-->
+                                <Decorator_BeginTurn>
+                                    <Condition_CheckInterpreter>
+                                        <Input_Context VarName="$CurrentEmpire"/>
+                                        <Input_Expression VarName="$Expression02"/>
+                                    </Condition_CheckInterpreter>                                 
+                                </Decorator_BeginTurn>
+                            </Sequence>                                   
+                                                       
+                            <Sequence>
+                                <Decorator_BeginTurn>
+                                    <Condition_CheckInterpreter>
+                                        <Input_Context VarName="$CurrentEmpire"/>
+                                        <Input_Expression VarName="$Expression01"/>
+                                    </Condition_CheckInterpreter>
+                                </Decorator_BeginTurn>
+                                <Action_Fail/>
+                            </Sequence>
+                            
+                            <Sequence>
+                                <Decorator_BeginTurn>
+                                    <Condition_TimerEnded>
+                                        <Input_Timer VarName="$Timer"/>
+                                    </Condition_TimerEnded>
+                                </Decorator_BeginTurn>
+                                <Action_Fail/>
+                            </Sequence>
+
+                            <Sequence>                             
+                                <Decorator_InvadeSystem Initiator="OtherEmpires">
+                                    <Input_System VarName="$SophonsSystem01Location"/>
+                                    <Input_GroundBattleOutcomeType>CaptureOrRaze</Input_GroundBattleOutcomeType>
+                                </Decorator_InvadeSystem>
+                                <Action_Fail/>
+                             </Sequence>                            
+                           
+                            <Sequence>
+                                <Decorator_SystemDecolonized Initiator="Empire">
+                                    <Input_Systems VarName="$SophonsSystem01Location"/>
+                                </Decorator_SystemDecolonized>
+                                <Action_Fail/>
+                            </Sequence>                         
+                                                        
+                        </Parallel>
+                    </Objective>
+                    <Reward Droplist="DroplistPopulation02" Picks="1"/>
+                </ObjectiveSet>
+                <!--============ STEP 2 - Call the Police Hisshos Alternative ============-->
+                <ObjectiveSet ObjectiveComposition="All">
+                    <StartActions>
+                        <Action_StartTimer>
+                            <Input_Duration VarName="$Duration"/>
+                            <Output_Timer VarName="$Timer"/>
+                        </Action_StartTimer>
+                    </StartActions>
+                    <Objective Name="C2Step1_Objective1Alt">
+
+
+                        <!-- TODO -->
+                        <AIHint Category="Minimal" MinAutoResolutionTurn="10" MaxAutoResolutionTurn="10" AutoResolutionProbability="0.5" />
+                        <Parallel CompletionPolicy="First">
+
+                            <Sequence>
+                                <!--Fill 2 Hangars of Sophons System with 2 Ships each-->
+                                <Decorator_BeginTurn>
+                                    <Condition_CheckInterpreter>
+                                        <Input_Context VarName="$CurrentEmpire"/>
+                                        <Input_Expression VarName="$Expression02"/>
+                                    </Condition_CheckInterpreter>
+                                </Decorator_BeginTurn>
+                            </Sequence>
+
+                            <Sequence>
+                                <Decorator_BeginTurn>
+                                    <Condition_CheckInterpreter>
+                                        <Input_Context VarName="$CurrentEmpire"/>
+                                        <Input_Expression VarName="$Expression01"/>
+                                    </Condition_CheckInterpreter>
+                                </Decorator_BeginTurn>
+                                <Action_Fail/>
+                            </Sequence>
+
+                            <Sequence>
+                                <Decorator_BeginTurn>
+                                    <Condition_TimerEnded>
+                                        <Input_Timer VarName="$Timer"/>
+                                    </Condition_TimerEnded>
+                                </Decorator_BeginTurn>
+                                <Action_Fail/>
+                            </Sequence>
+
+                            <Sequence>
+                                <Decorator_InvadeSystem Initiator="OtherEmpires">
+                                    <Input_System VarName="$SophonsSystem01Location"/>
+                                    <Input_GroundBattleOutcomeType>CaptureOrRaze</Input_GroundBattleOutcomeType>
+                                </Decorator_InvadeSystem>
+                                <Action_Fail/>
+                            </Sequence>
+
+                            <Sequence>
+                                <Decorator_SystemDecolonized Initiator="Empire">
+                                    <Input_Systems VarName="$SophonsSystem01Location"/>
+                                </Decorator_SystemDecolonized>
+                                <Action_Fail/>
+                            </Sequence>
+
+                        </Parallel>
+                    </Objective>
+                    <Reward Droplist="DroplistMinorRewards" Picks="1"/>
+                </ObjectiveSet>
+            </Step>
+        </Steps>
+    </QuestDefinition>
+
+    <!--           POPULATION QUEST 11       -->
+    <!--               Lord of War           -->
+
+
+   <QuestDefinition Name="PopulationQuest11" Category="PopulationQuest" SubCategory="Population" MinimumTurn="30" TriggeringProbability="1">  
+       
+        <!--============ TAGS ============-->
+        <Tags>BeginTurn</Tags>
+
+        <QuestContextSolo/>
+
+
+        <RepetitionRules  NumberOfOccurrencesPerGame="0"
+                          NumberOfOccurrencesPerEmpire="1"
+                          NumberOfConcurrentInstances="0"/>
+
+        <!--============ VARIABLES ============-->
+        <Vars>
+
+            <Var VarName="$CurrentEmpire">
+                <From Source="$Empire"/>
+            </Var>
+            <Var VarName="$MyColonizedStarSystems">              
+                    <From Source="$CurrentEmpire.$ColonizedStarSystems">
+                        <Where>
+                            <PathPrerequisite Flags="Prerequisite">ColonizedStarSystemStateColony/ClassPopulationStarSystemAffinityTerransCount</PathPrerequisite>                           
+                            <!--<PathPrerequisite Flags="Prerequisite" Inverted="true">ClassColonizedStarSystem,ColonizedStarSystemStateOutpost</PathPrerequisite>-->
+                        </Where>
+                    </From>                
+            </Var>
+            <Var VarName="$ColonizedStarSystem01">
+                <Any>
+                    <From Source="$MyColonizedStarSystems"/>
+                </Any>
+            </Var>
+            <Var VarName="$StarSystem01">
+                <From Source="$ColonizedStarSystem01.$StarSystem"/>
+            </Var>
+            <Var VarName="$ColonizedStarSystem02">
+                <Any>
+                    <From Source="$MyColonizedStarSystems">
+                        <Where>
+                            <IsNot EntityVarName="$ColonizedStarSystem01"/>
+                        </Where>
+                    </From>
+                </Any>
+            </Var>
+            <Var VarName="$StarSystem02">
+                <From Source="$ColonizedStarSystem02.$StarSystem"/>
+            </Var>
+            <Var VarName="$ColonizedStarSystem03">
+                <Any>
+                    <From Source="$MyColonizedStarSystems">
+                        <Where>
+                            <IsNot EntityVarName="$ColonizedStarSystem01"/>
+                            <IsNot EntityVarName="$ColonizedStarSystem02"/>
+                        </Where>
+                    </From>
+                </Any>
+            </Var>
+            <Var VarName="$StarSystem03">
+                <From Source="$ColonizedStarSystem03.$StarSystem"/>
+            </Var>
+
+            <Var VarName="$Expression04" StringValue="Property(Context, @'ClassEmpire/ClassPopulationEmpireAffinityTerransCount', PopulationCount, true) lt 1"/>
+            
+            <Var VarName="$Expression01" StringValue="Property(ColonizedStarSystem01, @'ClassColonizedStarSystem/ClassHero', Level, true) ge 5"/>
+            <Var VarName="$Expression02" StringValue="Property(ColonizedStarSystem02, @'ClassColonizedStarSystem/ClassHero', Level, true) ge 5"/>
+            <Var VarName="$Expression03" StringValue="Property(ColonizedStarSystem03, @'ClassColonizedStarSystem/ClassHero', Level, true) ge 5"/>
+
+            <Var VarName="$Expression05" StringValue="Property(ColonizedStarSystem01, @'ClassColonizedStarSystem', Happiness, true) ge 60"/>
+            <Var VarName="$Expression06" StringValue="Property(ColonizedStarSystem02, @'ClassColonizedStarSystem', Happiness, true) ge 60"/>
+            <Var VarName="$Expression07" StringValue="Property(ColonizedStarSystem03, @'ClassColonizedStarSystem', Happiness, true) ge 60"/>
+
+            <Var VarName="$Expression08" StringValue="Property(Context, @'ClassEmpire', Obedience, true)"/>
+
+            <Var VarName="$Amount01" IntValue="5"/>
+            <Var VarName="$Amount02" IntValue="60"/>
+
+            <InterpretedVar VarName="$Amount03"  Target="$(Empire)">
+                <Expression>Property(Context, @'ClassEmpire', Obedience, true)</Expression>
+            </InterpretedVar>
+            <InterpretedVar VarName="$Amount04"  Target="$(Empire)">
+                <Expression>Min(100, Property(Context, @'ClassEmpire', Obedience, true)+5)</Expression>
+            </InterpretedVar>
+
+            <Var VarName="$Marker01"/>
+            <Var VarName="$Marker02"/>
+            <Var VarName="$Marker03"/>
+            
+            <LocalizationVar LocalizationKey="$Amount01Name" Source="$Amount01"/>
+            <LocalizationVar LocalizationKey="$Amount02Name" Source="$Amount02"/>
+            <LocalizationVar LocalizationKey="$Amount04Name" Source="$Amount04"/>
+            <LocalizationVar LocalizationKey="$StarSystem01Name" Source="$StarSystem01"/>
+            <LocalizationVar LocalizationKey="$StarSystem02Name" Source="$StarSystem02"/>
+            <LocalizationVar LocalizationKey="$StarSystem03Name" Source="$StarSystem03"/>
+            
+        </Vars>
+
+
+        <!--============ PREREQUISITES ============-->
+
+        <Prerequisites Target="$(Empire)">               
+            <InterpreterPrerequisite Flags="Prerequisite">Count(Context, @'ClassEmpire/ColonizedStarSystemStateColony/ClassPopulation,ClassPopulationStarSystemAffinityTerransCount') ge 3</InterpreterPrerequisite>
+            <InterpreterPrerequisite Flags="Prerequisite">Property(Context, @'ClassEmpire/ClassEducation', HeroCount) ge 2</InterpreterPrerequisite>
+            <InterpreterPrerequisite Flags="Prerequisite">Property(Context, @'ClassEmpire', Happiness) ge 50</InterpreterPrerequisite>
+            <QuestStatePrerequisite Flags="Prerequisite" Inverted="true" QuestDefinitionName="UE_Quest-Chapter4.1-Sheredyn" QuestState="InProgress"/>
+            <QuestStatePrerequisite Flags="Prerequisite" Inverted="true" QuestDefinitionName="UE_Quest-Chapter4.1-Sheredyn" QuestState="Completed"/>
+            <QuestStatePrerequisite Flags="Prerequisite" Inverted="true" QuestDefinitionName="UE_Quest-Chapter4.1-Sheredyn" QuestState="Failed"/>
+            <QuestStatePrerequisite Flags="Prerequisite" Inverted="true" QuestDefinitionName="UE_Quest-Chapter4.1-Mezari" QuestState="InProgress"/>
+            <QuestStatePrerequisite Flags="Prerequisite" Inverted="true" QuestDefinitionName="UE_Quest-Chapter4.1-Mezari" QuestState="Completed"/>
+            <QuestStatePrerequisite Flags="Prerequisite" Inverted="true" QuestDefinitionName="UE_Quest-Chapter4.1-Mezari" QuestState="Failed"/>
+        </Prerequisites>
+
+        <!--============ STEPS ============-->
+        <Steps>
+            <Step Name="Step1">
+                <Choice DefaultChoiceIndex="0">
+                    <ChoiceItem ObjectiveSetIndex="0"/>
+                    <ChoiceItem ObjectiveSetIndex="1">
+                        <Prerequisites Target="$(Empire)">
+                            <PathPrerequisite Flags="Prerequisite" Inverted="true">../ClassEmpire,EmpireTypeMajor,AffinityGameplayMajorHisshos</PathPrerequisite>
+                        </Prerequisites>
+                    </ChoiceItem>
+                    <ChoiceItem ObjectiveSetIndex="2">
+                        <Prerequisites Target="$(Empire)">
+                            <PathPrerequisite Flags="Prerequisite">../ClassEmpire,EmpireTypeMajor,AffinityGameplayMajorHisshos</PathPrerequisite>
+                        </Prerequisites>
+                    </ChoiceItem>             
+                </Choice>
+           
+                <ObjectiveSet>
+                    <StartActions>
+                        <Action_AddQuestMarkers>
+                            <Input_Targets VarName="$StarSystem01"/>
+                            <Input_Empires VarName="$CurrentEmpire"/>
+                            <Output_Markers VarName="$Marker01"/>
+                        </Action_AddQuestMarkers>
+                        <Action_AddQuestMarkers>
+                            <Input_Targets VarName="$StarSystem02"/>
+                            <Input_Empires VarName="$CurrentEmpire"/>
+                            <Output_Markers VarName="$Marker02"/>
+                        </Action_AddQuestMarkers>
+                        <Action_AddQuestMarkers>
+                            <Input_Targets VarName="$StarSystem03"/>
+                            <Input_Empires VarName="$CurrentEmpire"/>
+                            <Output_Markers VarName="$Marker03"/>
+                        </Action_AddQuestMarkers>
+                    </StartActions>
+                    <Objective Name="Step1_Objective1">                
+                        <!-- TODO -->
+                        <AIHint Category="Minimal" MinAutoResolutionTurn="17" MaxAutoResolutionTurn="25" AutoResolutionProbability="0.75" />                    
+                        <Parallel CompletionPolicy="First">
+                            <Sequence>                               
+                                <Decorator_BeginTurn>
+                                    <Condition_CheckInterpreter>                                  
+                                        <Input_Context VarName="$CurrentEmpire"/>                                   
+                                        <Input_Expression VarName="$Expression01"/>
+                                    </Condition_CheckInterpreter>
+                                    <Condition_CheckInterpreter>
+                                        <Input_Context VarName="$CurrentEmpire"/>
+                                        <Input_Expression VarName="$Expression02"/>
+                                    </Condition_CheckInterpreter>
+                                    <Condition_CheckInterpreter>
+                                        <Input_Context VarName="$CurrentEmpire"/>
+                                        <Input_Expression VarName="$Expression03"/>
+                                    </Condition_CheckInterpreter>
+                                </Decorator_BeginTurn>
+                                    <Action_RemoveQuestMarkers>
+                                        <Input_Markers VarName="$Marker01"/>
+                                    </Action_RemoveQuestMarkers>
+                                    <Action_RemoveQuestMarkers>
+                                        <Input_Markers VarName="$Marker02"/>
+                                    </Action_RemoveQuestMarkers>
+                                    <Action_RemoveQuestMarkers>
+                                        <Input_Markers VarName="$Marker03"/>
+                                    </Action_RemoveQuestMarkers>                                
+                            </Sequence>
+                            
+                             <Sequence>
+                                <Decorator_BeginTurn>
+                                    <Condition_CheckInterpreter>
+                                        <Input_Context VarName="$CurrentEmpire"/>
+                                        <Input_Expression VarName="$Expression04"/>
+                                    </Condition_CheckInterpreter>
+                                </Decorator_BeginTurn>
+                                 <Action_RemoveQuestMarkers>
+                                     <Input_Markers VarName="$Marker01"/>
+                                 </Action_RemoveQuestMarkers>
+                                 <Action_RemoveQuestMarkers>
+                                     <Input_Markers VarName="$Marker02"/>
+                                 </Action_RemoveQuestMarkers>
+                                 <Action_RemoveQuestMarkers>
+                                     <Input_Markers VarName="$Marker03"/>
+                                 </Action_RemoveQuestMarkers>
+                                <Action_Fail/>
+                            </Sequence>
+                            
+                            <Sequence>
+                                <Parallel CompletionPolicy="Any">
+                                    <Sequence>
+                                        <Decorator_InvadeSystem Initiator="OtherEmpires">
+                                            <Input_System VarName="$StarSystem01"/>
+                                            <Input_GroundBattleOutcomeType>CaptureOrRaze</Input_GroundBattleOutcomeType>
+                                        </Decorator_InvadeSystem>
+                                    </Sequence>
+                                    <Sequence>
+                                        <Decorator_InvadeSystem Initiator="OtherEmpires">
+                                            <Input_System VarName="$StarSystem02"/>
+                                            <Input_GroundBattleOutcomeType>CaptureOrRaze</Input_GroundBattleOutcomeType>
+                                        </Decorator_InvadeSystem>
+                                    </Sequence>
+                                    <Sequence>
+                                        <Decorator_InvadeSystem Initiator="OtherEmpires">
+                                            <Input_System VarName="$StarSystem03"/>
+                                            <Input_GroundBattleOutcomeType>CaptureOrRaze</Input_GroundBattleOutcomeType>
+                                        </Decorator_InvadeSystem>
+                                    </Sequence>
+                                </Parallel>
+                                <Action_RemoveQuestMarkers>
+                                    <Input_Markers VarName="$Marker01"/>
+                                </Action_RemoveQuestMarkers>
+                                <Action_RemoveQuestMarkers>
+                                    <Input_Markers VarName="$Marker02"/>
+                                </Action_RemoveQuestMarkers>
+                                <Action_RemoveQuestMarkers>
+                                    <Input_Markers VarName="$Marker03"/>
+                                </Action_RemoveQuestMarkers>
+                                <Action_Fail/>
+                            </Sequence>
+
+                            <Sequence>
+                                <Parallel CompletionPolicy="Any">
+                                    <Sequence>
+                                        <Decorator_SystemDecolonized Initiator="Empire">
+                                            <Input_Systems VarName="$StarSystem01"/>                                          
+                                        </Decorator_SystemDecolonized>
+                                    </Sequence>
+                                    <Sequence>
+                                        <Decorator_SystemDecolonized Initiator="Empire">
+                                            <Input_Systems VarName="$StarSystem02"/>
+                                        </Decorator_SystemDecolonized>
+                                    </Sequence>
+                                    <Sequence>
+                                        <Decorator_SystemDecolonized Initiator="Empire">
+                                            <Input_Systems VarName="$StarSystem03"/>
+                                        </Decorator_SystemDecolonized>
+                                    </Sequence>
+                                </Parallel>
+                                <Action_RemoveQuestMarkers>
+                                    <Input_Markers VarName="$Marker01"/>
+                                </Action_RemoveQuestMarkers>
+                                <Action_RemoveQuestMarkers>
+                                    <Input_Markers VarName="$Marker02"/>
+                                </Action_RemoveQuestMarkers>
+                                <Action_RemoveQuestMarkers>
+                                    <Input_Markers VarName="$Marker03"/>
+                                </Action_RemoveQuestMarkers>
+                                <Action_Fail/>
+                            </Sequence>
+
+                          <Sequence>
+                            <Parallel CompletionPolicy="Any">
+                              <Sequence>
+                                <Decorator_SystemDestroyed>
+                                  <Input_Nodes VarName="$StarSystem01"/>
+                                  <Input_Victim VarName="$CurrentEmpire"/>
+                                </Decorator_SystemDestroyed>                               
+                              </Sequence>
+                              <Sequence>
+                                <Decorator_SystemDestroyed>
+                                  <Input_Nodes VarName="$StarSystem02"/>
+                                  <Input_Victim VarName="$CurrentEmpire"/>
+                                </Decorator_SystemDestroyed>
+                              </Sequence>
+                              <Sequence>
+                                <Decorator_SystemDestroyed>
+                                  <Input_Nodes VarName="$StarSystem03"/>
+                                  <Input_Victim VarName="$CurrentEmpire"/>
+                                </Decorator_SystemDestroyed>
+                              </Sequence>                             
+                            </Parallel>
+                            <Action_RemoveQuestMarkers>
+                              <Input_Markers VarName="$Marker01"/>
+                            </Action_RemoveQuestMarkers>
+                            <Action_RemoveQuestMarkers>
+                              <Input_Markers VarName="$Marker02"/>
+                            </Action_RemoveQuestMarkers>
+                            <Action_RemoveQuestMarkers>
+                              <Input_Markers VarName="$Marker03"/>
+                            </Action_RemoveQuestMarkers>
+                            <Action_Fail/>
+                          </Sequence>
+                        </Parallel>
+                        
+                        
+                        
+                    </Objective>                    
+                    <Reward Droplist="DroplistTechnology" EvaluationMethod="Dynamic" Picks="1" PreviewLocalizationKey="%RandomTechnologyTitle"/>
+                </ObjectiveSet>
+                
+                <ObjectiveSet>
+                    <StartActions>
+                        <Action_AddQuestMarkers>
+                            <Input_Targets VarName="$StarSystem01"/>
+                            <Input_Empires VarName="$CurrentEmpire"/>
+                            <Output_Markers VarName="$Marker01"/>
+                        </Action_AddQuestMarkers>
+                        <Action_AddQuestMarkers>
+                            <Input_Targets VarName="$StarSystem02"/>
+                            <Input_Empires VarName="$CurrentEmpire"/>
+                            <Output_Markers VarName="$Marker02"/>
+                        </Action_AddQuestMarkers>
+                        <Action_AddQuestMarkers>
+                            <Input_Targets VarName="$StarSystem03"/>
+                            <Input_Empires VarName="$CurrentEmpire"/>
+                            <Output_Markers VarName="$Marker03"/>
+                        </Action_AddQuestMarkers>
+                    </StartActions>
+                    <Objective Name="Step1_Objective2">
+                        <!-- TODO -->
+                        <AIHint Category="Minimal" MinAutoResolutionTurn="17" MaxAutoResolutionTurn="25" AutoResolutionProbability="0.75" />
+                        <Parallel CompletionPolicy="First">
+                            <Sequence>
+                                <Decorator_BeginTurn>
+                                    <Condition_CheckInterpreter>
+                                        <Input_Context VarName="$CurrentEmpire"/>
+                                        <Input_Expression VarName="$Expression05"/>
+                                    </Condition_CheckInterpreter>
+                                    <Condition_CheckInterpreter>
+                                        <Input_Context VarName="$CurrentEmpire"/>
+                                        <Input_Expression VarName="$Expression06"/>
+                                    </Condition_CheckInterpreter>
+                                    <Condition_CheckInterpreter>
+                                        <Input_Context VarName="$CurrentEmpire"/>
+                                        <Input_Expression VarName="$Expression07"/>
+                                    </Condition_CheckInterpreter>
+                                </Decorator_BeginTurn>
+                                <Action_RemoveQuestMarkers>
+                                    <Input_Markers VarName="$Marker01"/>
+                                </Action_RemoveQuestMarkers>
+                                <Action_RemoveQuestMarkers>
+                                    <Input_Markers VarName="$Marker02"/>
+                                </Action_RemoveQuestMarkers>
+                                <Action_RemoveQuestMarkers>
+                                    <Input_Markers VarName="$Marker03"/>
+                                </Action_RemoveQuestMarkers>
+                            </Sequence>
+                            <Sequence>
+                                <Parallel CompletionPolicy="First">
+                                    <Sequence>
+                                        <Decorator_InvadeSystem Initiator="OtherEmpires">
+                                            <Input_System VarName="$StarSystem01"/>
+                                            <Input_GroundBattleOutcomeType>CaptureOrRaze</Input_GroundBattleOutcomeType>
+                                        </Decorator_InvadeSystem>
+                                    </Sequence>
+                                    <Sequence>
+                                        <Decorator_InvadeSystem Initiator="OtherEmpires">
+                                            <Input_System VarName="$StarSystem02"/>
+                                             <Input_GroundBattleOutcomeType>CaptureOrRaze</Input_GroundBattleOutcomeType>
+                                        </Decorator_InvadeSystem>
+                                    </Sequence>
+                                    <Sequence>
+                                        <Decorator_InvadeSystem Initiator="OtherEmpires">
+                                            <Input_System VarName="$StarSystem03"/>
+                                            <Input_GroundBattleOutcomeType>CaptureOrRaze</Input_GroundBattleOutcomeType>
+                                        </Decorator_InvadeSystem>
+                                    </Sequence>                                  
+                                </Parallel>
+                                <Action_RemoveQuestMarkers>
+                                    <Input_Markers VarName="$Marker01"/>
+                                </Action_RemoveQuestMarkers>
+                                <Action_RemoveQuestMarkers>
+                                    <Input_Markers VarName="$Marker02"/>
+                                </Action_RemoveQuestMarkers>
+                                <Action_RemoveQuestMarkers>
+                                    <Input_Markers VarName="$Marker03"/>
+                                </Action_RemoveQuestMarkers>
+                                <Action_Fail/>
+                            </Sequence>
+
+                            <Sequence>
+                                <Parallel CompletionPolicy="First">
+                                    <Sequence>
+                                        <Decorator_SystemDecolonized Initiator="Empire">
+                                            <Input_Systems VarName="$StarSystem01"/>
+                                        </Decorator_SystemDecolonized>
+                                    </Sequence>
+                                    <Sequence>
+                                        <Decorator_SystemDecolonized Initiator="Empire">
+                                            <Input_Systems VarName="$StarSystem02"/>
+                                        </Decorator_SystemDecolonized>
+                                    </Sequence>
+                                    <Sequence>
+                                        <Decorator_SystemDecolonized Initiator="Empire">
+                                            <Input_Systems VarName="$StarSystem03"/>
+                                        </Decorator_SystemDecolonized>
+                                    </Sequence>
+                                </Parallel>
+                                <Action_RemoveQuestMarkers>
+                                    <Input_Markers VarName="$Marker01"/>
+                                </Action_RemoveQuestMarkers>
+                                <Action_RemoveQuestMarkers>
+                                    <Input_Markers VarName="$Marker02"/>
+                                </Action_RemoveQuestMarkers>
+                                <Action_RemoveQuestMarkers>
+                                    <Input_Markers VarName="$Marker03"/>
+                                </Action_RemoveQuestMarkers>
+                                <Action_Fail/>
+                            </Sequence>
+
+                          <Sequence>
+                            <Parallel CompletionPolicy="Any">
+                              <Sequence>
+                                <Decorator_SystemDestroyed>
+                                  <Input_Nodes VarName="$StarSystem01"/>
+                                  <Input_Victim VarName="$CurrentEmpire"/>
+                                </Decorator_SystemDestroyed>
+                              </Sequence>
+                              <Sequence>
+                                <Decorator_SystemDestroyed>
+                                  <Input_Nodes VarName="$StarSystem02"/>
+                                  <Input_Victim VarName="$CurrentEmpire"/>
+                                </Decorator_SystemDestroyed>
+                              </Sequence>
+                              <Sequence>
+                                <Decorator_SystemDestroyed>
+                                  <Input_Nodes VarName="$StarSystem03"/>
+                                  <Input_Victim VarName="$CurrentEmpire"/>
+                                </Decorator_SystemDestroyed>
+                              </Sequence>
+                            </Parallel>
+                            <Action_RemoveQuestMarkers>
+                              <Input_Markers VarName="$Marker01"/>
+                            </Action_RemoveQuestMarkers>
+                            <Action_RemoveQuestMarkers>
+                              <Input_Markers VarName="$Marker02"/>
+                            </Action_RemoveQuestMarkers>
+                            <Action_RemoveQuestMarkers>
+                              <Input_Markers VarName="$Marker03"/>
+                            </Action_RemoveQuestMarkers>
+                            <Action_Fail/>
+                          </Sequence>
+                            
+                            <Sequence>
+                                <Decorator_BeginTurn>
+                                    <Condition_CheckInterpreter>
+                                        <Input_Context VarName="$CurrentEmpire"/>
+                                        <Input_Expression VarName="$Expression04"/>
+                                    </Condition_CheckInterpreter>
+                                </Decorator_BeginTurn>
+                                <Action_RemoveQuestMarkers>
+                                    <Input_Markers VarName="$Marker01"/>
+                                </Action_RemoveQuestMarkers>
+                                <Action_RemoveQuestMarkers>
+                                    <Input_Markers VarName="$Marker02"/>
+                                </Action_RemoveQuestMarkers>
+                                <Action_RemoveQuestMarkers>
+                                    <Input_Markers VarName="$Marker03"/>
+                                </Action_RemoveQuestMarkers>
+                                <Action_Fail/>
+                            </Sequence>
+                        </Parallel>
+                    </Objective>
+                    <Reward Droplist="DroplistTechnology" EvaluationMethod="Dynamic" Picks="1" PreviewLocalizationKey="%RandomTechnologyTitle"/>
+                </ObjectiveSet>
+
+                <ObjectiveSet>                   
+                    <Objective Name="Step1_Objective2Alt" StartValue="$Amount03" EndValue="$Amount04">
+                        <!-- TODO -->
+                        <AIHint Category="Minimal" MinAutoResolutionTurn="17" MaxAutoResolutionTurn="25" AutoResolutionProbability="0.75" />
+                        <Parallel CompletionPolicy="First">
+                            <Sequence>
+                                <Decorator_BeginTurn>
+                                    <Condition_IsProgressionComplete>
+                                        <Input_Context VarName="$CurrentEmpire"/>
+                                        <Input_EmpireWhoseProgressToUpdate VarName="$CurrentEmpire"/>
+                                        <Input_Expression VarName="$Expression08"/>
+                                    </Condition_IsProgressionComplete>
+                                </Decorator_BeginTurn>                              
+                            </Sequence>  
+                            <Sequence>
+                                <Decorator_BeginTurn>
+                                    <Condition_CheckInterpreter>
+                                        <Input_Context VarName="$CurrentEmpire"/>
+                                        <Input_Expression VarName="$Expression04"/>
+                                    </Condition_CheckInterpreter>
+                                </Decorator_BeginTurn>                                
+                                <Action_Fail/>
+                            </Sequence>
+                        </Parallel>
+                    </Objective>
+                    <Reward Droplist="DroplistTechnology" EvaluationMethod="Dynamic" Picks="1" PreviewLocalizationKey="%RandomTechnologyTitle"/>
+                </ObjectiveSet>
             </Step>
         </Steps>
     </QuestDefinition>

--- a/Endless Space Competitive Mod/Quests/QuestDefinitions[Population].xml
+++ b/Endless Space Competitive Mod/Quests/QuestDefinitions[Population].xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Datatable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xsi:noNamespaceSchemaLocation="../Schemas/QuestDefinition.xsd">
 
     <!--           POPULATION QUEST 07       -->

--- a/Endless Space Competitive Mod/Quests/QuestDefinitions[Population].xml
+++ b/Endless Space Competitive Mod/Quests/QuestDefinitions[Population].xml
@@ -247,8 +247,7 @@
 
 
             <Var VarName="$Expression01" StringValue="Property(Context, @'ClassEmpire/ClassPopulationEmpire,ClassPopulationEmpireAffinitySophonsCount', PopulationCount, true) lt 1"/>
-            <Var VarName="$Expression02" StringValue="Count(SophonsSystems01, @'ClassColonizedStarSystem/ClassGarrison/ClassShip,ShipForBattle,!ShipRoleHero') ge 2"/>           
-            
+
             <Var VarName="$Timer"/>
             <InterpretedVar VarName="$Duration" Target="$(Empire)">
                 <Expression>Property(Context, @../ClassEmpire, GameSpeedMultiplier, true)*16</Expression>
@@ -527,14 +526,6 @@
 
             <Var VarName="$Expression04" StringValue="Property(Context, @'ClassEmpire/ClassPopulationEmpireAffinityTerransCount', PopulationCount, true) lt 1"/>
             
-            <Var VarName="$Expression01" StringValue="Property(ColonizedStarSystem01, @'ClassColonizedStarSystem/ClassHero', Level, true) ge 5"/>
-            <Var VarName="$Expression02" StringValue="Property(ColonizedStarSystem02, @'ClassColonizedStarSystem/ClassHero', Level, true) ge 5"/>
-            <Var VarName="$Expression03" StringValue="Property(ColonizedStarSystem03, @'ClassColonizedStarSystem/ClassHero', Level, true) ge 5"/>
-
-            <Var VarName="$Expression05" StringValue="Property(ColonizedStarSystem01, @'ClassColonizedStarSystem', Happiness, true) ge 60"/>
-            <Var VarName="$Expression06" StringValue="Property(ColonizedStarSystem02, @'ClassColonizedStarSystem', Happiness, true) ge 60"/>
-            <Var VarName="$Expression07" StringValue="Property(ColonizedStarSystem03, @'ClassColonizedStarSystem', Happiness, true) ge 60"/>
-
             <Var VarName="$Expression08" StringValue="Property(Context, @'ClassEmpire', Obedience, true)"/>
 
             <Var VarName="$Amount01" IntValue="5"/>

--- a/Endless Space Competitive Mod/Quests/QuestDefinitions[Population].xml
+++ b/Endless Space Competitive Mod/Quests/QuestDefinitions[Population].xml
@@ -258,13 +258,21 @@
             <LocalizationVar LocalizationKey="$SystemName02" Source="$SophonsSystem02Location"/>
             <LocalizationVar LocalizationKey="$Amount01Name" Source="$Amount01"/>
             <LocalizationVar LocalizationKey="$Amount02Name" Source="$Amount02"/>
+            <InterpretedVar VarName="$C2Step1_Objective1Val" Target="$(Empire)">
+                <Expression>Count(SophonsSystems01, @'ClassColonizedStarSystem/ClassGarrison/ClassShip,ShipForBattle,!ShipRoleHero')</Expression>
+            </InterpretedVar>
+            <Var VarName="$C2Step1_Objective1Expr" StringValue="Count(SophonsSystems01, @'ClassColonizedStarSystem/ClassGarrison/ClassShip,ShipForBattle,!ShipRoleHero')"/>
+            <InterpretedVar VarName="$C2Step1_Objective1AltVal" Target="$(Empire)">
+                <Expression>Count(SophonsSystems01, @'ClassColonizedStarSystem/ClassGarrison/ClassShip,ShipForBattle,!ShipRoleHero')</Expression>
+            </InterpretedVar>
+            <Var VarName="$C2Step1_Objective1AltExpr" StringValue="Count(SophonsSystems01, @'ClassColonizedStarSystem/ClassGarrison/ClassShip,ShipForBattle,!ShipRoleHero')"/>
 
         </Vars>
 
         <!--============ PREREQUISITES ============-->
 
         <Prerequisites Target="$(Empire)">
-            <PathPrerequisite Flags="Prerequisite" Inverted="true">EmpireTypeMajor,AffinityGameplayMajorHisshos</PathPrerequisite>           
+            <PathPrerequisite Flags="Prerequisite" Inverted="true">EmpireTypeMajor,AffinityGameplayMajorHisshos</PathPrerequisite>
             <InterpreterPrerequisite Flags="Prerequisite">Count(Context, @'ClassEmpire/ColonizedStarSystemStateColony/ClassPopulation,ClassPopulationStarSystemAffinitySophonsCount') ge 2</InterpreterPrerequisite>
         </Prerequisites>
 
@@ -345,22 +353,15 @@
                             <Output_Timer VarName="$Timer"/>
                         </Action_StartTimer>
                     </StartActions>
-                    <Objective Name="C2Step1_Objective1">
-
-
-                        <!-- TODO -->
+                    <Objective Name="C2Step1_Objective1" StartValue="$C2Step1_Objective1Val" EndValue="$Amount02">
                         <AIHint Category="Minimal" MinAutoResolutionTurn="10" MaxAutoResolutionTurn="10" AutoResolutionProbability="0.5" />
                         <Parallel CompletionPolicy="First">
-                           
-                            <Sequence>
-                                <!--Fill 2 Hangars of Sophons System with 2 Ships each-->
-                                <Decorator_BeginTurn>
-                                    <Condition_CheckInterpreter>
-                                        <Input_Context VarName="$CurrentEmpire"/>
-                                        <Input_Expression VarName="$Expression02"/>
-                                    </Condition_CheckInterpreter>                                 
-                                </Decorator_BeginTurn>
-                            </Sequence>                                   
+                            <Decorator_BeginTurn>
+                                <Condition_IsProgressionComplete>
+                                    <Input_Context VarName="$CurrentEmpire"/>
+                                    <Input_Expression VarName="$C2Step1_Objective1Expr"/>
+                                </Condition_IsProgressionComplete>
+                            </Decorator_BeginTurn>
                                                        
                             <Sequence>
                                 <Decorator_BeginTurn>
@@ -408,22 +409,15 @@
                             <Output_Timer VarName="$Timer"/>
                         </Action_StartTimer>
                     </StartActions>
-                    <Objective Name="C2Step1_Objective1Alt">
-
-
-                        <!-- TODO -->
+                    <Objective Name="C2Step1_Objective1Alt" StartValue="$C2Step1_Objective1AltVal" EndValue="$Amount02">
                         <AIHint Category="Minimal" MinAutoResolutionTurn="10" MaxAutoResolutionTurn="10" AutoResolutionProbability="0.5" />
                         <Parallel CompletionPolicy="First">
-
-                            <Sequence>
-                                <!--Fill 2 Hangars of Sophons System with 2 Ships each-->
-                                <Decorator_BeginTurn>
-                                    <Condition_CheckInterpreter>
-                                        <Input_Context VarName="$CurrentEmpire"/>
-                                        <Input_Expression VarName="$Expression02"/>
-                                    </Condition_CheckInterpreter>
-                                </Decorator_BeginTurn>
-                            </Sequence>
+                            <Decorator_BeginTurn>
+                                <Condition_IsProgressionComplete>
+                                    <Input_Context VarName="$CurrentEmpire"/>
+                                    <Input_Expression VarName="$C2Step1_Objective1AltExpr"/>
+                                </Condition_IsProgressionComplete>
+                            </Decorator_BeginTurn>
 
                             <Sequence>
                                 <Decorator_BeginTurn>
@@ -563,7 +557,16 @@
             <LocalizationVar LocalizationKey="$StarSystem01Name" Source="$StarSystem01"/>
             <LocalizationVar LocalizationKey="$StarSystem02Name" Source="$StarSystem02"/>
             <LocalizationVar LocalizationKey="$StarSystem03Name" Source="$StarSystem03"/>
-            
+            <Var VarName="$Threshold3" IntValue="3"/>
+            <InterpretedVar VarName="$Step1_Objective1Val" Target="$(Empire)">
+                <Expression>Min(1, Max(0, Property(ColonizedStarSystem01, @'ClassColonizedStarSystem/ClassHero', Level, true) - 4)) + Min(1, Max(0, Property(ColonizedStarSystem02, @'ClassColonizedStarSystem/ClassHero', Level, true) - 4)) + Min(1, Max(0, Property(ColonizedStarSystem03, @'ClassColonizedStarSystem/ClassHero', Level, true) - 4))</Expression>
+            </InterpretedVar>
+            <Var VarName="$Step1_Objective1Expr" StringValue="Min(1, Max(0, Property(ColonizedStarSystem01, @'ClassColonizedStarSystem/ClassHero', Level, true) - 4)) + Min(1, Max(0, Property(ColonizedStarSystem02, @'ClassColonizedStarSystem/ClassHero', Level, true) - 4)) + Min(1, Max(0, Property(ColonizedStarSystem03, @'ClassColonizedStarSystem/ClassHero', Level, true) - 4))"/>
+            <InterpretedVar VarName="$Step1_Objective2Val" Target="$(Empire)">
+                <Expression>Min(1, Max(0, Property(ColonizedStarSystem01, @'ClassColonizedStarSystem', Happiness, true) - 59)) + Min(1, Max(0, Property(ColonizedStarSystem02, @'ClassColonizedStarSystem', Happiness, true) - 59)) + Min(1, Max(0, Property(ColonizedStarSystem03, @'ClassColonizedStarSystem', Happiness, true) - 59))</Expression>
+            </InterpretedVar>
+            <Var VarName="$Step1_Objective2Expr" StringValue="Min(1, Max(0, Property(ColonizedStarSystem01, @'ClassColonizedStarSystem', Happiness, true) - 59)) + Min(1, Max(0, Property(ColonizedStarSystem02, @'ClassColonizedStarSystem', Happiness, true) - 59)) + Min(1, Max(0, Property(ColonizedStarSystem03, @'ClassColonizedStarSystem', Happiness, true) - 59))"/>
+
         </Vars>
 
 
@@ -616,24 +619,15 @@
                             <Output_Markers VarName="$Marker03"/>
                         </Action_AddQuestMarkers>
                     </StartActions>
-                    <Objective Name="Step1_Objective1">                
-                        <!-- TODO -->
-                        <AIHint Category="Minimal" MinAutoResolutionTurn="17" MaxAutoResolutionTurn="25" AutoResolutionProbability="0.75" />                    
+                    <Objective Name="Step1_Objective1" StartValue="$Step1_Objective1Val" EndValue="$Threshold3">
+                        <AIHint Category="Minimal" MinAutoResolutionTurn="17" MaxAutoResolutionTurn="25" AutoResolutionProbability="0.75" />
                         <Parallel CompletionPolicy="First">
-                            <Sequence>                               
+                            <Sequence>
                                 <Decorator_BeginTurn>
-                                    <Condition_CheckInterpreter>                                  
-                                        <Input_Context VarName="$CurrentEmpire"/>                                   
-                                        <Input_Expression VarName="$Expression01"/>
-                                    </Condition_CheckInterpreter>
-                                    <Condition_CheckInterpreter>
+                                    <Condition_IsProgressionComplete>
                                         <Input_Context VarName="$CurrentEmpire"/>
-                                        <Input_Expression VarName="$Expression02"/>
-                                    </Condition_CheckInterpreter>
-                                    <Condition_CheckInterpreter>
-                                        <Input_Context VarName="$CurrentEmpire"/>
-                                        <Input_Expression VarName="$Expression03"/>
-                                    </Condition_CheckInterpreter>
+                                        <Input_Expression VarName="$Step1_Objective1Expr"/>
+                                    </Condition_IsProgressionComplete>
                                 </Decorator_BeginTurn>
                                     <Action_RemoveQuestMarkers>
                                         <Input_Markers VarName="$Marker01"/>
@@ -786,24 +780,15 @@
                             <Output_Markers VarName="$Marker03"/>
                         </Action_AddQuestMarkers>
                     </StartActions>
-                    <Objective Name="Step1_Objective2">
-                        <!-- TODO -->
+                    <Objective Name="Step1_Objective2" StartValue="$Step1_Objective2Val" EndValue="$Threshold3">
                         <AIHint Category="Minimal" MinAutoResolutionTurn="17" MaxAutoResolutionTurn="25" AutoResolutionProbability="0.75" />
                         <Parallel CompletionPolicy="First">
                             <Sequence>
                                 <Decorator_BeginTurn>
-                                    <Condition_CheckInterpreter>
+                                    <Condition_IsProgressionComplete>
                                         <Input_Context VarName="$CurrentEmpire"/>
-                                        <Input_Expression VarName="$Expression05"/>
-                                    </Condition_CheckInterpreter>
-                                    <Condition_CheckInterpreter>
-                                        <Input_Context VarName="$CurrentEmpire"/>
-                                        <Input_Expression VarName="$Expression06"/>
-                                    </Condition_CheckInterpreter>
-                                    <Condition_CheckInterpreter>
-                                        <Input_Context VarName="$CurrentEmpire"/>
-                                        <Input_Expression VarName="$Expression07"/>
-                                    </Condition_CheckInterpreter>
+                                        <Input_Expression VarName="$Step1_Objective2Expr"/>
+                                    </Condition_IsProgressionComplete>
                                 </Decorator_BeginTurn>
                                 <Action_RemoveQuestMarkers>
                                     <Input_Markers VarName="$Marker01"/>

--- a/Endless Space Competitive Mod/Quests/QuestDefinitions[Sophons].xml
+++ b/Endless Space Competitive Mod/Quests/QuestDefinitions[Sophons].xml
@@ -1159,8 +1159,6 @@
                 <From Source="$ColonizedSystem01.$StarSystem"></From>
             </Var>
 
-            <Var VarName="$Expression01" StringValue="Count(ColonizedSystem01, @'ClassColonizedStarSystem/ClassGarrison/ClassShip,ShipForBattle,!ShipRoleHero') ge 2"/>
-
             <!-- Define a Hull and an amount of Ship requiered-->
             <Var VarName="$MinimumAmount" IntValue="2"/>
             <Var VarName="$MinimumAmount02" IntValue="1"/>

--- a/Endless Space Competitive Mod/Quests/QuestDefinitions[Sophons].xml
+++ b/Endless Space Competitive Mod/Quests/QuestDefinitions[Sophons].xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8" ?>
 <Datatable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xsi:noNamespaceSchemaLocation="../Schemas/QuestDefinition.xsd">
 
 
@@ -1121,6 +1121,111 @@
       </Step>
     </Steps>
   </QuestDefinition>
+
+  <!--  #######################################  -->
+  <!--           Chapter 2.1 - Diplomacy          -->
+  <!--  #######################################  -->
+  <QuestDefinition Name="SophonsQuest-Chapter2.1-Diplomacy" Category="MajorQuest" SubCategory="Sophons" CheckRandom="false">
+
+        <!--============ TAGS ============-->
+        <Tags>Chapter2.1-Diplomacy</Tags>
+
+        <QuestContextSolo/>
+
+
+        <RepetitionRules  NumberOfOccurrencesPerGame="0"
+                          NumberOfOccurrencesPerEmpire="1"
+                          NumberOfConcurrentInstances="0"/>
+
+        <!--============ VARIABLES ============-->
+        <Vars>
+            <!--   Define a Hangar of a Random System in the Colonized Star System which is not a Home System-->
+            <Var VarName="$CurrentEmpire">
+                <From Source="$Empire"/>
+            </Var>
+            <Var IsGlobal="true" VarName="$ColonizedSystem01">
+                <Any>
+                    <From Source="$CurrentEmpire.$ColonizedStarSystems">
+                        <Where>
+                            <PathPrerequisite Inverted="true" Flags="Prerequisite">ClassColonizedStarSystem,ColonizedStarSystemStateOutpost</PathPrerequisite>
+                        </Where>
+                    </From>
+                </Any>
+            </Var>
+            <Var VarName="$Hangar">
+                <From Source="$ColonizedSystem01.$Hangar"/>
+            </Var>
+            <Var VarName="$ColonizedSystemLocation">
+                <From Source="$ColonizedSystem01.$StarSystem"></From>
+            </Var>
+
+            <Var VarName="$Expression01" StringValue="Count(ColonizedSystem01, @'ClassColonizedStarSystem/ClassGarrison/ClassShip,ShipForBattle,!ShipRoleHero') ge 2"/>
+
+            <!-- Define a Hull and an amount of Ship requiered-->
+            <Var VarName="$MinimumAmount" IntValue="2"/>
+            <Var VarName="$MinimumAmount02" IntValue="1"/>
+            <!--Decorator should count the SHIP whatever the hulls/modules are-->
+            <Var VarName="$BattleShipTag" StringValue="ShipForBattle"/>
+
+            <LocalizationVar LocalizationKey="$SystemName01" Source="$ColonizedSystemLocation"/>
+            <Var VarName="$Marker01"/>
+            <Var VarName="$Amount01" IntValue="2"/>
+            <LocalizationVar Source="$Amount01" LocalizationKey="$Amount01Name"/>
+            <!--POLITICAL EFFECT -->
+            <Var VarName="$PoliticalEffectPacifist" StringValue="PopulationEventSophons02.1Pacifist"/>
+        </Vars>
+
+        <!--============ PREREQUISITES ============-->
+
+        <!--============ STEPS ============-->
+
+        <Steps>
+            <!--============ STEP 1 ============-->
+            <Step Name="Step1">
+                <ObjectiveSet>
+                    <StartActions>
+                        <Action_TriggerPopulationEvent>
+                            <Input_Empire VarName="$CurrentEmpire"/>
+                            <Input_Target VarName="$CurrentEmpire"/>
+                            <Input_PopulationEventDefinition VarName="$PoliticalEffectPacifist"/>
+                        </Action_TriggerPopulationEvent>
+                        <Action_AddQuestMarkers RevealsLocation="true">
+                            <Input_Targets VarName="$ColonizedSystemLocation"/>
+                            <Input_Empires VarName="$CurrentEmpire"/>
+                            <Output_Markers VarName="$Marker01"/>
+                        </Action_AddQuestMarkers>
+                    </StartActions>
+                    <Objective Name="Step1_Objective1">
+                        <!-- Garrison 2 Military Ships in the system at the same time. -->
+                        <AIHint Category="Minimal" MinAutoResolutionTurn="15" MaxAutoResolutionTurn="20" AutoResolutionProbability="1" />
+                        <Sequence>
+                            <Decorator_BeginTurn>
+                                <Condition_CheckInterpreter>
+                                    <Input_Context VarName="$CurrentEmpire"/>
+                                    <Input_Expression VarName="$Expression01"/>
+                                </Condition_CheckInterpreter>
+                            </Decorator_BeginTurn>
+                            <Action_RemoveQuestMarkers>
+                                <Input_Markers VarName="$Marker01"/>
+                            </Action_RemoveQuestMarkers>
+                            <Action_ChooseOutcome Name="Outcome1"/>
+                        </Sequence>
+                        <Outcome Name="Outcome1">
+                            <Triggers Weight="1">
+                                <QuestTrigger>
+                                    <Tags>Chapter2.2-Diplomacy</Tags>
+                                    <QuestContextSolo ParticipantsVarName="$CurrentEmpire"/>
+                                </QuestTrigger>
+                            </Triggers>
+                        </Outcome>
+                    </Objective>
+                </ObjectiveSet>
+                <Reward Droplist="DroplistLuxuriesEra2" Picks="1"/>
+            </Step>
+
+        </Steps>
+
+    </QuestDefinition>
 
   <!--  #######################################  -->
   <!--            Chapter 2.2 - Diplomacy           -->

--- a/Endless Space Competitive Mod/Quests/QuestDefinitions[Sophons].xml
+++ b/Endless Space Competitive Mod/Quests/QuestDefinitions[Sophons].xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <Datatable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xsi:noNamespaceSchemaLocation="../Schemas/QuestDefinition.xsd">
 
 

--- a/Endless Space Competitive Mod/Quests/QuestDefinitions[Sophons].xml
+++ b/Endless Space Competitive Mod/Quests/QuestDefinitions[Sophons].xml
@@ -1159,7 +1159,7 @@
                 <From Source="$ColonizedSystem01.$StarSystem"></From>
             </Var>
 
-            <!-- Define a Hull and an amount of Ship requiered-->
+            <!-- Define a Hull and an amount of Ship required-->
             <Var VarName="$MinimumAmount" IntValue="2"/>
 
             <LocalizationVar LocalizationKey="$SystemName01" Source="$ColonizedSystemLocation"/>

--- a/Endless Space Competitive Mod/Quests/QuestDefinitions[Sophons].xml
+++ b/Endless Space Competitive Mod/Quests/QuestDefinitions[Sophons].xml
@@ -1173,6 +1173,10 @@
             <LocalizationVar Source="$Amount01" LocalizationKey="$Amount01Name"/>
             <!--POLITICAL EFFECT -->
             <Var VarName="$PoliticalEffectPacifist" StringValue="PopulationEventSophons02.1Pacifist"/>
+            <InterpretedVar VarName="$Step1_Objective1Val" Target="$(Empire)">
+                <Expression>Count(ColonizedSystem01, @'ClassColonizedStarSystem/ClassGarrison/ClassShip,ShipForBattle,!ShipRoleHero')</Expression>
+            </InterpretedVar>
+            <Var VarName="$Step1_Objective1Expr" StringValue="Count(ColonizedSystem01, @'ClassColonizedStarSystem/ClassGarrison/ClassShip,ShipForBattle,!ShipRoleHero')"/>
         </Vars>
 
         <!--============ PREREQUISITES ============-->
@@ -1195,15 +1199,15 @@
                             <Output_Markers VarName="$Marker01"/>
                         </Action_AddQuestMarkers>
                     </StartActions>
-                    <Objective Name="Step1_Objective1">
+                    <Objective Name="Step1_Objective1" StartValue="$Step1_Objective1Val" EndValue="$MinimumAmount">
                         <!-- Garrison 2 Military Ships in the system at the same time. -->
                         <AIHint Category="Minimal" MinAutoResolutionTurn="15" MaxAutoResolutionTurn="20" AutoResolutionProbability="1" />
                         <Sequence>
                             <Decorator_BeginTurn>
-                                <Condition_CheckInterpreter>
+                                <Condition_IsProgressionComplete>
                                     <Input_Context VarName="$CurrentEmpire"/>
-                                    <Input_Expression VarName="$Expression01"/>
-                                </Condition_CheckInterpreter>
+                                    <Input_Expression VarName="$Step1_Objective1Expr"/>
+                                </Condition_IsProgressionComplete>
                             </Decorator_BeginTurn>
                             <Action_RemoveQuestMarkers>
                                 <Input_Markers VarName="$Marker01"/>

--- a/Endless Space Competitive Mod/Quests/QuestDefinitions[Sophons].xml
+++ b/Endless Space Competitive Mod/Quests/QuestDefinitions[Sophons].xml
@@ -1161,9 +1161,6 @@
 
             <!-- Define a Hull and an amount of Ship requiered-->
             <Var VarName="$MinimumAmount" IntValue="2"/>
-            <Var VarName="$MinimumAmount02" IntValue="1"/>
-            <!--Decorator should count the SHIP whatever the hulls/modules are-->
-            <Var VarName="$BattleShipTag" StringValue="ShipForBattle"/>
 
             <LocalizationVar LocalizationKey="$SystemName01" Source="$ColonizedSystemLocation"/>
             <Var VarName="$Marker01"/>

--- a/Endless Space Competitive Mod/Quests/QuestDefinitions[UE].xml
+++ b/Endless Space Competitive Mod/Quests/QuestDefinitions[UE].xml
@@ -199,7 +199,6 @@
 				</Any>
 			</Var>
 			<Var VarName="$NewSystemName" StringValue="%UE_Quest-Chapter1.1Outpost"/>
-			<Var VarName="$Expression" StringValue="Property(Context, MaximumEmpireManpowerStock) ge 800"/>
 			<LocalizationVar LocalizationKey="$ManpowerAmountName" Source="$ManpowerAmount"/>
 			<LocalizationVar LocalizationKey="$DustAmoutName" Source="$DustAmout"/>
 			<LocalizationVar LocalizationKey="$LoopCountName" Source="$LoopCount"/>

--- a/Endless Space Competitive Mod/Quests/QuestDefinitions[UE].xml
+++ b/Endless Space Competitive Mod/Quests/QuestDefinitions[UE].xml
@@ -203,6 +203,10 @@
 			<LocalizationVar LocalizationKey="$ManpowerAmountName" Source="$ManpowerAmount"/>
 			<LocalizationVar LocalizationKey="$DustAmoutName" Source="$DustAmout"/>
 			<LocalizationVar LocalizationKey="$LoopCountName" Source="$LoopCount"/>
+			<InterpretedVar VarName="$Step2_1_Objective1Val" Target="$(Empire)">
+				<Expression>Property(Context, MaximumEmpireManpowerStock)</Expression>
+			</InterpretedVar>
+			<Var VarName="$Step2_1_Objective1Expr" StringValue="Property(Context, MaximumEmpireManpowerStock)"/>
 			<InterpretedVar VarName="$Step2_2_Objective1Val" Target="$(Empire)">
 				<Expression>Property(Context, @'ClassEmpire', BankAccount)</Expression>
 			</InterpretedVar>
@@ -271,15 +275,15 @@
 							<Input_PopulationEventDefinition VarName="$PoliticalEffectMilitary"/>
 						</Action_TriggerPopulationEvent>
 					</StartActions>
-					<Objective Name="Step2_1_Objective1">
+					<Objective Name="Step2_1_Objective1" StartValue="$Step2_1_Objective1Val" EndValue="$ManpowerAmount">
 						<!-- TODO -->
 						<AIHint Category="Minimal" MinAutoResolutionTurn="25" MaxAutoResolutionTurn="35" AutoResolutionProbability="1" />
 						<Sequence>
 							<Decorator_BeginTurn>
-								<Condition_CheckInterpreter>
+								<Condition_IsProgressionComplete>
 									<Input_Context VarName="$CurrentEmpire"/>
-									<Input_Expression VarName="$Expression"/>
-								</Condition_CheckInterpreter>
+									<Input_Expression VarName="$Step2_1_Objective1Expr"/>
+								</Condition_IsProgressionComplete>
 							</Decorator_BeginTurn>
 							<Action_ChooseOutcome Name="Outcome1"/>
 						</Sequence>


### PR DESCRIPTION
This PR adds progress counters to a handful of quests not covered by #1693 and #1697. The general structure is as before - we are adding `StartValue` / `EndValue` attributes to quest objectives where they were not present and replacing progression checks with `<Condition_IsProgressionComplete>` nodes that both refresh the displayed counter and possibly progress the quest if it hits the needed value. As before I've split the commits up to ease review - the first one copies the quests as-is from vanilla, second (the most interesting one) applies the counter changes, the third strips out quest variables that are no longer needed as a result of the 2nd.

The objectives covered are:

- **United Empire** (UE_Quest-Chapter1.1): reach X manpower stock
- **Sophons** (SophonsQuest-Chapter2.1-Diplomacy): garrison X ships
- **Sophon Population** (PopulationQuest02): garrison X ships
- **Lord of War** (PopulationQuest11): have X level 5 governors across designated systems
- **Lord of War** (PopulationQuest11): have X of designated system at required approval level
- **Nakalim Population** (PopulationQuest28): have X systems at required approval level