### PR TITLE
Fix galaxy-gen quest reliability (timing + null aborts)

### DIFF
--- a/Endless Space Competitive Mod/Quests/QuestDefinitions[GalaxyGen].xml
+++ b/Endless Space Competitive Mod/Quests/QuestDefinitions[GalaxyGen].xml
@@ -12,7 +12,7 @@
     <!-- ##### GALAXY GEN QUEST Constellation 0 Step 0: Determine position of Constellation 0 (Deficit, Surplus or Balance) #####-->
     <QuestDefinition Name="GalaxyGenerationQuest_Planets-C0S0" Category="GalaxyGeneration" SubCategory="SystemNormalization" IsInstant="true" TriggeringProbability="1" CheckRandom="false" MinimumTurn="0">
       <!--============ TAGS ============-->
-      <Tags>Hidden</Tags>
+      <Tags>Hidden, BeginTurn</Tags>
       <!--============ CONTEXT ============-->
       <QuestContextSolo/>
       <!--============ OCCURRENCE RULES ============-->
@@ -700,7 +700,7 @@
    <!-- ##### GALAXY GEN QUEST Constellation 1 Step 0: Determine position of Constellation 1 (Deficit, Surplus or Balance) #####-->
    <QuestDefinition Name="GalaxyGenerationQuest_Planets-C1S0" Category="GalaxyGeneration" SubCategory="SystemNormalization" IsInstant="true" TriggeringProbability="1" CheckRandom="false" MinimumTurn="0">
     <!--============ TAGS ============-->
-    <Tags>Hidden</Tags>
+    <Tags>Hidden, BeginTurn</Tags>
     <!--============ CONTEXT ============-->
     <QuestContextSolo/>
     <!--============ OCCURRENCE RULES ============-->
@@ -1383,7 +1383,7 @@
 <!-- ##### GALAXY GEN QUEST Constellation 1 Step 0: Determine position of Constellation 1 (Deficit, Surplus or Balance) #####-->
 <QuestDefinition Name="GalaxyGenerationQuest_Planets-C2S0" Category="GalaxyGeneration" SubCategory="SystemNormalization" IsInstant="true" TriggeringProbability="1" CheckRandom="false" MinimumTurn="0">
   <!--============ TAGS ============-->
-  <Tags>Hidden</Tags>
+  <Tags>Hidden, BeginTurn</Tags>
   <!--============ CONTEXT ============-->
   <QuestContextSolo/>
   <!--============ OCCURRENCE RULES ============-->
@@ -2066,7 +2066,7 @@
 <!-- ##### GALAXY GEN QUEST Constellation 1 Step 0: Determine position of Constellation 1 (Deficit, Surplus or Balance) #####-->
 <QuestDefinition Name="GalaxyGenerationQuest_Planets-C3S0" Category="GalaxyGeneration" SubCategory="SystemNormalization" IsInstant="true" TriggeringProbability="1" CheckRandom="false" MinimumTurn="0">
   <!--============ TAGS ============-->
-  <Tags>Hidden</Tags>
+  <Tags>Hidden, BeginTurn</Tags>
   <!--============ CONTEXT ============-->
   <QuestContextSolo/>
   <!--============ OCCURRENCE RULES ============-->
@@ -2750,7 +2750,7 @@
 <!-- ##### GALAXY GEN QUEST Constellation 1 Step 0: Determine position of Constellation 1 (Deficit, Surplus or Balance) #####-->
 <QuestDefinition Name="GalaxyGenerationQuest_Planets-C4S0" Category="GalaxyGeneration" SubCategory="SystemNormalization" IsInstant="true" TriggeringProbability="1" CheckRandom="false" MinimumTurn="0">
   <!--============ TAGS ============-->
-  <Tags>Hidden</Tags>
+  <Tags>Hidden, BeginTurn</Tags>
   <!--============ CONTEXT ============-->
   <QuestContextSolo/>
   <!--============ OCCURRENCE RULES ============-->

--- a/Endless Space Competitive Mod/Quests/QuestDefinitions[GalaxyGen].xml
+++ b/Endless Space Competitive Mod/Quests/QuestDefinitions[GalaxyGen].xml
@@ -27,13 +27,9 @@
           </Select>
         </Var>
 
-        <!-- Find the Academy, just to have an objective frame of reference for this process-->
+        <!-- Anchor on the chosen empire home system (queryable at Turn-1 begin) as the frame of reference; replaces the WorldAcademy lookup which was not ready at Turn-1 begin-->
         <Var VarName="$AcademySystem">
-          <From Source="$Constellations.$StarSystems">
-              <Where>
-                  <PathPrerequisite Flags="Prerequisite">WorldAcademy</PathPrerequisite>
-              </Where>
-          </From>
+          <From Source="$ChosenEmpire.$HomeStarSystem"/>
         </Var>
         <Var VarName="$Constellation0">
           <From Source="$AcademySystem.$Constellation"/>
@@ -204,13 +200,9 @@
           </Select>
       </Var>
 
-      <!-- Find the Academy, just to have an objective frame of reference for this process-->
+      <!-- Anchor on the chosen empire home system (queryable at Turn-1 begin) as the frame of reference; replaces the WorldAcademy lookup which was not ready at Turn-1 begin-->
       <Var VarName="$AcademySystem">
-        <From Source="$Constellations.$StarSystems">
-            <Where>
-                <PathPrerequisite Flags="Prerequisite">WorldAcademy</PathPrerequisite>
-            </Where>
-        </From>
+        <From Source="$ChosenEmpire.$HomeStarSystem"/>
       </Var>
       <Var VarName="$Constellation0">
         <From Source="$AcademySystem.$Constellation"/>
@@ -327,13 +319,9 @@
           </Select>
       </Var>
 
-      <!-- Find the Academy, just to have an objective frame of reference for this process-->
+      <!-- Anchor on the chosen empire home system (queryable at Turn-1 begin) as the frame of reference; replaces the WorldAcademy lookup which was not ready at Turn-1 begin-->
       <Var VarName="$AcademySystem">
-        <From Source="$Constellations.$StarSystems">
-            <Where>
-                <PathPrerequisite Flags="Prerequisite">WorldAcademy</PathPrerequisite>
-            </Where>
-        </From>
+        <From Source="$ChosenEmpire.$HomeStarSystem"/>
       </Var>
       <Var VarName="$Constellation0">
         <From Source="$AcademySystem.$Constellation"/>
@@ -450,13 +438,9 @@
           </Select>
       </Var>
 
-      <!-- Find the Academy, just to have an objective frame of reference for this process-->
+      <!-- Anchor on the chosen empire home system (queryable at Turn-1 begin) as the frame of reference; replaces the WorldAcademy lookup which was not ready at Turn-1 begin-->
       <Var VarName="$AcademySystem">
-        <From Source="$Constellations.$StarSystems">
-            <Where>
-                <PathPrerequisite Flags="Prerequisite">WorldAcademy</PathPrerequisite>
-            </Where>
-        </From>
+        <From Source="$ChosenEmpire.$HomeStarSystem"/>
       </Var>
       <Var VarName="$Constellation0">
         <From Source="$AcademySystem.$Constellation"/>
@@ -577,13 +561,9 @@
           </Select>
       </Var>
 
-      <!-- Find the Academy, just to have an objective frame of reference for this process-->
+      <!-- Anchor on the chosen empire home system (queryable at Turn-1 begin) as the frame of reference; replaces the WorldAcademy lookup which was not ready at Turn-1 begin-->
       <Var VarName="$AcademySystem">
-        <From Source="$Constellations.$StarSystems">
-            <Where>
-                <PathPrerequisite Flags="Prerequisite">WorldAcademy</PathPrerequisite>
-            </Where>
-        </From>
+        <From Source="$ChosenEmpire.$HomeStarSystem"/>
       </Var>
       <Var VarName="$Constellation0">
         <From Source="$AcademySystem.$Constellation"/>
@@ -704,13 +684,9 @@
           </Select>
       </Var>
 
-      <!-- Find the Academy, just to have an objective frame of reference for this process-->
+      <!-- Anchor on the chosen empire home system (queryable at Turn-1 begin) as the frame of reference; replaces the WorldAcademy lookup which was not ready at Turn-1 begin-->
       <Var VarName="$AcademySystem">
-        <From Source="$Constellations.$StarSystems">
-            <Where>
-                <PathPrerequisite Flags="Prerequisite">WorldAcademy</PathPrerequisite>
-            </Where>
-        </From>
+        <From Source="$ChosenEmpire.$HomeStarSystem"/>
       </Var>
       <Var VarName="$Constellation0">
         <From Source="$AcademySystem.$Constellation"/>
@@ -887,13 +863,9 @@
           </Select>
     </Var>
 
-    <!-- Find the Academy, just to have an objective frame of reference for this process-->
+    <!-- Anchor on the chosen empire home system (queryable at Turn-1 begin) as the frame of reference; replaces the WorldAcademy lookup which was not ready at Turn-1 begin-->
     <Var VarName="$AcademySystem">
-      <From Source="$Constellations.$StarSystems">
-          <Where>
-              <PathPrerequisite Flags="Prerequisite">WorldAcademy</PathPrerequisite>
-          </Where>
-      </From>
+      <From Source="$ChosenEmpire.$HomeStarSystem"/>
     </Var>
     <Var VarName="$Constellation0">
       <From Source="$AcademySystem.$Constellation"/>
@@ -1015,13 +987,9 @@
           </Select>
     </Var>
 
-    <!-- Find the Academy, just to have an objective frame of reference for this process-->
+    <!-- Anchor on the chosen empire home system (queryable at Turn-1 begin) as the frame of reference; replaces the WorldAcademy lookup which was not ready at Turn-1 begin-->
     <Var VarName="$AcademySystem">
-      <From Source="$Constellations.$StarSystems">
-          <Where>
-              <PathPrerequisite Flags="Prerequisite">WorldAcademy</PathPrerequisite>
-          </Where>
-      </From>
+      <From Source="$ChosenEmpire.$HomeStarSystem"/>
     </Var>
     <Var VarName="$Constellation0">
       <From Source="$AcademySystem.$Constellation"/>
@@ -1143,13 +1111,9 @@
           </Select>
     </Var>
 
-    <!-- Find the Academy, just to have an objective frame of reference for this process-->
+    <!-- Anchor on the chosen empire home system (queryable at Turn-1 begin) as the frame of reference; replaces the WorldAcademy lookup which was not ready at Turn-1 begin-->
     <Var VarName="$AcademySystem">
-      <From Source="$Constellations.$StarSystems">
-          <Where>
-              <PathPrerequisite Flags="Prerequisite">WorldAcademy</PathPrerequisite>
-          </Where>
-      </From>
+      <From Source="$ChosenEmpire.$HomeStarSystem"/>
     </Var>
     <Var VarName="$Constellation0">
       <From Source="$AcademySystem.$Constellation"/>
@@ -1275,13 +1239,9 @@
           </Select>
     </Var>
 
-    <!-- Find the Academy, just to have an objective frame of reference for this process-->
+    <!-- Anchor on the chosen empire home system (queryable at Turn-1 begin) as the frame of reference; replaces the WorldAcademy lookup which was not ready at Turn-1 begin-->
     <Var VarName="$AcademySystem">
-      <From Source="$Constellations.$StarSystems">
-          <Where>
-              <PathPrerequisite Flags="Prerequisite">WorldAcademy</PathPrerequisite>
-          </Where>
-      </From>
+      <From Source="$ChosenEmpire.$HomeStarSystem"/>
     </Var>
     <Var VarName="$Constellation0">
       <From Source="$AcademySystem.$Constellation"/>
@@ -1407,13 +1367,9 @@
           </Select>
     </Var>
 
-    <!-- Find the Academy, just to have an objective frame of reference for this process-->
+    <!-- Anchor on the chosen empire home system (queryable at Turn-1 begin) as the frame of reference; replaces the WorldAcademy lookup which was not ready at Turn-1 begin-->
     <Var VarName="$AcademySystem">
-      <From Source="$Constellations.$StarSystems">
-          <Where>
-              <PathPrerequisite Flags="Prerequisite">WorldAcademy</PathPrerequisite>
-          </Where>
-      </From>
+      <From Source="$ChosenEmpire.$HomeStarSystem"/>
     </Var>
     <Var VarName="$Constellation0">
       <From Source="$AcademySystem.$Constellation"/>
@@ -1590,13 +1546,9 @@
           </Select>
     </Var>
 
-    <!-- Find the Academy, just to have an objective frame of reference for this process-->
+    <!-- Anchor on the chosen empire home system (queryable at Turn-1 begin) as the frame of reference; replaces the WorldAcademy lookup which was not ready at Turn-1 begin-->
     <Var VarName="$AcademySystem">
-      <From Source="$Constellations.$StarSystems">
-          <Where>
-              <PathPrerequisite Flags="Prerequisite">WorldAcademy</PathPrerequisite>
-          </Where>
-      </From>
+      <From Source="$ChosenEmpire.$HomeStarSystem"/>
     </Var>
     <Var VarName="$Constellation0">
       <From Source="$AcademySystem.$Constellation"/>
@@ -1718,13 +1670,9 @@
           </Select>
     </Var>
 
-    <!-- Find the Academy, just to have an objective frame of reference for this process-->
+    <!-- Anchor on the chosen empire home system (queryable at Turn-1 begin) as the frame of reference; replaces the WorldAcademy lookup which was not ready at Turn-1 begin-->
     <Var VarName="$AcademySystem">
-      <From Source="$Constellations.$StarSystems">
-          <Where>
-              <PathPrerequisite Flags="Prerequisite">WorldAcademy</PathPrerequisite>
-          </Where>
-      </From>
+      <From Source="$ChosenEmpire.$HomeStarSystem"/>
     </Var>
     <Var VarName="$Constellation0">
       <From Source="$AcademySystem.$Constellation"/>
@@ -1846,13 +1794,9 @@
           </Select>
     </Var>
 
-    <!-- Find the Academy, just to have an objective frame of reference for this process-->
+    <!-- Anchor on the chosen empire home system (queryable at Turn-1 begin) as the frame of reference; replaces the WorldAcademy lookup which was not ready at Turn-1 begin-->
     <Var VarName="$AcademySystem">
-      <From Source="$Constellations.$StarSystems">
-          <Where>
-              <PathPrerequisite Flags="Prerequisite">WorldAcademy</PathPrerequisite>
-          </Where>
-      </From>
+      <From Source="$ChosenEmpire.$HomeStarSystem"/>
     </Var>
     <Var VarName="$Constellation0">
       <From Source="$AcademySystem.$Constellation"/>
@@ -1978,13 +1922,9 @@
           </Select>
     </Var>
 
-    <!-- Find the Academy, just to have an objective frame of reference for this process-->
+    <!-- Anchor on the chosen empire home system (queryable at Turn-1 begin) as the frame of reference; replaces the WorldAcademy lookup which was not ready at Turn-1 begin-->
     <Var VarName="$AcademySystem">
-      <From Source="$Constellations.$StarSystems">
-          <Where>
-              <PathPrerequisite Flags="Prerequisite">WorldAcademy</PathPrerequisite>
-          </Where>
-      </From>
+      <From Source="$ChosenEmpire.$HomeStarSystem"/>
     </Var>
     <Var VarName="$Constellation0">
       <From Source="$AcademySystem.$Constellation"/>
@@ -2110,13 +2050,9 @@
           </Select>
     </Var>
 
-    <!-- Find the Academy, just to have an objective frame of reference for this process-->
+    <!-- Anchor on the chosen empire home system (queryable at Turn-1 begin) as the frame of reference; replaces the WorldAcademy lookup which was not ready at Turn-1 begin-->
     <Var VarName="$AcademySystem">
-      <From Source="$Constellations.$StarSystems">
-          <Where>
-              <PathPrerequisite Flags="Prerequisite">WorldAcademy</PathPrerequisite>
-          </Where>
-      </From>
+      <From Source="$ChosenEmpire.$HomeStarSystem"/>
     </Var>
     <Var VarName="$Constellation0">
       <From Source="$AcademySystem.$Constellation"/>
@@ -2294,13 +2230,9 @@
           </Select>
     </Var>
 
-    <!-- Find the Academy, just to have an objective frame of reference for this process-->
+    <!-- Anchor on the chosen empire home system (queryable at Turn-1 begin) as the frame of reference; replaces the WorldAcademy lookup which was not ready at Turn-1 begin-->
     <Var VarName="$AcademySystem">
-      <From Source="$Constellations.$StarSystems">
-          <Where>
-              <PathPrerequisite Flags="Prerequisite">WorldAcademy</PathPrerequisite>
-          </Where>
-      </From>
+      <From Source="$ChosenEmpire.$HomeStarSystem"/>
     </Var>
     <Var VarName="$Constellation0">
       <From Source="$AcademySystem.$Constellation"/>
@@ -2422,13 +2354,9 @@
           </Select>
     </Var>
 
-    <!-- Find the Academy, just to have an objective frame of reference for this process-->
+    <!-- Anchor on the chosen empire home system (queryable at Turn-1 begin) as the frame of reference; replaces the WorldAcademy lookup which was not ready at Turn-1 begin-->
     <Var VarName="$AcademySystem">
-      <From Source="$Constellations.$StarSystems">
-          <Where>
-              <PathPrerequisite Flags="Prerequisite">WorldAcademy</PathPrerequisite>
-          </Where>
-      </From>
+      <From Source="$ChosenEmpire.$HomeStarSystem"/>
     </Var>
     <Var VarName="$Constellation0">
       <From Source="$AcademySystem.$Constellation"/>
@@ -2550,13 +2478,9 @@
           </Select>
     </Var>
 
-    <!-- Find the Academy, just to have an objective frame of reference for this process-->
+    <!-- Anchor on the chosen empire home system (queryable at Turn-1 begin) as the frame of reference; replaces the WorldAcademy lookup which was not ready at Turn-1 begin-->
     <Var VarName="$AcademySystem">
-      <From Source="$Constellations.$StarSystems">
-          <Where>
-              <PathPrerequisite Flags="Prerequisite">WorldAcademy</PathPrerequisite>
-          </Where>
-      </From>
+      <From Source="$ChosenEmpire.$HomeStarSystem"/>
     </Var>
     <Var VarName="$Constellation0">
       <From Source="$AcademySystem.$Constellation"/>
@@ -2682,13 +2606,9 @@
           </Select>
     </Var>
 
-    <!-- Find the Academy, just to have an objective frame of reference for this process-->
+    <!-- Anchor on the chosen empire home system (queryable at Turn-1 begin) as the frame of reference; replaces the WorldAcademy lookup which was not ready at Turn-1 begin-->
     <Var VarName="$AcademySystem">
-      <From Source="$Constellations.$StarSystems">
-          <Where>
-              <PathPrerequisite Flags="Prerequisite">WorldAcademy</PathPrerequisite>
-          </Where>
-      </From>
+      <From Source="$ChosenEmpire.$HomeStarSystem"/>
     </Var>
     <Var VarName="$Constellation0">
       <From Source="$AcademySystem.$Constellation"/>
@@ -2814,13 +2734,9 @@
           </Select>
     </Var>
 
-    <!-- Find the Academy, just to have an objective frame of reference for this process-->
+    <!-- Anchor on the chosen empire home system (queryable at Turn-1 begin) as the frame of reference; replaces the WorldAcademy lookup which was not ready at Turn-1 begin-->
     <Var VarName="$AcademySystem">
-      <From Source="$Constellations.$StarSystems">
-          <Where>
-              <PathPrerequisite Flags="Prerequisite">WorldAcademy</PathPrerequisite>
-          </Where>
-      </From>
+      <From Source="$ChosenEmpire.$HomeStarSystem"/>
     </Var>
     <Var VarName="$Constellation0">
       <From Source="$AcademySystem.$Constellation"/>
@@ -2997,13 +2913,9 @@
           </Select>
     </Var>
 
-    <!-- Find the Academy, just to have an objective frame of reference for this process-->
+    <!-- Anchor on the chosen empire home system (queryable at Turn-1 begin) as the frame of reference; replaces the WorldAcademy lookup which was not ready at Turn-1 begin-->
     <Var VarName="$AcademySystem">
-      <From Source="$Constellations.$StarSystems">
-          <Where>
-              <PathPrerequisite Flags="Prerequisite">WorldAcademy</PathPrerequisite>
-          </Where>
-      </From>
+      <From Source="$ChosenEmpire.$HomeStarSystem"/>
     </Var>
     <Var VarName="$Constellation0">
       <From Source="$AcademySystem.$Constellation"/>
@@ -3125,13 +3037,9 @@
           </Select>
     </Var>
 
-    <!-- Find the Academy, just to have an objective frame of reference for this process-->
+    <!-- Anchor on the chosen empire home system (queryable at Turn-1 begin) as the frame of reference; replaces the WorldAcademy lookup which was not ready at Turn-1 begin-->
     <Var VarName="$AcademySystem">
-      <From Source="$Constellations.$StarSystems">
-          <Where>
-              <PathPrerequisite Flags="Prerequisite">WorldAcademy</PathPrerequisite>
-          </Where>
-      </From>
+      <From Source="$ChosenEmpire.$HomeStarSystem"/>
     </Var>
     <Var VarName="$Constellation0">
       <From Source="$AcademySystem.$Constellation"/>
@@ -3253,13 +3161,9 @@
           </Select>
     </Var>
 
-    <!-- Find the Academy, just to have an objective frame of reference for this process-->
+    <!-- Anchor on the chosen empire home system (queryable at Turn-1 begin) as the frame of reference; replaces the WorldAcademy lookup which was not ready at Turn-1 begin-->
     <Var VarName="$AcademySystem">
-      <From Source="$Constellations.$StarSystems">
-          <Where>
-              <PathPrerequisite Flags="Prerequisite">WorldAcademy</PathPrerequisite>
-          </Where>
-      </From>
+      <From Source="$ChosenEmpire.$HomeStarSystem"/>
     </Var>
     <Var VarName="$Constellation0">
       <From Source="$AcademySystem.$Constellation"/>
@@ -3385,13 +3289,9 @@
           </Select>
     </Var>
 
-    <!-- Find the Academy, just to have an objective frame of reference for this process-->
+    <!-- Anchor on the chosen empire home system (queryable at Turn-1 begin) as the frame of reference; replaces the WorldAcademy lookup which was not ready at Turn-1 begin-->
     <Var VarName="$AcademySystem">
-      <From Source="$Constellations.$StarSystems">
-          <Where>
-              <PathPrerequisite Flags="Prerequisite">WorldAcademy</PathPrerequisite>
-          </Where>
-      </From>
+      <From Source="$ChosenEmpire.$HomeStarSystem"/>
     </Var>
     <Var VarName="$Constellation0">
       <From Source="$AcademySystem.$Constellation"/>

--- a/Endless Space Competitive Mod/Quests/QuestDefinitions[GalaxyGen].xml
+++ b/Endless Space Competitive Mod/Quests/QuestDefinitions[GalaxyGen].xml
@@ -283,15 +283,17 @@
     <!--============ STEPS ============-->
     <Steps>
         <Step Name="Step1">
+            <!-- Self-gate: run the work objective (0) only if this constellation is deficit (+1); else no-op (1) -->
+            <Choice DefaultChoiceIndex="1">
+              <ChoiceItem ObjectiveSetIndex="0">
+                <Prerequisites Target="$(Empires)" AnyTarget="true">
+                  <InterpreterPrerequisite Flags="Prerequisite">$(Constellation_5PlanetDeficit_Count) eq 1</InterpreterPrerequisite>
+                </Prerequisites>
+              </ChoiceItem>
+            </Choice>
             <ObjectiveSet>
               <Objective Name="Objective_Fake">
                 <Sequence>
-                  <Decorator_HeroAssigned>
-                    <Condition_CheckInterpreter>
-                      <Input_Context VarName="$ChosenEmpire"/>
-                      <Input_Expression VarName="$Constellation_5PlanetDeficitBoolean"/>
-                    </Condition_CheckInterpreter>
-                  </Decorator_HeroAssigned>
                   <Action_ApplyStarSystemDefinition>
                     <Input_DefinitionName VarName="$DefinitionName1"/>
                     <Input_StarSystemNode VarName="$SystemToUpgradeA"/>
@@ -306,6 +308,13 @@
                     </QuestTrigger>
                   </Triggers>
                 </Outcome>
+              </Objective>
+            </ObjectiveSet>
+            <ObjectiveSet>
+              <Objective Name="Objective_Fake">
+                <Sequence>
+                  <Action_DoNothing/>
+                </Sequence>
               </Objective>
             </ObjectiveSet>
         </Step>
@@ -413,15 +422,17 @@
     <!--============ STEPS ============-->
     <Steps>
         <Step Name="Step1">
+            <!-- Self-gate: run the work objective (0) only if this constellation is surplus (+1); else no-op (1) -->
+            <Choice DefaultChoiceIndex="1">
+              <ChoiceItem ObjectiveSetIndex="0">
+                <Prerequisites Target="$(Empires)" AnyTarget="true">
+                  <InterpreterPrerequisite Flags="Prerequisite">$(Constellation_5PlanetSurplus_Count) eq 1</InterpreterPrerequisite>
+                </Prerequisites>
+              </ChoiceItem>
+            </Choice>
             <ObjectiveSet>
               <Objective Name="Objective_Fake">
                   <Sequence>
-                    <Decorator_HeroAssigned>
-                      <Condition_CheckInterpreter>
-                        <Input_Context VarName="$ChosenEmpire"/>
-                        <Input_Expression VarName="$Constellation_5PlanetSurplusBoolean"/>
-                      </Condition_CheckInterpreter>
-                    </Decorator_HeroAssigned>
                     <Action_ApplyStarSystemDefinition>
                       <Input_DefinitionName VarName="$DefinitionName99"/>
                       <Input_StarSystemNode VarName="$SystemToDowngradeA"/>
@@ -436,6 +447,13 @@
                       </QuestTrigger>
                     </Triggers>
                   </Outcome>
+              </Objective>
+            </ObjectiveSet>
+            <ObjectiveSet>
+              <Objective Name="Objective_Fake">
+                  <Sequence>
+                    <Action_DoNothing/>
+                  </Sequence>
               </Objective>
             </ObjectiveSet>
         </Step>
@@ -543,15 +561,17 @@
     <!--============ STEPS ============-->
     <Steps>
         <Step Name="Step1">
+            <!-- Self-gate: run the work objective (0) only if this constellation is large-deficit (+2); else no-op (1) -->
+            <Choice DefaultChoiceIndex="1">
+              <ChoiceItem ObjectiveSetIndex="0">
+                <Prerequisites Target="$(Empires)" AnyTarget="true">
+                  <InterpreterPrerequisite Flags="Prerequisite">$(Constellation_5PlanetDeficit_Count) eq 2</InterpreterPrerequisite>
+                </Prerequisites>
+              </ChoiceItem>
+            </Choice>
             <ObjectiveSet>
               <Objective Name="Objective_Fake">
                 <Sequence>
-                  <Decorator_HeroAssigned>
-                    <Condition_CheckInterpreter>
-                      <Input_Context VarName="$ChosenEmpire"/>
-                      <Input_Expression VarName="$Constellation_5PlanetDeficit2Boolean"/>
-                    </Condition_CheckInterpreter>
-                  </Decorator_HeroAssigned>
                   <Action_ApplyStarSystemDefinition>
                     <Input_DefinitionName VarName="$DefinitionName1"/>
                     <Input_StarSystemNode VarName="$SystemToUpgradeA"/>
@@ -570,6 +590,13 @@
                     </QuestTrigger>
                   </Triggers>
                 </Outcome>
+              </Objective>
+            </ObjectiveSet>
+            <ObjectiveSet>
+              <Objective Name="Objective_Fake">
+                <Sequence>
+                  <Action_DoNothing/>
+                </Sequence>
               </Objective>
             </ObjectiveSet>
         </Step>
@@ -677,15 +704,17 @@
     <!--============ STEPS ============-->
     <Steps>
         <Step Name="Step1">
+            <!-- Self-gate: run the work objective (0) only if this constellation is large-surplus (+2); else no-op (1) -->
+            <Choice DefaultChoiceIndex="1">
+              <ChoiceItem ObjectiveSetIndex="0">
+                <Prerequisites Target="$(Empires)" AnyTarget="true">
+                  <InterpreterPrerequisite Flags="Prerequisite">$(Constellation_5PlanetSurplus_Count) eq 2</InterpreterPrerequisite>
+                </Prerequisites>
+              </ChoiceItem>
+            </Choice>
             <ObjectiveSet>
               <Objective Name="Objective_Fake">
                   <Sequence>
-                    <Decorator_HeroAssigned>
-                      <Condition_CheckInterpreter>
-                        <Input_Context VarName="$ChosenEmpire"/>
-                        <Input_Expression VarName="$Constellation_5PlanetSurplus2Boolean"/>
-                      </Condition_CheckInterpreter>
-                    </Decorator_HeroAssigned>
                     <Action_ApplyStarSystemDefinition>
                       <Input_DefinitionName VarName="$DefinitionName99"/>
                       <Input_StarSystemNode VarName="$SystemToDowngradeA"/>
@@ -704,6 +733,13 @@
                       </QuestTrigger>
                     </Triggers>
                   </Outcome>
+              </Objective>
+            </ObjectiveSet>
+            <ObjectiveSet>
+              <Objective Name="Objective_Fake">
+                  <Sequence>
+                    <Action_DoNothing/>
+                  </Sequence>
               </Objective>
             </ObjectiveSet>
         </Step>

--- a/Endless Space Competitive Mod/Quests/QuestDefinitions[GalaxyGen].xml
+++ b/Endless Space Competitive Mod/Quests/QuestDefinitions[GalaxyGen].xml
@@ -79,6 +79,45 @@
         <Var VarName="$Constellation_5PlanetSurplus2Boolean" StringValue="$(Constellation_5PlanetSurplus_Count) eq 2"/>
         <Var VarName="$Constellation_5PlanetBalancedBoolean" StringValue="$(Constellation_5PlanetDeficit_Count) eq 0"/>
 
+        <!-- ===== INLINED from variants C0S1v0-v3 so the work runs on Turn 1 in this quest (no deferred child-quest hop) ===== -->
+        <!-- Inferior systems to upgrade (deficit cases) -->
+        <Var VarName="$SystemsToUpgrade">
+          <From Source="$Constellation0.$StarSystems">
+            <Where>
+                <PathPrerequisite Inverted="true" Flags="Prerequisite">ClassStarSystem, QuestNode</PathPrerequisite>
+                <PathPrerequisite Inverted="true" Flags="Prerequisite">ClassStarSystem,HomeSystem</PathPrerequisite>
+                <PathPrerequisite Inverted="true" Flags="Prerequisite">ClassStarSystem,ColonizedStarSystemStateOutpost</PathPrerequisite>
+                <InterpreterPrerequisite Flags="Prerequisite">Count(Context, @'ClassStarSystem/ClassPlanet') le 3</InterpreterPrerequisite>
+            </Where>
+            <OrderBy>
+                <SortSystemByDistance OriginVarName="$AcademySystem" SortBy="Nearest" MinimumDistance="1" MaximumDistance="9999" MinimumCandidateCount="2"/>
+            </OrderBy>
+          </From>
+        </Var>
+        <Var VarName="$SystemToUpgradeA"><Select Index="0"><From Source="$SystemsToUpgrade"/></Select></Var>
+        <Var VarName="$SystemToUpgradeB"><Select Index="1"><From Source="$SystemsToUpgrade"/></Select></Var>
+        <!-- Superior systems to downgrade (surplus cases) -->
+        <Var VarName="$SystemsToDowngrade">
+          <From Source="$Constellation0.$StarSystems">
+            <Where>
+                <PathPrerequisite Inverted="true" Flags="Prerequisite">ClassStarSystem, QuestNode</PathPrerequisite>
+                <PathPrerequisite Inverted="true" Flags="Prerequisite">ClassStarSystem,HomeSystem</PathPrerequisite>
+                <PathPrerequisite Inverted="true" Flags="Prerequisite">ClassStarSystem,ColonizedStarSystemStateOutpost</PathPrerequisite>
+                <InterpreterPrerequisite Flags="Prerequisite">Count(Context, @'ClassStarSystem/ClassPlanet') ge 5</InterpreterPrerequisite>
+            </Where>
+            <OrderBy>
+                <SortSystemByDistance OriginVarName="$AcademySystem" SortBy="Nearest" MinimumDistance="1" MaximumDistance="9999" MinimumCandidateCount="2"/>
+            </OrderBy>
+          </From>
+        </Var>
+        <Var VarName="$SystemToDowngradeA"><Select Index="0"><From Source="$SystemsToDowngrade"/></Select></Var>
+        <Var VarName="$SystemToDowngradeB"><Select Index="1"><From Source="$SystemsToDowngrade"/></Select></Var>
+        <!-- Replacement node definitions -->
+        <Var VarName="$DefinitionName1" StringValue="Replacement5pNode1"/>
+        <Var VarName="$DefinitionName2" StringValue="Replacement5pNode2"/>
+        <Var VarName="$DefinitionName99" StringValue="Replacement4pNode1"/>
+        <Var VarName="$DefinitionName98" StringValue="Replacement4pNode2"/>
+
       </Vars>
       <!--============ PREREQUISITES ============-->
       <Prerequisites Target="$(Empires)" AnyTarget="true">
@@ -97,7 +136,7 @@
                           <Input_Expression VarName="$Constellation_5PlanetBalancedBoolean"/>
                         </Condition_CheckInterpreter>
                       </Decorator_HeroAssigned>
-                      <Action_ChooseOutcome Name="Outcome0"/>
+                      <Action_ChooseOutcome Name="DoResource"/>
                     </Sequence>
                     <Sequence>
                       <Decorator_HeroAssigned>
@@ -106,7 +145,11 @@
                           <Input_Expression VarName="$Constellation_5PlanetDeficitBoolean"/>
                         </Condition_CheckInterpreter>
                       </Decorator_HeroAssigned>
-                      <Action_ChooseOutcome Name="Outcome1"/>
+                      <Action_ApplyStarSystemDefinition>
+                        <Input_DefinitionName VarName="$DefinitionName1"/>
+                        <Input_StarSystemNode VarName="$SystemToUpgradeA"/>
+                      </Action_ApplyStarSystemDefinition>
+                      <Action_ChooseOutcome Name="DoResource"/>
                     </Sequence>
                     <Sequence>
                       <Decorator_HeroAssigned>
@@ -115,7 +158,11 @@
                           <Input_Expression VarName="$Constellation_5PlanetSurplusBoolean"/>
                         </Condition_CheckInterpreter>
                       </Decorator_HeroAssigned>
-                      <Action_ChooseOutcome Name="Outcome2"/>
+                      <Action_ApplyStarSystemDefinition>
+                        <Input_DefinitionName VarName="$DefinitionName99"/>
+                        <Input_StarSystemNode VarName="$SystemToDowngradeA"/>
+                      </Action_ApplyStarSystemDefinition>
+                      <Action_ChooseOutcome Name="DoResource"/>
                     </Sequence>
                     <Sequence>
                       <Decorator_HeroAssigned>
@@ -124,7 +171,15 @@
                           <Input_Expression VarName="$Constellation_5PlanetDeficit2Boolean"/>
                         </Condition_CheckInterpreter>
                       </Decorator_HeroAssigned>
-                      <Action_ChooseOutcome Name="Outcome3"/>
+                      <Action_ApplyStarSystemDefinition>
+                        <Input_DefinitionName VarName="$DefinitionName1"/>
+                        <Input_StarSystemNode VarName="$SystemToUpgradeA"/>
+                      </Action_ApplyStarSystemDefinition>
+                      <Action_ApplyStarSystemDefinition>
+                        <Input_DefinitionName VarName="$DefinitionName2"/>
+                        <Input_StarSystemNode VarName="$SystemToUpgradeB"/>
+                      </Action_ApplyStarSystemDefinition>
+                      <Action_ChooseOutcome Name="DoResource"/>
                     </Sequence>
                     <Sequence>
                       <Decorator_HeroAssigned>
@@ -133,45 +188,21 @@
                           <Input_Expression VarName="$Constellation_5PlanetSurplus2Boolean"/>
                         </Condition_CheckInterpreter>
                       </Decorator_HeroAssigned>
-                      <Action_ChooseOutcome Name="Outcome4"/>
+                      <Action_ApplyStarSystemDefinition>
+                        <Input_DefinitionName VarName="$DefinitionName99"/>
+                        <Input_StarSystemNode VarName="$SystemToDowngradeA"/>
+                      </Action_ApplyStarSystemDefinition>
+                      <Action_ApplyStarSystemDefinition>
+                        <Input_DefinitionName VarName="$DefinitionName98"/>
+                        <Input_StarSystemNode VarName="$SystemToDowngradeB"/>
+                      </Action_ApplyStarSystemDefinition>
+                      <Action_ChooseOutcome Name="DoResource"/>
                     </Sequence>
                   </Parallel>
-                  <Outcome Name="Outcome0">
+                  <Outcome Name="DoResource">
                     <Triggers Weight="1">
                       <QuestTrigger>
                         <Tags>StrategicResourceGenerationQuest</Tags>
-                        <QuestContextSolo ParticipantsVarName="$ChosenEmpire"/>
-                      </QuestTrigger>
-                    </Triggers>
-                  </Outcome>
-                  <Outcome Name="Outcome1">
-                    <Triggers Weight="1">
-                      <QuestTrigger>
-                        <Tags>GalaxyGenerationQuest_Planets-C0S1v0</Tags>
-                        <QuestContextSolo ParticipantsVarName="$ChosenEmpire"/>
-                      </QuestTrigger>
-                    </Triggers>
-                  </Outcome>
-                  <Outcome Name="Outcome2">
-                    <Triggers Weight="1">
-                      <QuestTrigger>
-                        <Tags>GalaxyGenerationQuest_Planets-C0S1v1</Tags>
-                        <QuestContextSolo ParticipantsVarName="$ChosenEmpire"/>
-                      </QuestTrigger>
-                    </Triggers>
-                  </Outcome>
-                  <Outcome Name="Outcome3">
-                    <Triggers Weight="1">
-                      <QuestTrigger>
-                        <Tags>GalaxyGenerationQuest_Planets-C0S1v2</Tags>
-                        <QuestContextSolo ParticipantsVarName="$ChosenEmpire"/>
-                      </QuestTrigger>
-                    </Triggers>
-                  </Outcome>
-                  <Outcome Name="Outcome4">
-                    <Triggers Weight="1">
-                      <QuestTrigger>
-                        <Tags>GalaxyGenerationQuest_Planets-C0S1v3</Tags>
                         <QuestContextSolo ParticipantsVarName="$ChosenEmpire"/>
                       </QuestTrigger>
                     </Triggers>

--- a/Endless Space Competitive Mod/Quests/QuestDefinitions[GalaxyGen].xml
+++ b/Endless Space Competitive Mod/Quests/QuestDefinitions[GalaxyGen].xml
@@ -12,7 +12,7 @@
     <!-- ##### GALAXY GEN QUEST Constellation 0 Step 0: Determine position of Constellation 0 (Deficit, Surplus or Balance) #####-->
     <QuestDefinition Name="GalaxyGenerationQuest_Planets-C0S0" Category="GalaxyGeneration" SubCategory="SystemNormalization" IsInstant="true" TriggeringProbability="1" CheckRandom="false" MinimumTurn="0">
       <!--============ TAGS ============-->
-      <Tags>Hidden, BeginTurn</Tags>
+      <Tags>Hidden</Tags>
       <!--============ CONTEXT ============-->
       <QuestContextSolo/>
       <!--============ OCCURRENCE RULES ============-->
@@ -669,7 +669,7 @@
    <!-- ##### GALAXY GEN QUEST Constellation 1 Step 0: Determine position of Constellation 1 (Deficit, Surplus or Balance) #####-->
    <QuestDefinition Name="GalaxyGenerationQuest_Planets-C1S0" Category="GalaxyGeneration" SubCategory="SystemNormalization" IsInstant="true" TriggeringProbability="1" CheckRandom="false" MinimumTurn="0">
     <!--============ TAGS ============-->
-    <Tags>Hidden, BeginTurn</Tags>
+    <Tags>Hidden</Tags>
     <!--============ CONTEXT ============-->
     <QuestContextSolo/>
     <!--============ OCCURRENCE RULES ============-->
@@ -1352,7 +1352,7 @@
 <!-- ##### GALAXY GEN QUEST Constellation 1 Step 0: Determine position of Constellation 1 (Deficit, Surplus or Balance) #####-->
 <QuestDefinition Name="GalaxyGenerationQuest_Planets-C2S0" Category="GalaxyGeneration" SubCategory="SystemNormalization" IsInstant="true" TriggeringProbability="1" CheckRandom="false" MinimumTurn="0">
   <!--============ TAGS ============-->
-  <Tags>Hidden, BeginTurn</Tags>
+  <Tags>Hidden</Tags>
   <!--============ CONTEXT ============-->
   <QuestContextSolo/>
   <!--============ OCCURRENCE RULES ============-->
@@ -2035,7 +2035,7 @@
 <!-- ##### GALAXY GEN QUEST Constellation 1 Step 0: Determine position of Constellation 1 (Deficit, Surplus or Balance) #####-->
 <QuestDefinition Name="GalaxyGenerationQuest_Planets-C3S0" Category="GalaxyGeneration" SubCategory="SystemNormalization" IsInstant="true" TriggeringProbability="1" CheckRandom="false" MinimumTurn="0">
   <!--============ TAGS ============-->
-  <Tags>Hidden, BeginTurn</Tags>
+  <Tags>Hidden</Tags>
   <!--============ CONTEXT ============-->
   <QuestContextSolo/>
   <!--============ OCCURRENCE RULES ============-->
@@ -2719,7 +2719,7 @@
 <!-- ##### GALAXY GEN QUEST Constellation 1 Step 0: Determine position of Constellation 1 (Deficit, Surplus or Balance) #####-->
 <QuestDefinition Name="GalaxyGenerationQuest_Planets-C4S0" Category="GalaxyGeneration" SubCategory="SystemNormalization" IsInstant="true" TriggeringProbability="1" CheckRandom="false" MinimumTurn="0">
   <!--============ TAGS ============-->
-  <Tags>Hidden, BeginTurn</Tags>
+  <Tags>Hidden</Tags>
   <!--============ CONTEXT ============-->
   <QuestContextSolo/>
   <!--============ OCCURRENCE RULES ============-->

--- a/Endless Space Competitive Mod/Quests/QuestDefinitions[GalaxyGen].xml
+++ b/Endless Space Competitive Mod/Quests/QuestDefinitions[GalaxyGen].xml
@@ -780,13 +780,49 @@
       <Var VarName="$Constellation_5PlanetSurplus2Boolean" StringValue="$(Constellation_5PlanetSurplus_Count) eq 2"/>
       <Var VarName="$Constellation_5PlanetBalancedBoolean" StringValue="$(Constellation_5PlanetDeficit_Count) eq 0"/>
 
+      <!-- ===== INLINED from variants C1S1v0-v3 so the work runs on Turn 1 in this quest (no deferred child-quest hop) ===== -->
+      <Var VarName="$SystemsToUpgrade">
+        <From Source="$TargetConstellation.$StarSystems">
+          <Where>
+              <PathPrerequisite Inverted="true" Flags="Prerequisite">ClassStarSystem, QuestNode</PathPrerequisite>
+              <PathPrerequisite Inverted="true" Flags="Prerequisite">ClassStarSystem,HomeSystem</PathPrerequisite>
+              <PathPrerequisite Inverted="true" Flags="Prerequisite">ClassStarSystem,ColonizedStarSystemStateOutpost</PathPrerequisite>
+              <InterpreterPrerequisite Flags="Prerequisite">Count(Context, @'ClassStarSystem/ClassPlanet') le 3</InterpreterPrerequisite>
+          </Where>
+          <OrderBy>
+              <SortSystemByDistance OriginVarName="$AcademySystem" SortBy="Nearest" MinimumDistance="1" MaximumDistance="9999" MinimumCandidateCount="2"/>
+          </OrderBy>
+        </From>
+      </Var>
+      <Var VarName="$SystemToUpgradeA"><Select Index="0"><From Source="$SystemsToUpgrade"/></Select></Var>
+      <Var VarName="$SystemToUpgradeB"><Select Index="1"><From Source="$SystemsToUpgrade"/></Select></Var>
+      <Var VarName="$SystemsToDowngrade">
+        <From Source="$TargetConstellation.$StarSystems">
+          <Where>
+              <PathPrerequisite Inverted="true" Flags="Prerequisite">ClassStarSystem, QuestNode</PathPrerequisite>
+              <PathPrerequisite Inverted="true" Flags="Prerequisite">ClassStarSystem,HomeSystem</PathPrerequisite>
+              <PathPrerequisite Inverted="true" Flags="Prerequisite">ClassStarSystem,ColonizedStarSystemStateOutpost</PathPrerequisite>
+              <InterpreterPrerequisite Flags="Prerequisite">Count(Context, @'ClassStarSystem/ClassPlanet') ge 5</InterpreterPrerequisite>
+          </Where>
+          <OrderBy>
+              <SortSystemByDistance OriginVarName="$AcademySystem" SortBy="Nearest" MinimumDistance="1" MaximumDistance="9999" MinimumCandidateCount="2"/>
+          </OrderBy>
+        </From>
+      </Var>
+      <Var VarName="$SystemToDowngradeA"><Select Index="0"><From Source="$SystemsToDowngrade"/></Select></Var>
+      <Var VarName="$SystemToDowngradeB"><Select Index="1"><From Source="$SystemsToDowngrade"/></Select></Var>
+      <Var VarName="$DefinitionName1" StringValue="Replacement5pNode3"/>
+      <Var VarName="$DefinitionName2" StringValue="Replacement5pNode4"/>
+      <Var VarName="$DefinitionName99" StringValue="Replacement4pNode3"/>
+      <Var VarName="$DefinitionName98" StringValue="Replacement4pNode4"/>
+
     </Vars>
     <!--============ PREREQUISITES ============-->
     <Prerequisites Target="$(Empires)" AnyTarget="true">
         <GameSettingPrerequisite>BalancedStarts,True</GameSettingPrerequisite>
     </Prerequisites>
     <!--============ STEPS ============-->
-    <Steps>   
+    <Steps>
         <Step Name="Step1">
             <ObjectiveSet>
               <Objective Name="Objective_Fake">
@@ -798,7 +834,10 @@
                         <Input_Expression VarName="$Constellation_5PlanetDeficitBoolean"/>
                       </Condition_CheckInterpreter>
                     </Decorator_HeroAssigned>
-                    <Action_ChooseOutcome Name="Outcome1"/>
+                    <Action_ApplyStarSystemDefinition>
+                      <Input_DefinitionName VarName="$DefinitionName1"/>
+                      <Input_StarSystemNode VarName="$SystemToUpgradeA"/>
+                    </Action_ApplyStarSystemDefinition>
                   </Sequence>
                   <Sequence>
                     <Decorator_HeroAssigned>
@@ -807,7 +846,10 @@
                         <Input_Expression VarName="$Constellation_5PlanetSurplusBoolean"/>
                       </Condition_CheckInterpreter>
                     </Decorator_HeroAssigned>
-                    <Action_ChooseOutcome Name="Outcome2"/>
+                    <Action_ApplyStarSystemDefinition>
+                      <Input_DefinitionName VarName="$DefinitionName99"/>
+                      <Input_StarSystemNode VarName="$SystemToDowngradeA"/>
+                    </Action_ApplyStarSystemDefinition>
                   </Sequence>
                   <Sequence>
                     <Decorator_HeroAssigned>
@@ -816,7 +858,14 @@
                         <Input_Expression VarName="$Constellation_5PlanetDeficit2Boolean"/>
                       </Condition_CheckInterpreter>
                     </Decorator_HeroAssigned>
-                    <Action_ChooseOutcome Name="Outcome3"/>
+                    <Action_ApplyStarSystemDefinition>
+                      <Input_DefinitionName VarName="$DefinitionName1"/>
+                      <Input_StarSystemNode VarName="$SystemToUpgradeA"/>
+                    </Action_ApplyStarSystemDefinition>
+                    <Action_ApplyStarSystemDefinition>
+                      <Input_DefinitionName VarName="$DefinitionName2"/>
+                      <Input_StarSystemNode VarName="$SystemToUpgradeB"/>
+                    </Action_ApplyStarSystemDefinition>
                   </Sequence>
                   <Sequence>
                     <Decorator_HeroAssigned>
@@ -825,7 +874,14 @@
                         <Input_Expression VarName="$Constellation_5PlanetSurplus2Boolean"/>
                       </Condition_CheckInterpreter>
                     </Decorator_HeroAssigned>
-                    <Action_ChooseOutcome Name="Outcome4"/>
+                    <Action_ApplyStarSystemDefinition>
+                      <Input_DefinitionName VarName="$DefinitionName99"/>
+                      <Input_StarSystemNode VarName="$SystemToDowngradeA"/>
+                    </Action_ApplyStarSystemDefinition>
+                    <Action_ApplyStarSystemDefinition>
+                      <Input_DefinitionName VarName="$DefinitionName98"/>
+                      <Input_StarSystemNode VarName="$SystemToDowngradeB"/>
+                    </Action_ApplyStarSystemDefinition>
                   </Sequence>
                   <Sequence>
                     <Decorator_HeroAssigned>
@@ -837,38 +893,6 @@
                     <Action_Fail/>
                   </Sequence>
                 </Parallel>
-                <Outcome Name="Outcome1">
-                  <Triggers Weight="1">
-                    <QuestTrigger>
-                      <Tags>GalaxyGenerationQuest_Planets-C1S1v0</Tags>
-                      <QuestContextSolo ParticipantsVarName="$ChosenEmpire"/>
-                    </QuestTrigger>
-                  </Triggers>
-                </Outcome>
-                <Outcome Name="Outcome2">
-                  <Triggers Weight="1">
-                    <QuestTrigger>
-                      <Tags>GalaxyGenerationQuest_Planets-C1S1v1</Tags>
-                      <QuestContextSolo ParticipantsVarName="$ChosenEmpire"/>
-                    </QuestTrigger>
-                  </Triggers>
-                </Outcome>
-                <Outcome Name="Outcome3">
-                  <Triggers Weight="1">
-                    <QuestTrigger>
-                      <Tags>GalaxyGenerationQuest_Planets-C1S1v2</Tags>
-                      <QuestContextSolo ParticipantsVarName="$ChosenEmpire"/>
-                    </QuestTrigger>
-                  </Triggers>
-                </Outcome>
-                <Outcome Name="Outcome4">
-                  <Triggers Weight="1">
-                    <QuestTrigger>
-                      <Tags>GalaxyGenerationQuest_Planets-C1S1v3</Tags>
-                      <QuestContextSolo ParticipantsVarName="$ChosenEmpire"/>
-                    </QuestTrigger>
-                  </Triggers>
-                </Outcome>
               </Objective>
             </ObjectiveSet>
         </Step>
@@ -1463,13 +1487,49 @@
     <Var VarName="$Constellation_5PlanetSurplus2Boolean" StringValue="$(Constellation_5PlanetSurplus_Count) eq 2"/>
     <Var VarName="$Constellation_5PlanetBalancedBoolean" StringValue="$(Constellation_5PlanetDeficit_Count) eq 0"/>
 
+    <!-- ===== INLINED from variants C2S1v0-v3 so the work runs on Turn 1 in this quest (no deferred child-quest hop) ===== -->
+    <Var VarName="$SystemsToUpgrade">
+      <From Source="$TargetConstellation.$StarSystems">
+        <Where>
+            <PathPrerequisite Inverted="true" Flags="Prerequisite">ClassStarSystem, QuestNode</PathPrerequisite>
+            <PathPrerequisite Inverted="true" Flags="Prerequisite">ClassStarSystem,HomeSystem</PathPrerequisite>
+            <PathPrerequisite Inverted="true" Flags="Prerequisite">ClassStarSystem,ColonizedStarSystemStateOutpost</PathPrerequisite>
+            <InterpreterPrerequisite Flags="Prerequisite">Count(Context, @'ClassStarSystem/ClassPlanet') le 3</InterpreterPrerequisite>
+        </Where>
+        <OrderBy>
+            <SortSystemByDistance OriginVarName="$AcademySystem" SortBy="Nearest" MinimumDistance="1" MaximumDistance="9999" MinimumCandidateCount="2"/>
+        </OrderBy>
+      </From>
+    </Var>
+    <Var VarName="$SystemToUpgradeA"><Select Index="0"><From Source="$SystemsToUpgrade"/></Select></Var>
+    <Var VarName="$SystemToUpgradeB"><Select Index="1"><From Source="$SystemsToUpgrade"/></Select></Var>
+    <Var VarName="$SystemsToDowngrade">
+      <From Source="$TargetConstellation.$StarSystems">
+        <Where>
+            <PathPrerequisite Inverted="true" Flags="Prerequisite">ClassStarSystem, QuestNode</PathPrerequisite>
+            <PathPrerequisite Inverted="true" Flags="Prerequisite">ClassStarSystem,HomeSystem</PathPrerequisite>
+            <PathPrerequisite Inverted="true" Flags="Prerequisite">ClassStarSystem,ColonizedStarSystemStateOutpost</PathPrerequisite>
+            <InterpreterPrerequisite Flags="Prerequisite">Count(Context, @'ClassStarSystem/ClassPlanet') ge 5</InterpreterPrerequisite>
+        </Where>
+        <OrderBy>
+            <SortSystemByDistance OriginVarName="$AcademySystem" SortBy="Nearest" MinimumDistance="1" MaximumDistance="9999" MinimumCandidateCount="2"/>
+        </OrderBy>
+      </From>
+    </Var>
+    <Var VarName="$SystemToDowngradeA"><Select Index="0"><From Source="$SystemsToDowngrade"/></Select></Var>
+    <Var VarName="$SystemToDowngradeB"><Select Index="1"><From Source="$SystemsToDowngrade"/></Select></Var>
+    <Var VarName="$DefinitionName1" StringValue="Replacement5pNode5"/>
+    <Var VarName="$DefinitionName2" StringValue="Replacement5pNode6"/>
+    <Var VarName="$DefinitionName99" StringValue="Replacement4pNode5"/>
+    <Var VarName="$DefinitionName98" StringValue="Replacement4pNode6"/>
+
   </Vars>
   <!--============ PREREQUISITES ============-->
   <Prerequisites Target="$(Empires)" AnyTarget="true">
       <GameSettingPrerequisite>BalancedStarts,True</GameSettingPrerequisite>
   </Prerequisites>
   <!--============ STEPS ============-->
-  <Steps>   
+  <Steps>
       <Step Name="Step1">
           <ObjectiveSet>
             <Objective Name="Objective_Fake">
@@ -1481,7 +1541,10 @@
                       <Input_Expression VarName="$Constellation_5PlanetDeficitBoolean"/>
                     </Condition_CheckInterpreter>
                   </Decorator_HeroAssigned>
-                  <Action_ChooseOutcome Name="Outcome1"/>
+                  <Action_ApplyStarSystemDefinition>
+                    <Input_DefinitionName VarName="$DefinitionName1"/>
+                    <Input_StarSystemNode VarName="$SystemToUpgradeA"/>
+                  </Action_ApplyStarSystemDefinition>
                 </Sequence>
                 <Sequence>
                   <Decorator_HeroAssigned>
@@ -1490,7 +1553,10 @@
                       <Input_Expression VarName="$Constellation_5PlanetSurplusBoolean"/>
                     </Condition_CheckInterpreter>
                   </Decorator_HeroAssigned>
-                  <Action_ChooseOutcome Name="Outcome2"/>
+                  <Action_ApplyStarSystemDefinition>
+                    <Input_DefinitionName VarName="$DefinitionName99"/>
+                    <Input_StarSystemNode VarName="$SystemToDowngradeA"/>
+                  </Action_ApplyStarSystemDefinition>
                 </Sequence>
                 <Sequence>
                   <Decorator_HeroAssigned>
@@ -1499,7 +1565,14 @@
                       <Input_Expression VarName="$Constellation_5PlanetDeficit2Boolean"/>
                     </Condition_CheckInterpreter>
                   </Decorator_HeroAssigned>
-                  <Action_ChooseOutcome Name="Outcome3"/>
+                  <Action_ApplyStarSystemDefinition>
+                    <Input_DefinitionName VarName="$DefinitionName1"/>
+                    <Input_StarSystemNode VarName="$SystemToUpgradeA"/>
+                  </Action_ApplyStarSystemDefinition>
+                  <Action_ApplyStarSystemDefinition>
+                    <Input_DefinitionName VarName="$DefinitionName2"/>
+                    <Input_StarSystemNode VarName="$SystemToUpgradeB"/>
+                  </Action_ApplyStarSystemDefinition>
                 </Sequence>
                 <Sequence>
                   <Decorator_HeroAssigned>
@@ -1508,7 +1581,14 @@
                       <Input_Expression VarName="$Constellation_5PlanetSurplus2Boolean"/>
                     </Condition_CheckInterpreter>
                   </Decorator_HeroAssigned>
-                  <Action_ChooseOutcome Name="Outcome4"/>
+                  <Action_ApplyStarSystemDefinition>
+                    <Input_DefinitionName VarName="$DefinitionName99"/>
+                    <Input_StarSystemNode VarName="$SystemToDowngradeA"/>
+                  </Action_ApplyStarSystemDefinition>
+                  <Action_ApplyStarSystemDefinition>
+                    <Input_DefinitionName VarName="$DefinitionName98"/>
+                    <Input_StarSystemNode VarName="$SystemToDowngradeB"/>
+                  </Action_ApplyStarSystemDefinition>
                 </Sequence>
                 <Sequence>
                   <Decorator_HeroAssigned>
@@ -1520,38 +1600,6 @@
                   <Action_Fail/>
                 </Sequence>
               </Parallel>
-              <Outcome Name="Outcome1">
-                <Triggers Weight="1">
-                  <QuestTrigger>
-                    <Tags>GalaxyGenerationQuest_Planets-C2S1v0</Tags>
-                    <QuestContextSolo ParticipantsVarName="$ChosenEmpire"/>
-                  </QuestTrigger>
-                </Triggers>
-              </Outcome>
-              <Outcome Name="Outcome2">
-                <Triggers Weight="1">
-                  <QuestTrigger>
-                    <Tags>GalaxyGenerationQuest_Planets-C2S1v1</Tags>
-                    <QuestContextSolo ParticipantsVarName="$ChosenEmpire"/>
-                  </QuestTrigger>
-                </Triggers>
-              </Outcome>
-              <Outcome Name="Outcome3">
-                <Triggers Weight="1">
-                  <QuestTrigger>
-                    <Tags>GalaxyGenerationQuest_Planets-C2S1v2</Tags>
-                    <QuestContextSolo ParticipantsVarName="$ChosenEmpire"/>
-                  </QuestTrigger>
-                </Triggers>
-              </Outcome>
-              <Outcome Name="Outcome4">
-                <Triggers Weight="1">
-                  <QuestTrigger>
-                    <Tags>GalaxyGenerationQuest_Planets-C2S1v3</Tags>
-                    <QuestContextSolo ParticipantsVarName="$ChosenEmpire"/>
-                  </QuestTrigger>
-                </Triggers>
-              </Outcome>
             </Objective>
           </ObjectiveSet>
       </Step>
@@ -2146,13 +2194,49 @@
     <Var VarName="$Constellation_5PlanetSurplus2Boolean" StringValue="$(Constellation_5PlanetSurplus_Count) eq 2"/>
     <Var VarName="$Constellation_5PlanetBalancedBoolean" StringValue="$(Constellation_5PlanetDeficit_Count) eq 0"/>
 
+    <!-- ===== INLINED from variants C3S1v0-v3 so the work runs on Turn 1 in this quest (no deferred child-quest hop) ===== -->
+    <Var VarName="$SystemsToUpgrade">
+      <From Source="$TargetConstellation.$StarSystems">
+        <Where>
+            <PathPrerequisite Inverted="true" Flags="Prerequisite">ClassStarSystem, QuestNode</PathPrerequisite>
+            <PathPrerequisite Inverted="true" Flags="Prerequisite">ClassStarSystem,HomeSystem</PathPrerequisite>
+            <PathPrerequisite Inverted="true" Flags="Prerequisite">ClassStarSystem,ColonizedStarSystemStateOutpost</PathPrerequisite>
+            <InterpreterPrerequisite Flags="Prerequisite">Count(Context, @'ClassStarSystem/ClassPlanet') le 3</InterpreterPrerequisite>
+        </Where>
+        <OrderBy>
+            <SortSystemByDistance OriginVarName="$AcademySystem" SortBy="Nearest" MinimumDistance="1" MaximumDistance="9999" MinimumCandidateCount="2"/>
+        </OrderBy>
+      </From>
+    </Var>
+    <Var VarName="$SystemToUpgradeA"><Select Index="0"><From Source="$SystemsToUpgrade"/></Select></Var>
+    <Var VarName="$SystemToUpgradeB"><Select Index="1"><From Source="$SystemsToUpgrade"/></Select></Var>
+    <Var VarName="$SystemsToDowngrade">
+      <From Source="$TargetConstellation.$StarSystems">
+        <Where>
+            <PathPrerequisite Inverted="true" Flags="Prerequisite">ClassStarSystem, QuestNode</PathPrerequisite>
+            <PathPrerequisite Inverted="true" Flags="Prerequisite">ClassStarSystem,HomeSystem</PathPrerequisite>
+            <PathPrerequisite Inverted="true" Flags="Prerequisite">ClassStarSystem,ColonizedStarSystemStateOutpost</PathPrerequisite>
+            <InterpreterPrerequisite Flags="Prerequisite">Count(Context, @'ClassStarSystem/ClassPlanet') ge 5</InterpreterPrerequisite>
+        </Where>
+        <OrderBy>
+            <SortSystemByDistance OriginVarName="$AcademySystem" SortBy="Nearest" MinimumDistance="1" MaximumDistance="9999" MinimumCandidateCount="2"/>
+        </OrderBy>
+      </From>
+    </Var>
+    <Var VarName="$SystemToDowngradeA"><Select Index="0"><From Source="$SystemsToDowngrade"/></Select></Var>
+    <Var VarName="$SystemToDowngradeB"><Select Index="1"><From Source="$SystemsToDowngrade"/></Select></Var>
+    <Var VarName="$DefinitionName1" StringValue="Replacement5pNode7"/>
+    <Var VarName="$DefinitionName2" StringValue="Replacement5pNode8"/>
+    <Var VarName="$DefinitionName99" StringValue="Replacement4pNode7"/>
+    <Var VarName="$DefinitionName98" StringValue="Replacement4pNode8"/>
+
   </Vars>
   <!--============ PREREQUISITES ============-->
   <Prerequisites Target="$(Empires)" AnyTarget="true">
       <GameSettingPrerequisite>BalancedStarts,True</GameSettingPrerequisite>
   </Prerequisites>
   <!--============ STEPS ============-->
-  <Steps>   
+  <Steps>
       <Step Name="Step1">
           <ObjectiveSet>
             <Objective Name="Objective_Fake">
@@ -2164,7 +2248,10 @@
                       <Input_Expression VarName="$Constellation_5PlanetDeficitBoolean"/>
                     </Condition_CheckInterpreter>
                   </Decorator_HeroAssigned>
-                  <Action_ChooseOutcome Name="Outcome1"/>
+                  <Action_ApplyStarSystemDefinition>
+                    <Input_DefinitionName VarName="$DefinitionName1"/>
+                    <Input_StarSystemNode VarName="$SystemToUpgradeA"/>
+                  </Action_ApplyStarSystemDefinition>
                 </Sequence>
                 <Sequence>
                   <Decorator_HeroAssigned>
@@ -2173,7 +2260,10 @@
                       <Input_Expression VarName="$Constellation_5PlanetSurplusBoolean"/>
                     </Condition_CheckInterpreter>
                   </Decorator_HeroAssigned>
-                  <Action_ChooseOutcome Name="Outcome2"/>
+                  <Action_ApplyStarSystemDefinition>
+                    <Input_DefinitionName VarName="$DefinitionName99"/>
+                    <Input_StarSystemNode VarName="$SystemToDowngradeA"/>
+                  </Action_ApplyStarSystemDefinition>
                 </Sequence>
                 <Sequence>
                   <Decorator_HeroAssigned>
@@ -2182,7 +2272,14 @@
                       <Input_Expression VarName="$Constellation_5PlanetDeficit2Boolean"/>
                     </Condition_CheckInterpreter>
                   </Decorator_HeroAssigned>
-                  <Action_ChooseOutcome Name="Outcome3"/>
+                  <Action_ApplyStarSystemDefinition>
+                    <Input_DefinitionName VarName="$DefinitionName1"/>
+                    <Input_StarSystemNode VarName="$SystemToUpgradeA"/>
+                  </Action_ApplyStarSystemDefinition>
+                  <Action_ApplyStarSystemDefinition>
+                    <Input_DefinitionName VarName="$DefinitionName2"/>
+                    <Input_StarSystemNode VarName="$SystemToUpgradeB"/>
+                  </Action_ApplyStarSystemDefinition>
                 </Sequence>
                 <Sequence>
                   <Decorator_HeroAssigned>
@@ -2191,7 +2288,14 @@
                       <Input_Expression VarName="$Constellation_5PlanetSurplus2Boolean"/>
                     </Condition_CheckInterpreter>
                   </Decorator_HeroAssigned>
-                  <Action_ChooseOutcome Name="Outcome4"/>
+                  <Action_ApplyStarSystemDefinition>
+                    <Input_DefinitionName VarName="$DefinitionName99"/>
+                    <Input_StarSystemNode VarName="$SystemToDowngradeA"/>
+                  </Action_ApplyStarSystemDefinition>
+                  <Action_ApplyStarSystemDefinition>
+                    <Input_DefinitionName VarName="$DefinitionName98"/>
+                    <Input_StarSystemNode VarName="$SystemToDowngradeB"/>
+                  </Action_ApplyStarSystemDefinition>
                 </Sequence>
                 <Sequence>
                   <Decorator_HeroAssigned>
@@ -2203,38 +2307,6 @@
                   <Action_Fail/>
                 </Sequence>
               </Parallel>
-              <Outcome Name="Outcome1">
-                <Triggers Weight="1">
-                  <QuestTrigger>
-                    <Tags>GalaxyGenerationQuest_Planets-C3S1v0</Tags>
-                    <QuestContextSolo ParticipantsVarName="$ChosenEmpire"/>
-                  </QuestTrigger>
-                </Triggers>
-              </Outcome>
-              <Outcome Name="Outcome2">
-                <Triggers Weight="1">
-                  <QuestTrigger>
-                    <Tags>GalaxyGenerationQuest_Planets-C3S1v1</Tags>
-                    <QuestContextSolo ParticipantsVarName="$ChosenEmpire"/>
-                  </QuestTrigger>
-                </Triggers>
-              </Outcome>
-              <Outcome Name="Outcome3">
-                <Triggers Weight="1">
-                  <QuestTrigger>
-                    <Tags>GalaxyGenerationQuest_Planets-C3S1v2</Tags>
-                    <QuestContextSolo ParticipantsVarName="$ChosenEmpire"/>
-                  </QuestTrigger>
-                </Triggers>
-              </Outcome>
-              <Outcome Name="Outcome4">
-                <Triggers Weight="1">
-                  <QuestTrigger>
-                    <Tags>GalaxyGenerationQuest_Planets-C3S1v3</Tags>
-                    <QuestContextSolo ParticipantsVarName="$ChosenEmpire"/>
-                  </QuestTrigger>
-                </Triggers>
-              </Outcome>
             </Objective>
           </ObjectiveSet>
       </Step>
@@ -2830,13 +2902,49 @@
     <Var VarName="$Constellation_5PlanetSurplus2Boolean" StringValue="$(Constellation_5PlanetSurplus_Count) eq 2"/>
     <Var VarName="$Constellation_5PlanetBalancedBoolean" StringValue="$(Constellation_5PlanetDeficit_Count) eq 0"/>
 
+    <!-- ===== INLINED from variants C4S1v0-v3 so the work runs on Turn 1 in this quest (no deferred child-quest hop) ===== -->
+    <Var VarName="$SystemsToUpgrade">
+      <From Source="$TargetConstellation.$StarSystems">
+        <Where>
+            <PathPrerequisite Inverted="true" Flags="Prerequisite">ClassStarSystem, QuestNode</PathPrerequisite>
+            <PathPrerequisite Inverted="true" Flags="Prerequisite">ClassStarSystem,HomeSystem</PathPrerequisite>
+            <PathPrerequisite Inverted="true" Flags="Prerequisite">ClassStarSystem,ColonizedStarSystemStateOutpost</PathPrerequisite>
+            <InterpreterPrerequisite Flags="Prerequisite">Count(Context, @'ClassStarSystem/ClassPlanet') le 3</InterpreterPrerequisite>
+        </Where>
+        <OrderBy>
+            <SortSystemByDistance OriginVarName="$AcademySystem" SortBy="Nearest" MinimumDistance="1" MaximumDistance="9999" MinimumCandidateCount="2"/>
+        </OrderBy>
+      </From>
+    </Var>
+    <Var VarName="$SystemToUpgradeA"><Select Index="0"><From Source="$SystemsToUpgrade"/></Select></Var>
+    <Var VarName="$SystemToUpgradeB"><Select Index="1"><From Source="$SystemsToUpgrade"/></Select></Var>
+    <Var VarName="$SystemsToDowngrade">
+      <From Source="$TargetConstellation.$StarSystems">
+        <Where>
+            <PathPrerequisite Inverted="true" Flags="Prerequisite">ClassStarSystem, QuestNode</PathPrerequisite>
+            <PathPrerequisite Inverted="true" Flags="Prerequisite">ClassStarSystem,HomeSystem</PathPrerequisite>
+            <PathPrerequisite Inverted="true" Flags="Prerequisite">ClassStarSystem,ColonizedStarSystemStateOutpost</PathPrerequisite>
+            <InterpreterPrerequisite Flags="Prerequisite">Count(Context, @'ClassStarSystem/ClassPlanet') ge 5</InterpreterPrerequisite>
+        </Where>
+        <OrderBy>
+            <SortSystemByDistance OriginVarName="$AcademySystem" SortBy="Nearest" MinimumDistance="1" MaximumDistance="9999" MinimumCandidateCount="2"/>
+        </OrderBy>
+      </From>
+    </Var>
+    <Var VarName="$SystemToDowngradeA"><Select Index="0"><From Source="$SystemsToDowngrade"/></Select></Var>
+    <Var VarName="$SystemToDowngradeB"><Select Index="1"><From Source="$SystemsToDowngrade"/></Select></Var>
+    <Var VarName="$DefinitionName1" StringValue="Replacement5pNode9"/>
+    <Var VarName="$DefinitionName2" StringValue="Replacement5pNode10"/>
+    <Var VarName="$DefinitionName99" StringValue="Replacement4pNode9"/>
+    <Var VarName="$DefinitionName98" StringValue="Replacement4pNode10"/>
+
   </Vars>
   <!--============ PREREQUISITES ============-->
   <Prerequisites Target="$(Empires)" AnyTarget="true">
       <GameSettingPrerequisite>BalancedStarts,True</GameSettingPrerequisite>
   </Prerequisites>
   <!--============ STEPS ============-->
-  <Steps>   
+  <Steps>
       <Step Name="Step1">
           <ObjectiveSet>
             <Objective Name="Objective_Fake">
@@ -2848,7 +2956,10 @@
                       <Input_Expression VarName="$Constellation_5PlanetDeficitBoolean"/>
                     </Condition_CheckInterpreter>
                   </Decorator_HeroAssigned>
-                  <Action_ChooseOutcome Name="Outcome1"/>
+                  <Action_ApplyStarSystemDefinition>
+                    <Input_DefinitionName VarName="$DefinitionName1"/>
+                    <Input_StarSystemNode VarName="$SystemToUpgradeA"/>
+                  </Action_ApplyStarSystemDefinition>
                 </Sequence>
                 <Sequence>
                   <Decorator_HeroAssigned>
@@ -2857,7 +2968,10 @@
                       <Input_Expression VarName="$Constellation_5PlanetSurplusBoolean"/>
                     </Condition_CheckInterpreter>
                   </Decorator_HeroAssigned>
-                  <Action_ChooseOutcome Name="Outcome2"/>
+                  <Action_ApplyStarSystemDefinition>
+                    <Input_DefinitionName VarName="$DefinitionName99"/>
+                    <Input_StarSystemNode VarName="$SystemToDowngradeA"/>
+                  </Action_ApplyStarSystemDefinition>
                 </Sequence>
                 <Sequence>
                   <Decorator_HeroAssigned>
@@ -2866,7 +2980,14 @@
                       <Input_Expression VarName="$Constellation_5PlanetDeficit2Boolean"/>
                     </Condition_CheckInterpreter>
                   </Decorator_HeroAssigned>
-                  <Action_ChooseOutcome Name="Outcome3"/>
+                  <Action_ApplyStarSystemDefinition>
+                    <Input_DefinitionName VarName="$DefinitionName1"/>
+                    <Input_StarSystemNode VarName="$SystemToUpgradeA"/>
+                  </Action_ApplyStarSystemDefinition>
+                  <Action_ApplyStarSystemDefinition>
+                    <Input_DefinitionName VarName="$DefinitionName2"/>
+                    <Input_StarSystemNode VarName="$SystemToUpgradeB"/>
+                  </Action_ApplyStarSystemDefinition>
                 </Sequence>
                 <Sequence>
                   <Decorator_HeroAssigned>
@@ -2875,7 +2996,14 @@
                       <Input_Expression VarName="$Constellation_5PlanetSurplus2Boolean"/>
                     </Condition_CheckInterpreter>
                   </Decorator_HeroAssigned>
-                  <Action_ChooseOutcome Name="Outcome4"/>
+                  <Action_ApplyStarSystemDefinition>
+                    <Input_DefinitionName VarName="$DefinitionName99"/>
+                    <Input_StarSystemNode VarName="$SystemToDowngradeA"/>
+                  </Action_ApplyStarSystemDefinition>
+                  <Action_ApplyStarSystemDefinition>
+                    <Input_DefinitionName VarName="$DefinitionName98"/>
+                    <Input_StarSystemNode VarName="$SystemToDowngradeB"/>
+                  </Action_ApplyStarSystemDefinition>
                 </Sequence>
                 <Sequence>
                   <Decorator_HeroAssigned>
@@ -2887,38 +3015,6 @@
                   <Action_Fail/>
                 </Sequence>
               </Parallel>
-              <Outcome Name="Outcome1">
-                <Triggers Weight="1">
-                  <QuestTrigger>
-                    <Tags>GalaxyGenerationQuest_Planets-C4S1v0</Tags>
-                    <QuestContextSolo ParticipantsVarName="$ChosenEmpire"/>
-                  </QuestTrigger>
-                </Triggers>
-              </Outcome>
-              <Outcome Name="Outcome2">
-                <Triggers Weight="1">
-                  <QuestTrigger>
-                    <Tags>GalaxyGenerationQuest_Planets-C4S1v1</Tags>
-                    <QuestContextSolo ParticipantsVarName="$ChosenEmpire"/>
-                  </QuestTrigger>
-                </Triggers>
-              </Outcome>
-              <Outcome Name="Outcome3">
-                <Triggers Weight="1">
-                  <QuestTrigger>
-                    <Tags>GalaxyGenerationQuest_Planets-C4S1v2</Tags>
-                    <QuestContextSolo ParticipantsVarName="$ChosenEmpire"/>
-                  </QuestTrigger>
-                </Triggers>
-              </Outcome>
-              <Outcome Name="Outcome4">
-                <Triggers Weight="1">
-                  <QuestTrigger>
-                    <Tags>GalaxyGenerationQuest_Planets-C4S1v3</Tags>
-                    <QuestContextSolo ParticipantsVarName="$ChosenEmpire"/>
-                  </QuestTrigger>
-                </Triggers>
-              </Outcome>
             </Objective>
           </ObjectiveSet>
       </Step>

--- a/Endless Space Competitive Mod/Quests/QuestDefinitions[GalaxyGen].xml
+++ b/Endless Space Competitive Mod/Quests/QuestDefinitions[GalaxyGen].xml
@@ -10,7 +10,7 @@
     -->
 
     <!-- ##### GALAXY GEN QUEST Constellation 0 Step 0: Determine position of Constellation 0 (Deficit, Surplus or Balance) #####-->
-    <QuestDefinition Name="GalaxyGenerationQuest_Planets-C0S0" Category="GalaxyGeneration" SubCategory="SystemNormalization" IsInstant="true" TriggeringProbability="1" CheckRandom="true" MinimumTurn="0">
+    <QuestDefinition Name="GalaxyGenerationQuest_Planets-C0S0" Category="GalaxyGeneration" SubCategory="SystemNormalization" IsInstant="true" TriggeringProbability="1" CheckRandom="false" MinimumTurn="0">
       <!--============ TAGS ============-->
       <Tags>Hidden, BeginTurn</Tags>
       <!--============ CONTEXT ============-->
@@ -51,7 +51,7 @@
           </Count>
         </Var>
         <InterpretedVar VarName="$Expected5pSystems">
-          <Expression>Floor(($(SystemCount)/$(ConstellationCount))/10)</Expression>
+          <Expression>Floor(($(SystemCount)/Max(1,$(ConstellationCount)))/10)</Expression>
         </InterpretedVar>
 
         <!-- Count the number of 5-planet systems in the constellation -->
@@ -187,7 +187,7 @@
   </QuestDefinition>
 
   <!-- ##### GALAXY GEN QUEST Constellation 0 Step 1 Version 0: Rectify Deficit #####-->
-  <QuestDefinition Name="GalaxyGenerationQuest_Planets-C0S1v0" Category="GalaxyGeneration" SubCategory="SystemNormalization" IsInstant="true" TriggeringProbability="1" CheckRandom="true" MinimumTurn="0">
+  <QuestDefinition Name="GalaxyGenerationQuest_Planets-C0S1v0" Category="GalaxyGeneration" SubCategory="SystemNormalization" IsInstant="true" TriggeringProbability="1" CheckRandom="false" MinimumTurn="0">
     <!--============ TAGS ============-->
     <Tags>Hidden, GalaxyGenerationQuest_Planets-C0S1v0</Tags>
     <!--============ CONTEXT ============-->
@@ -228,7 +228,7 @@
         </Count>
       </Var>
       <InterpretedVar VarName="$Expected5pSystems">
-        <Expression>Floor(($(SystemCount)/$(ConstellationCount))/10)</Expression>
+        <Expression>Floor(($(SystemCount)/Max(1,$(ConstellationCount)))/10)</Expression>
       </InterpretedVar>
 
       <!-- Count the number of 5-planet systems in the constellation -->
@@ -310,7 +310,7 @@
   </QuestDefinition>
 
   <!-- ##### GALAXY GEN QUEST Constellation 0 Step 1 Version 1: Rectify Surplus #####-->
-  <QuestDefinition Name="GalaxyGenerationQuest_Planets-C0S1v1" Category="GalaxyGeneration" SubCategory="SystemNormalization" IsInstant="true" TriggeringProbability="1" CheckRandom="true" MinimumTurn="0">
+  <QuestDefinition Name="GalaxyGenerationQuest_Planets-C0S1v1" Category="GalaxyGeneration" SubCategory="SystemNormalization" IsInstant="true" TriggeringProbability="1" CheckRandom="false" MinimumTurn="0">
     <!--============ TAGS ============-->
     <Tags>Hidden, GalaxyGenerationQuest_Planets-C0S1v1</Tags>
     <!--============ CONTEXT ============-->
@@ -351,7 +351,7 @@
         </Count>
       </Var>
       <InterpretedVar VarName="$Expected5pSystems">
-        <Expression>Floor(($(SystemCount)/$(ConstellationCount))/10)</Expression>
+        <Expression>Floor(($(SystemCount)/Max(1,$(ConstellationCount)))/10)</Expression>
       </InterpretedVar>
 
       <!-- Count the number of 5-planet systems in the constellation -->
@@ -433,7 +433,7 @@
   </QuestDefinition>
 
   <!-- ##### GALAXY GEN QUEST Constellation 0 Step 1 Version 2: Rectify Large Deficit #####-->
-  <QuestDefinition Name="GalaxyGenerationQuest_Planets-C0S1v2" Category="GalaxyGeneration" SubCategory="SystemNormalization" IsInstant="true" TriggeringProbability="1" CheckRandom="true" MinimumTurn="0">
+  <QuestDefinition Name="GalaxyGenerationQuest_Planets-C0S1v2" Category="GalaxyGeneration" SubCategory="SystemNormalization" IsInstant="true" TriggeringProbability="1" CheckRandom="false" MinimumTurn="0">
     <!--============ TAGS ============-->
     <Tags>Hidden, GalaxyGenerationQuest_Planets-C0S1v2</Tags>
     <!--============ CONTEXT ============-->
@@ -474,7 +474,7 @@
         </Count>
       </Var>
       <InterpretedVar VarName="$Expected5pSystems">
-        <Expression>Floor(($(SystemCount)/$(ConstellationCount))/10)</Expression>
+        <Expression>Floor(($(SystemCount)/Max(1,$(ConstellationCount)))/10)</Expression>
       </InterpretedVar>
 
       <!-- Count the number of 5-planet systems in the constellation -->
@@ -560,7 +560,7 @@
   </QuestDefinition>
 
   <!-- ##### GALAXY GEN QUEST Constellation 0 Step 1 Version 3: Rectify Large Surplus #####-->
-  <QuestDefinition Name="GalaxyGenerationQuest_Planets-C0S1v3" Category="GalaxyGeneration" SubCategory="SystemNormalization" IsInstant="true" TriggeringProbability="1" CheckRandom="true" MinimumTurn="0">
+  <QuestDefinition Name="GalaxyGenerationQuest_Planets-C0S1v3" Category="GalaxyGeneration" SubCategory="SystemNormalization" IsInstant="true" TriggeringProbability="1" CheckRandom="false" MinimumTurn="0">
     <!--============ TAGS ============-->
     <Tags>Hidden, GalaxyGenerationQuest_Planets-C0S1v3</Tags>
     <!--============ CONTEXT ============-->
@@ -601,7 +601,7 @@
         </Count>
       </Var>
       <InterpretedVar VarName="$Expected5pSystems">
-        <Expression>Floor(($(SystemCount)/$(ConstellationCount))/10)</Expression>
+        <Expression>Floor(($(SystemCount)/Max(1,$(ConstellationCount)))/10)</Expression>
       </InterpretedVar>
 
       <!-- Count the number of 5-planet systems in the constellation -->
@@ -687,7 +687,7 @@
   </QuestDefinition>
 
    <!-- ##### GALAXY GEN QUEST Constellation 1 Step 0: Determine position of Constellation 1 (Deficit, Surplus or Balance) #####-->
-   <QuestDefinition Name="GalaxyGenerationQuest_Planets-C1S0" Category="GalaxyGeneration" SubCategory="SystemNormalization" IsInstant="true" TriggeringProbability="1" CheckRandom="true" MinimumTurn="0">
+   <QuestDefinition Name="GalaxyGenerationQuest_Planets-C1S0" Category="GalaxyGeneration" SubCategory="SystemNormalization" IsInstant="true" TriggeringProbability="1" CheckRandom="false" MinimumTurn="0">
     <!--============ TAGS ============-->
     <Tags>Hidden, BeginTurn</Tags>
     <!--============ CONTEXT ============-->
@@ -728,7 +728,7 @@
         </Count>
       </Var>
       <InterpretedVar VarName="$Expected5pSystems">
-        <Expression>Floor(($(SystemCount)/$(ConstellationCount))/10)</Expression>
+        <Expression>Floor(($(SystemCount)/Max(1,$(ConstellationCount)))/10)</Expression>
       </InterpretedVar>
 
       <!-- Build the index of constellations -->
@@ -870,7 +870,7 @@
 
 
 <!-- ##### GALAXY GEN QUEST Constellation 1 Step 1 Version 0: Rectify Deficit #####-->
-<QuestDefinition Name="GalaxyGenerationQuest_Planets-C1S1v0" Category="GalaxyGeneration" SubCategory="SystemNormalization" IsInstant="true" TriggeringProbability="1" CheckRandom="true" MinimumTurn="0">
+<QuestDefinition Name="GalaxyGenerationQuest_Planets-C1S1v0" Category="GalaxyGeneration" SubCategory="SystemNormalization" IsInstant="true" TriggeringProbability="1" CheckRandom="false" MinimumTurn="0">
   <!--============ TAGS ============-->
   <Tags>Hidden, GalaxyGenerationQuest_Planets-C1S1v0</Tags>
   <!--============ CONTEXT ============-->
@@ -911,7 +911,7 @@
       </Count>
     </Var>
     <InterpretedVar VarName="$Expected5pSystems">
-      <Expression>Floor(($(SystemCount)/$(ConstellationCount))/10)</Expression>
+      <Expression>Floor(($(SystemCount)/Max(1,$(ConstellationCount)))/10)</Expression>
     </InterpretedVar>
 
     <!-- Build the index of constellations -->
@@ -998,7 +998,7 @@
 </QuestDefinition>
 
 <!-- ##### GALAXY GEN QUEST Constellation 1 Step 1 Version 1: Rectify Surplus #####-->
-<QuestDefinition Name="GalaxyGenerationQuest_Planets-C1S1v1" Category="GalaxyGeneration" SubCategory="SystemNormalization" IsInstant="true" TriggeringProbability="1" CheckRandom="true" MinimumTurn="0">
+<QuestDefinition Name="GalaxyGenerationQuest_Planets-C1S1v1" Category="GalaxyGeneration" SubCategory="SystemNormalization" IsInstant="true" TriggeringProbability="1" CheckRandom="false" MinimumTurn="0">
   <!--============ TAGS ============-->
   <Tags>Hidden, GalaxyGenerationQuest_Planets-C1S1v1</Tags>
   <!--============ CONTEXT ============-->
@@ -1039,7 +1039,7 @@
       </Count>
     </Var>
     <InterpretedVar VarName="$Expected5pSystems">
-      <Expression>Floor(($(SystemCount)/$(ConstellationCount))/10)</Expression>
+      <Expression>Floor(($(SystemCount)/Max(1,$(ConstellationCount)))/10)</Expression>
     </InterpretedVar>
 
     <!-- Build the index of constellations -->
@@ -1126,7 +1126,7 @@
 </QuestDefinition>
 
 <!-- ##### GALAXY GEN QUEST Constellation 1 Step 1 Version 2: Rectify Large Deficit #####-->
-<QuestDefinition Name="GalaxyGenerationQuest_Planets-C1S1v2" Category="GalaxyGeneration" SubCategory="SystemNormalization" IsInstant="true" TriggeringProbability="1" CheckRandom="true" MinimumTurn="0">
+<QuestDefinition Name="GalaxyGenerationQuest_Planets-C1S1v2" Category="GalaxyGeneration" SubCategory="SystemNormalization" IsInstant="true" TriggeringProbability="1" CheckRandom="false" MinimumTurn="0">
   <!--============ TAGS ============-->
   <Tags>Hidden, GalaxyGenerationQuest_Planets-C1S1v2</Tags>
   <!--============ CONTEXT ============-->
@@ -1167,7 +1167,7 @@
       </Count>
     </Var>
     <InterpretedVar VarName="$Expected5pSystems">
-      <Expression>Floor(($(SystemCount)/$(ConstellationCount))/10)</Expression>
+      <Expression>Floor(($(SystemCount)/Max(1,$(ConstellationCount)))/10)</Expression>
     </InterpretedVar>
 
     <!-- Build the index of constellations -->
@@ -1258,7 +1258,7 @@
 </QuestDefinition>
 
 <!-- ##### GALAXY GEN QUEST Constellation 1 Step 1 Version 3: Rectify Large Surplus #####-->
-<QuestDefinition Name="GalaxyGenerationQuest_Planets-C1S1v3" Category="GalaxyGeneration" SubCategory="SystemNormalization" IsInstant="true" TriggeringProbability="1" CheckRandom="true" MinimumTurn="0">
+<QuestDefinition Name="GalaxyGenerationQuest_Planets-C1S1v3" Category="GalaxyGeneration" SubCategory="SystemNormalization" IsInstant="true" TriggeringProbability="1" CheckRandom="false" MinimumTurn="0">
   <!--============ TAGS ============-->
   <Tags>Hidden, GalaxyGenerationQuest_Planets-C1S1v3</Tags>
   <!--============ CONTEXT ============-->
@@ -1299,7 +1299,7 @@
       </Count>
     </Var>
     <InterpretedVar VarName="$Expected5pSystems">
-      <Expression>Floor(($(SystemCount)/$(ConstellationCount))/10)</Expression>
+      <Expression>Floor(($(SystemCount)/Max(1,$(ConstellationCount)))/10)</Expression>
     </InterpretedVar>
 
     <!-- Build the index of constellations -->
@@ -1390,7 +1390,7 @@
 </QuestDefinition>
 
 <!-- ##### GALAXY GEN QUEST Constellation 1 Step 0: Determine position of Constellation 1 (Deficit, Surplus or Balance) #####-->
-<QuestDefinition Name="GalaxyGenerationQuest_Planets-C2S0" Category="GalaxyGeneration" SubCategory="SystemNormalization" IsInstant="true" TriggeringProbability="1" CheckRandom="true" MinimumTurn="0">
+<QuestDefinition Name="GalaxyGenerationQuest_Planets-C2S0" Category="GalaxyGeneration" SubCategory="SystemNormalization" IsInstant="true" TriggeringProbability="1" CheckRandom="false" MinimumTurn="0">
   <!--============ TAGS ============-->
   <Tags>Hidden, BeginTurn</Tags>
   <!--============ CONTEXT ============-->
@@ -1431,7 +1431,7 @@
       </Count>
     </Var>
     <InterpretedVar VarName="$Expected5pSystems">
-      <Expression>Floor(($(SystemCount)/$(ConstellationCount))/10)</Expression>
+      <Expression>Floor(($(SystemCount)/Max(1,$(ConstellationCount)))/10)</Expression>
     </InterpretedVar>
 
     <!-- Build the index of constellations -->
@@ -1573,7 +1573,7 @@
 
 
 <!-- ##### GALAXY GEN QUEST Constellation 2 Step 1 Version 0: Rectify Deficit #####-->
-<QuestDefinition Name="GalaxyGenerationQuest_Planets-C2S1v0" Category="GalaxyGeneration" SubCategory="SystemNormalization" IsInstant="true" TriggeringProbability="1" CheckRandom="true" MinimumTurn="0">
+<QuestDefinition Name="GalaxyGenerationQuest_Planets-C2S1v0" Category="GalaxyGeneration" SubCategory="SystemNormalization" IsInstant="true" TriggeringProbability="1" CheckRandom="false" MinimumTurn="0">
   <!--============ TAGS ============-->
   <Tags>Hidden, GalaxyGenerationQuest_Planets-C2S1v0</Tags>
   <!--============ CONTEXT ============-->
@@ -1614,7 +1614,7 @@
       </Count>
     </Var>
     <InterpretedVar VarName="$Expected5pSystems">
-      <Expression>Floor(($(SystemCount)/$(ConstellationCount))/10)</Expression>
+      <Expression>Floor(($(SystemCount)/Max(1,$(ConstellationCount)))/10)</Expression>
     </InterpretedVar>
 
     <!-- Build the index of constellations -->
@@ -1701,7 +1701,7 @@
 </QuestDefinition>
 
 <!-- ##### GALAXY GEN QUEST Constellation 1 Step 1 Version 1: Rectify Surplus #####-->
-<QuestDefinition Name="GalaxyGenerationQuest_Planets-C2S1v1" Category="GalaxyGeneration" SubCategory="SystemNormalization" IsInstant="true" TriggeringProbability="1" CheckRandom="true" MinimumTurn="0">
+<QuestDefinition Name="GalaxyGenerationQuest_Planets-C2S1v1" Category="GalaxyGeneration" SubCategory="SystemNormalization" IsInstant="true" TriggeringProbability="1" CheckRandom="false" MinimumTurn="0">
   <!--============ TAGS ============-->
   <Tags>Hidden, GalaxyGenerationQuest_Planets-C2S1v1</Tags>
   <!--============ CONTEXT ============-->
@@ -1742,7 +1742,7 @@
       </Count>
     </Var>
     <InterpretedVar VarName="$Expected5pSystems">
-      <Expression>Floor(($(SystemCount)/$(ConstellationCount))/10)</Expression>
+      <Expression>Floor(($(SystemCount)/Max(1,$(ConstellationCount)))/10)</Expression>
     </InterpretedVar>
 
     <!-- Build the index of constellations -->
@@ -1829,7 +1829,7 @@
 </QuestDefinition>
 
 <!-- ##### GALAXY GEN QUEST Constellation 1 Step 1 Version 2: Rectify Large Deficit #####-->
-<QuestDefinition Name="GalaxyGenerationQuest_Planets-C2S1v2" Category="GalaxyGeneration" SubCategory="SystemNormalization" IsInstant="true" TriggeringProbability="1" CheckRandom="true" MinimumTurn="0">
+<QuestDefinition Name="GalaxyGenerationQuest_Planets-C2S1v2" Category="GalaxyGeneration" SubCategory="SystemNormalization" IsInstant="true" TriggeringProbability="1" CheckRandom="false" MinimumTurn="0">
   <!--============ TAGS ============-->
   <Tags>Hidden, GalaxyGenerationQuest_Planets-C2S1v2</Tags>
   <!--============ CONTEXT ============-->
@@ -1870,7 +1870,7 @@
       </Count>
     </Var>
     <InterpretedVar VarName="$Expected5pSystems">
-      <Expression>Floor(($(SystemCount)/$(ConstellationCount))/10)</Expression>
+      <Expression>Floor(($(SystemCount)/Max(1,$(ConstellationCount)))/10)</Expression>
     </InterpretedVar>
 
     <!-- Build the index of constellations -->
@@ -1961,7 +1961,7 @@
 </QuestDefinition>
 
 <!-- ##### GALAXY GEN QUEST Constellation 1 Step 1 Version 3: Rectify Large Surplus #####-->
-<QuestDefinition Name="GalaxyGenerationQuest_Planets-C2S1v3" Category="GalaxyGeneration" SubCategory="SystemNormalization" IsInstant="true" TriggeringProbability="1" CheckRandom="true" MinimumTurn="0">
+<QuestDefinition Name="GalaxyGenerationQuest_Planets-C2S1v3" Category="GalaxyGeneration" SubCategory="SystemNormalization" IsInstant="true" TriggeringProbability="1" CheckRandom="false" MinimumTurn="0">
   <!--============ TAGS ============-->
   <Tags>Hidden, GalaxyGenerationQuest_Planets-C2S1v3</Tags>
   <!--============ CONTEXT ============-->
@@ -2002,7 +2002,7 @@
       </Count>
     </Var>
     <InterpretedVar VarName="$Expected5pSystems">
-      <Expression>Floor(($(SystemCount)/$(ConstellationCount))/10)</Expression>
+      <Expression>Floor(($(SystemCount)/Max(1,$(ConstellationCount)))/10)</Expression>
     </InterpretedVar>
 
     <!-- Build the index of constellations -->
@@ -2093,7 +2093,7 @@
 </QuestDefinition>
 
 <!-- ##### GALAXY GEN QUEST Constellation 1 Step 0: Determine position of Constellation 1 (Deficit, Surplus or Balance) #####-->
-<QuestDefinition Name="GalaxyGenerationQuest_Planets-C3S0" Category="GalaxyGeneration" SubCategory="SystemNormalization" IsInstant="true" TriggeringProbability="1" CheckRandom="true" MinimumTurn="0">
+<QuestDefinition Name="GalaxyGenerationQuest_Planets-C3S0" Category="GalaxyGeneration" SubCategory="SystemNormalization" IsInstant="true" TriggeringProbability="1" CheckRandom="false" MinimumTurn="0">
   <!--============ TAGS ============-->
   <Tags>Hidden, BeginTurn</Tags>
   <!--============ CONTEXT ============-->
@@ -2134,7 +2134,7 @@
       </Count>
     </Var>
     <InterpretedVar VarName="$Expected5pSystems">
-      <Expression>Floor(($(SystemCount)/$(ConstellationCount))/10)</Expression>
+      <Expression>Floor(($(SystemCount)/Max(1,$(ConstellationCount)))/10)</Expression>
     </InterpretedVar>
 
     <!-- Build the index of constellations -->
@@ -2277,7 +2277,7 @@
 
 
 <!-- ##### GALAXY GEN QUEST Constellation 1 Step 1 Version 0: Rectify Deficit #####-->
-<QuestDefinition Name="GalaxyGenerationQuest_Planets-C3S1v0" Category="GalaxyGeneration" SubCategory="SystemNormalization" IsInstant="true" TriggeringProbability="1" CheckRandom="true" MinimumTurn="0">
+<QuestDefinition Name="GalaxyGenerationQuest_Planets-C3S1v0" Category="GalaxyGeneration" SubCategory="SystemNormalization" IsInstant="true" TriggeringProbability="1" CheckRandom="false" MinimumTurn="0">
   <!--============ TAGS ============-->
   <Tags>Hidden, GalaxyGenerationQuest_Planets-C3S1v0</Tags>
   <!--============ CONTEXT ============-->
@@ -2318,7 +2318,7 @@
       </Count>
     </Var>
     <InterpretedVar VarName="$Expected5pSystems">
-      <Expression>Floor(($(SystemCount)/$(ConstellationCount))/10)</Expression>
+      <Expression>Floor(($(SystemCount)/Max(1,$(ConstellationCount)))/10)</Expression>
     </InterpretedVar>
 
     <!-- Build the index of constellations -->
@@ -2405,7 +2405,7 @@
 </QuestDefinition>
 
 <!-- ##### GALAXY GEN QUEST Constellation 1 Step 1 Version 1: Rectify Surplus #####-->
-<QuestDefinition Name="GalaxyGenerationQuest_Planets-C3S1v1" Category="GalaxyGeneration" SubCategory="SystemNormalization" IsInstant="true" TriggeringProbability="1" CheckRandom="true" MinimumTurn="0">
+<QuestDefinition Name="GalaxyGenerationQuest_Planets-C3S1v1" Category="GalaxyGeneration" SubCategory="SystemNormalization" IsInstant="true" TriggeringProbability="1" CheckRandom="false" MinimumTurn="0">
   <!--============ TAGS ============-->
   <Tags>Hidden, GalaxyGenerationQuest_Planets-C3S1v1</Tags>
   <!--============ CONTEXT ============-->
@@ -2446,7 +2446,7 @@
       </Count>
     </Var>
     <InterpretedVar VarName="$Expected5pSystems">
-      <Expression>Floor(($(SystemCount)/$(ConstellationCount))/10)</Expression>
+      <Expression>Floor(($(SystemCount)/Max(1,$(ConstellationCount)))/10)</Expression>
     </InterpretedVar>
 
     <!-- Build the index of constellations -->
@@ -2533,7 +2533,7 @@
 </QuestDefinition>
 
 <!-- ##### GALAXY GEN QUEST Constellation 1 Step 1 Version 2: Rectify Large Deficit #####-->
-<QuestDefinition Name="GalaxyGenerationQuest_Planets-C3S1v2" Category="GalaxyGeneration" SubCategory="SystemNormalization" IsInstant="true" TriggeringProbability="1" CheckRandom="true" MinimumTurn="0">
+<QuestDefinition Name="GalaxyGenerationQuest_Planets-C3S1v2" Category="GalaxyGeneration" SubCategory="SystemNormalization" IsInstant="true" TriggeringProbability="1" CheckRandom="false" MinimumTurn="0">
   <!--============ TAGS ============-->
   <Tags>Hidden, GalaxyGenerationQuest_Planets-C3S1v2</Tags>
   <!--============ CONTEXT ============-->
@@ -2574,7 +2574,7 @@
       </Count>
     </Var>
     <InterpretedVar VarName="$Expected5pSystems">
-      <Expression>Floor(($(SystemCount)/$(ConstellationCount))/10)</Expression>
+      <Expression>Floor(($(SystemCount)/Max(1,$(ConstellationCount)))/10)</Expression>
     </InterpretedVar>
 
     <!-- Build the index of constellations -->
@@ -2665,7 +2665,7 @@
 </QuestDefinition>
 
 <!-- ##### GALAXY GEN QUEST Constellation 1 Step 1 Version 3: Rectify Large Surplus #####-->
-<QuestDefinition Name="GalaxyGenerationQuest_Planets-C3S1v3" Category="GalaxyGeneration" SubCategory="SystemNormalization" IsInstant="true" TriggeringProbability="1" CheckRandom="true" MinimumTurn="0">
+<QuestDefinition Name="GalaxyGenerationQuest_Planets-C3S1v3" Category="GalaxyGeneration" SubCategory="SystemNormalization" IsInstant="true" TriggeringProbability="1" CheckRandom="false" MinimumTurn="0">
   <!--============ TAGS ============-->
   <Tags>Hidden, GalaxyGenerationQuest_Planets-C3S1v3</Tags>
   <!--============ CONTEXT ============-->
@@ -2706,7 +2706,7 @@
       </Count>
     </Var>
     <InterpretedVar VarName="$Expected5pSystems">
-      <Expression>Floor(($(SystemCount)/$(ConstellationCount))/10)</Expression>
+      <Expression>Floor(($(SystemCount)/Max(1,$(ConstellationCount)))/10)</Expression>
     </InterpretedVar>
 
     <!-- Build the index of constellations -->
@@ -2797,7 +2797,7 @@
 </QuestDefinition>
 
 <!-- ##### GALAXY GEN QUEST Constellation 1 Step 0: Determine position of Constellation 1 (Deficit, Surplus or Balance) #####-->
-<QuestDefinition Name="GalaxyGenerationQuest_Planets-C4S0" Category="GalaxyGeneration" SubCategory="SystemNormalization" IsInstant="true" TriggeringProbability="1" CheckRandom="true" MinimumTurn="0">
+<QuestDefinition Name="GalaxyGenerationQuest_Planets-C4S0" Category="GalaxyGeneration" SubCategory="SystemNormalization" IsInstant="true" TriggeringProbability="1" CheckRandom="false" MinimumTurn="0">
   <!--============ TAGS ============-->
   <Tags>Hidden, BeginTurn</Tags>
   <!--============ CONTEXT ============-->
@@ -2838,7 +2838,7 @@
       </Count>
     </Var>
     <InterpretedVar VarName="$Expected5pSystems">
-      <Expression>Floor(($(SystemCount)/$(ConstellationCount))/10)</Expression>
+      <Expression>Floor(($(SystemCount)/Max(1,$(ConstellationCount)))/10)</Expression>
     </InterpretedVar>
 
     <!-- Build the index of constellations -->
@@ -2980,7 +2980,7 @@
 
 
 <!-- ##### GALAXY GEN QUEST Constellation 1 Step 1 Version 0: Rectify Deficit #####-->
-<QuestDefinition Name="GalaxyGenerationQuest_Planets-C4S1v0" Category="GalaxyGeneration" SubCategory="SystemNormalization" IsInstant="true" TriggeringProbability="1" CheckRandom="true" MinimumTurn="0">
+<QuestDefinition Name="GalaxyGenerationQuest_Planets-C4S1v0" Category="GalaxyGeneration" SubCategory="SystemNormalization" IsInstant="true" TriggeringProbability="1" CheckRandom="false" MinimumTurn="0">
   <!--============ TAGS ============-->
   <Tags>Hidden, GalaxyGenerationQuest_Planets-C4S1v0</Tags>
   <!--============ CONTEXT ============-->
@@ -3021,7 +3021,7 @@
       </Count>
     </Var>
     <InterpretedVar VarName="$Expected5pSystems">
-      <Expression>Floor(($(SystemCount)/$(ConstellationCount))/10)</Expression>
+      <Expression>Floor(($(SystemCount)/Max(1,$(ConstellationCount)))/10)</Expression>
     </InterpretedVar>
 
     <!-- Build the index of constellations -->
@@ -3108,7 +3108,7 @@
 </QuestDefinition>
 
 <!-- ##### GALAXY GEN QUEST Constellation 1 Step 1 Version 1: Rectify Surplus #####-->
-<QuestDefinition Name="GalaxyGenerationQuest_Planets-C4S1v1" Category="GalaxyGeneration" SubCategory="SystemNormalization" IsInstant="true" TriggeringProbability="1" CheckRandom="true" MinimumTurn="0">
+<QuestDefinition Name="GalaxyGenerationQuest_Planets-C4S1v1" Category="GalaxyGeneration" SubCategory="SystemNormalization" IsInstant="true" TriggeringProbability="1" CheckRandom="false" MinimumTurn="0">
   <!--============ TAGS ============-->
   <Tags>Hidden, GalaxyGenerationQuest_Planets-C4S1v1</Tags>
   <!--============ CONTEXT ============-->
@@ -3149,7 +3149,7 @@
       </Count>
     </Var>
     <InterpretedVar VarName="$Expected5pSystems">
-      <Expression>Floor(($(SystemCount)/$(ConstellationCount))/10)</Expression>
+      <Expression>Floor(($(SystemCount)/Max(1,$(ConstellationCount)))/10)</Expression>
     </InterpretedVar>
 
     <!-- Build the index of constellations -->
@@ -3236,7 +3236,7 @@
 </QuestDefinition>
 
 <!-- ##### GALAXY GEN QUEST Constellation 1 Step 1 Version 2: Rectify Large Deficit #####-->
-<QuestDefinition Name="GalaxyGenerationQuest_Planets-C4S1v2" Category="GalaxyGeneration" SubCategory="SystemNormalization" IsInstant="true" TriggeringProbability="1" CheckRandom="true" MinimumTurn="0">
+<QuestDefinition Name="GalaxyGenerationQuest_Planets-C4S1v2" Category="GalaxyGeneration" SubCategory="SystemNormalization" IsInstant="true" TriggeringProbability="1" CheckRandom="false" MinimumTurn="0">
   <!--============ TAGS ============-->
   <Tags>Hidden, GalaxyGenerationQuest_Planets-C4S1v2</Tags>
   <!--============ CONTEXT ============-->
@@ -3277,7 +3277,7 @@
       </Count>
     </Var>
     <InterpretedVar VarName="$Expected5pSystems">
-      <Expression>Floor(($(SystemCount)/$(ConstellationCount))/10)</Expression>
+      <Expression>Floor(($(SystemCount)/Max(1,$(ConstellationCount)))/10)</Expression>
     </InterpretedVar>
 
     <!-- Build the index of constellations -->
@@ -3368,7 +3368,7 @@
 </QuestDefinition>
 
 <!-- ##### GALAXY GEN QUEST Constellation 1 Step 1 Version 3: Rectify Large Surplus #####-->
-<QuestDefinition Name="GalaxyGenerationQuest_Planets-C4S1v3" Category="GalaxyGeneration" SubCategory="SystemNormalization" IsInstant="true" TriggeringProbability="1" CheckRandom="true" MinimumTurn="0">
+<QuestDefinition Name="GalaxyGenerationQuest_Planets-C4S1v3" Category="GalaxyGeneration" SubCategory="SystemNormalization" IsInstant="true" TriggeringProbability="1" CheckRandom="false" MinimumTurn="0">
   <!--============ TAGS ============-->
   <Tags>Hidden, GalaxyGenerationQuest_Planets-C4S1v3</Tags>
   <!--============ CONTEXT ============-->
@@ -3409,7 +3409,7 @@
       </Count>
     </Var>
     <InterpretedVar VarName="$Expected5pSystems">
-      <Expression>Floor(($(SystemCount)/$(ConstellationCount))/10)</Expression>
+      <Expression>Floor(($(SystemCount)/Max(1,$(ConstellationCount)))/10)</Expression>
     </InterpretedVar>
 
     <!-- Build the index of constellations -->

--- a/Endless Space Competitive Mod/Quests/QuestDefinitions[GalaxyGen].xml
+++ b/Endless Space Competitive Mod/Quests/QuestDefinitions[GalaxyGen].xml
@@ -79,45 +79,6 @@
         <Var VarName="$Constellation_5PlanetSurplus2Boolean" StringValue="$(Constellation_5PlanetSurplus_Count) eq 2"/>
         <Var VarName="$Constellation_5PlanetBalancedBoolean" StringValue="$(Constellation_5PlanetDeficit_Count) eq 0"/>
 
-        <!-- ===== INLINED from variants C0S1v0-v3 so the work runs on Turn 1 in this quest (no deferred child-quest hop) ===== -->
-        <!-- Inferior systems to upgrade (deficit cases) -->
-        <Var VarName="$SystemsToUpgrade">
-          <From Source="$Constellation0.$StarSystems">
-            <Where>
-                <PathPrerequisite Inverted="true" Flags="Prerequisite">ClassStarSystem, QuestNode</PathPrerequisite>
-                <PathPrerequisite Inverted="true" Flags="Prerequisite">ClassStarSystem,HomeSystem</PathPrerequisite>
-                <PathPrerequisite Inverted="true" Flags="Prerequisite">ClassStarSystem,ColonizedStarSystemStateOutpost</PathPrerequisite>
-                <InterpreterPrerequisite Flags="Prerequisite">Count(Context, @'ClassStarSystem/ClassPlanet') le 3</InterpreterPrerequisite>
-            </Where>
-            <OrderBy>
-                <SortSystemByDistance OriginVarName="$AcademySystem" SortBy="Nearest" MinimumDistance="1" MaximumDistance="9999" MinimumCandidateCount="2"/>
-            </OrderBy>
-          </From>
-        </Var>
-        <Var VarName="$SystemToUpgradeA"><Select Index="0"><From Source="$SystemsToUpgrade"/></Select></Var>
-        <Var VarName="$SystemToUpgradeB"><Select Index="1"><From Source="$SystemsToUpgrade"/></Select></Var>
-        <!-- Superior systems to downgrade (surplus cases) -->
-        <Var VarName="$SystemsToDowngrade">
-          <From Source="$Constellation0.$StarSystems">
-            <Where>
-                <PathPrerequisite Inverted="true" Flags="Prerequisite">ClassStarSystem, QuestNode</PathPrerequisite>
-                <PathPrerequisite Inverted="true" Flags="Prerequisite">ClassStarSystem,HomeSystem</PathPrerequisite>
-                <PathPrerequisite Inverted="true" Flags="Prerequisite">ClassStarSystem,ColonizedStarSystemStateOutpost</PathPrerequisite>
-                <InterpreterPrerequisite Flags="Prerequisite">Count(Context, @'ClassStarSystem/ClassPlanet') ge 5</InterpreterPrerequisite>
-            </Where>
-            <OrderBy>
-                <SortSystemByDistance OriginVarName="$AcademySystem" SortBy="Nearest" MinimumDistance="1" MaximumDistance="9999" MinimumCandidateCount="2"/>
-            </OrderBy>
-          </From>
-        </Var>
-        <Var VarName="$SystemToDowngradeA"><Select Index="0"><From Source="$SystemsToDowngrade"/></Select></Var>
-        <Var VarName="$SystemToDowngradeB"><Select Index="1"><From Source="$SystemsToDowngrade"/></Select></Var>
-        <!-- Replacement node definitions -->
-        <Var VarName="$DefinitionName1" StringValue="Replacement5pNode1"/>
-        <Var VarName="$DefinitionName2" StringValue="Replacement5pNode2"/>
-        <Var VarName="$DefinitionName99" StringValue="Replacement4pNode1"/>
-        <Var VarName="$DefinitionName98" StringValue="Replacement4pNode2"/>
-
       </Vars>
       <!--============ PREREQUISITES ============-->
       <Prerequisites Target="$(Empires)" AnyTarget="true">
@@ -136,7 +97,7 @@
                           <Input_Expression VarName="$Constellation_5PlanetBalancedBoolean"/>
                         </Condition_CheckInterpreter>
                       </Decorator_HeroAssigned>
-                      <Action_ChooseOutcome Name="DoResource"/>
+                      <Action_ChooseOutcome Name="Outcome0"/>
                     </Sequence>
                     <Sequence>
                       <Decorator_HeroAssigned>
@@ -145,11 +106,7 @@
                           <Input_Expression VarName="$Constellation_5PlanetDeficitBoolean"/>
                         </Condition_CheckInterpreter>
                       </Decorator_HeroAssigned>
-                      <Action_ApplyStarSystemDefinition>
-                        <Input_DefinitionName VarName="$DefinitionName1"/>
-                        <Input_StarSystemNode VarName="$SystemToUpgradeA"/>
-                      </Action_ApplyStarSystemDefinition>
-                      <Action_ChooseOutcome Name="DoResource"/>
+                      <Action_ChooseOutcome Name="Outcome1"/>
                     </Sequence>
                     <Sequence>
                       <Decorator_HeroAssigned>
@@ -158,11 +115,7 @@
                           <Input_Expression VarName="$Constellation_5PlanetSurplusBoolean"/>
                         </Condition_CheckInterpreter>
                       </Decorator_HeroAssigned>
-                      <Action_ApplyStarSystemDefinition>
-                        <Input_DefinitionName VarName="$DefinitionName99"/>
-                        <Input_StarSystemNode VarName="$SystemToDowngradeA"/>
-                      </Action_ApplyStarSystemDefinition>
-                      <Action_ChooseOutcome Name="DoResource"/>
+                      <Action_ChooseOutcome Name="Outcome2"/>
                     </Sequence>
                     <Sequence>
                       <Decorator_HeroAssigned>
@@ -171,15 +124,7 @@
                           <Input_Expression VarName="$Constellation_5PlanetDeficit2Boolean"/>
                         </Condition_CheckInterpreter>
                       </Decorator_HeroAssigned>
-                      <Action_ApplyStarSystemDefinition>
-                        <Input_DefinitionName VarName="$DefinitionName1"/>
-                        <Input_StarSystemNode VarName="$SystemToUpgradeA"/>
-                      </Action_ApplyStarSystemDefinition>
-                      <Action_ApplyStarSystemDefinition>
-                        <Input_DefinitionName VarName="$DefinitionName2"/>
-                        <Input_StarSystemNode VarName="$SystemToUpgradeB"/>
-                      </Action_ApplyStarSystemDefinition>
-                      <Action_ChooseOutcome Name="DoResource"/>
+                      <Action_ChooseOutcome Name="Outcome3"/>
                     </Sequence>
                     <Sequence>
                       <Decorator_HeroAssigned>
@@ -188,21 +133,45 @@
                           <Input_Expression VarName="$Constellation_5PlanetSurplus2Boolean"/>
                         </Condition_CheckInterpreter>
                       </Decorator_HeroAssigned>
-                      <Action_ApplyStarSystemDefinition>
-                        <Input_DefinitionName VarName="$DefinitionName99"/>
-                        <Input_StarSystemNode VarName="$SystemToDowngradeA"/>
-                      </Action_ApplyStarSystemDefinition>
-                      <Action_ApplyStarSystemDefinition>
-                        <Input_DefinitionName VarName="$DefinitionName98"/>
-                        <Input_StarSystemNode VarName="$SystemToDowngradeB"/>
-                      </Action_ApplyStarSystemDefinition>
-                      <Action_ChooseOutcome Name="DoResource"/>
+                      <Action_ChooseOutcome Name="Outcome4"/>
                     </Sequence>
                   </Parallel>
-                  <Outcome Name="DoResource">
+                  <Outcome Name="Outcome0">
                     <Triggers Weight="1">
                       <QuestTrigger>
                         <Tags>StrategicResourceGenerationQuest</Tags>
+                        <QuestContextSolo ParticipantsVarName="$ChosenEmpire"/>
+                      </QuestTrigger>
+                    </Triggers>
+                  </Outcome>
+                  <Outcome Name="Outcome1">
+                    <Triggers Weight="1">
+                      <QuestTrigger>
+                        <Tags>GalaxyGenerationQuest_Planets-C0S1v0</Tags>
+                        <QuestContextSolo ParticipantsVarName="$ChosenEmpire"/>
+                      </QuestTrigger>
+                    </Triggers>
+                  </Outcome>
+                  <Outcome Name="Outcome2">
+                    <Triggers Weight="1">
+                      <QuestTrigger>
+                        <Tags>GalaxyGenerationQuest_Planets-C0S1v1</Tags>
+                        <QuestContextSolo ParticipantsVarName="$ChosenEmpire"/>
+                      </QuestTrigger>
+                    </Triggers>
+                  </Outcome>
+                  <Outcome Name="Outcome3">
+                    <Triggers Weight="1">
+                      <QuestTrigger>
+                        <Tags>GalaxyGenerationQuest_Planets-C0S1v2</Tags>
+                        <QuestContextSolo ParticipantsVarName="$ChosenEmpire"/>
+                      </QuestTrigger>
+                    </Triggers>
+                  </Outcome>
+                  <Outcome Name="Outcome4">
+                    <Triggers Weight="1">
+                      <QuestTrigger>
+                        <Tags>GalaxyGenerationQuest_Planets-C0S1v3</Tags>
                         <QuestContextSolo ParticipantsVarName="$ChosenEmpire"/>
                       </QuestTrigger>
                     </Triggers>
@@ -216,7 +185,7 @@
   <!-- ##### GALAXY GEN QUEST Constellation 0 Step 1 Version 0: Rectify Deficit #####-->
   <QuestDefinition Name="GalaxyGenerationQuest_Planets-C0S1v0" Category="GalaxyGeneration" SubCategory="SystemNormalization" IsInstant="true" TriggeringProbability="1" CheckRandom="false" MinimumTurn="0">
     <!--============ TAGS ============-->
-    <Tags>Hidden, GalaxyGenerationQuest_Planets-C0S1v0</Tags>
+    <Tags>Hidden, BeginTurn, GalaxyGenerationQuest_Planets-C0S1v0</Tags>
     <!--============ CONTEXT ============-->
     <QuestContextSolo/>
     <!--============ OCCURRENCE RULES ============-->
@@ -274,17 +243,19 @@
 
       <!-- Create interpreter tests for determining required adjustments -->
       <Var VarName="$Constellation_5PlanetDeficitB" StringValue="$(Constellation_5PlanetDeficit_Count) ge 2"/>
+      <!-- Self-trigger gate: this variant (deficit, +1) only acts when its case matches -->
+      <Var VarName="$Constellation_5PlanetDeficitBoolean" StringValue="$(Constellation_5PlanetDeficit_Count) eq 1"/>
 
-      <!--Choose inferior systems to replace-->  
+      <!--Choose inferior systems to replace-->
       <Var VarName="$SystemsToUpgrade">
         <From Source="$Constellation0.$StarSystems">
             <Where>
                 <PathPrerequisite Inverted="true" Flags="Prerequisite">ClassStarSystem, QuestNode</PathPrerequisite>
                 <PathPrerequisite Inverted="true" Flags="Prerequisite">ClassStarSystem,HomeSystem</PathPrerequisite>
                 <PathPrerequisite Inverted="true" Flags="Prerequisite">ClassStarSystem,ColonizedStarSystemStateOutpost</PathPrerequisite>
-                <InterpreterPrerequisite Flags="Prerequisite">Count(Context, @'ClassStarSystem/ClassPlanet') le 3</InterpreterPrerequisite>            
+                <InterpreterPrerequisite Flags="Prerequisite">Count(Context, @'ClassStarSystem/ClassPlanet') le 3</InterpreterPrerequisite>
             </Where>
-            <OrderBy>                        
+            <OrderBy>
                 <SortSystemByDistance OriginVarName="$AcademySystem" SortBy="Nearest" MinimumDistance="1" MaximumDistance="9999" MinimumCandidateCount="2"/>
             </OrderBy>
         </From>
@@ -305,18 +276,27 @@
       <Var VarName="$DefinitionName2"  StringValue="Replacement5pNode2"/>
 
     </Vars>
-    
+    <!--============ PREREQUISITES (self-trigger: only run when BalancedStarts is on) ============-->
+    <Prerequisites Target="$(Empires)" AnyTarget="true">
+        <GameSettingPrerequisite>BalancedStarts,True</GameSettingPrerequisite>
+    </Prerequisites>
     <!--============ STEPS ============-->
-    <Steps>   
+    <Steps>
         <Step Name="Step1">
             <ObjectiveSet>
               <Objective Name="Objective_Fake">
                 <Sequence>
+                  <Decorator_HeroAssigned>
+                    <Condition_CheckInterpreter>
+                      <Input_Context VarName="$ChosenEmpire"/>
+                      <Input_Expression VarName="$Constellation_5PlanetDeficitBoolean"/>
+                    </Condition_CheckInterpreter>
+                  </Decorator_HeroAssigned>
                   <Action_ApplyStarSystemDefinition>
                     <Input_DefinitionName VarName="$DefinitionName1"/>
                     <Input_StarSystemNode VarName="$SystemToUpgradeA"/>
                   </Action_ApplyStarSystemDefinition>
-                  <Action_ChooseOutcome Name="Outcome0"/> 
+                  <Action_ChooseOutcome Name="Outcome0"/>
                 </Sequence>
                 <Outcome Name="Outcome0">
                   <Triggers Weight="1">
@@ -335,7 +315,7 @@
   <!-- ##### GALAXY GEN QUEST Constellation 0 Step 1 Version 1: Rectify Surplus #####-->
   <QuestDefinition Name="GalaxyGenerationQuest_Planets-C0S1v1" Category="GalaxyGeneration" SubCategory="SystemNormalization" IsInstant="true" TriggeringProbability="1" CheckRandom="false" MinimumTurn="0">
     <!--============ TAGS ============-->
-    <Tags>Hidden, GalaxyGenerationQuest_Planets-C0S1v1</Tags>
+    <Tags>Hidden, BeginTurn, GalaxyGenerationQuest_Planets-C0S1v1</Tags>
     <!--============ CONTEXT ============-->
     <QuestContextSolo/>
     <!--============ OCCURRENCE RULES ============-->
@@ -393,17 +373,19 @@
 
       <!-- Create interpreter tests for determining required adjustments -->
       <Var VarName="$Constellation_5PlanetSurplusB" StringValue="$(Constellation_5PlanetSurplus_Count) ge 2"/>
-      
-      <!--Choose surplus systems to replace-->  
+      <!-- Self-trigger gate: this variant (surplus, +1) only acts when its case matches -->
+      <Var VarName="$Constellation_5PlanetSurplusBoolean" StringValue="$(Constellation_5PlanetSurplus_Count) eq 1"/>
+
+      <!--Choose surplus systems to replace-->
       <Var VarName="$SystemsToDowngrade">
         <From Source="$Constellation0.$StarSystems">
             <Where>
                 <PathPrerequisite Inverted="true" Flags="Prerequisite">ClassStarSystem, QuestNode</PathPrerequisite>
                 <PathPrerequisite Inverted="true" Flags="Prerequisite">ClassStarSystem,HomeSystem</PathPrerequisite>
                 <PathPrerequisite Inverted="true" Flags="Prerequisite">ClassStarSystem,ColonizedStarSystemStateOutpost</PathPrerequisite>
-                <InterpreterPrerequisite Flags="Prerequisite">Count(Context, @'ClassStarSystem/ClassPlanet') ge 5</InterpreterPrerequisite>            
+                <InterpreterPrerequisite Flags="Prerequisite">Count(Context, @'ClassStarSystem/ClassPlanet') ge 5</InterpreterPrerequisite>
             </Where>
-            <OrderBy>                        
+            <OrderBy>
                 <SortSystemByDistance OriginVarName="$AcademySystem" SortBy="Nearest" MinimumDistance="1" MaximumDistance="9999" MinimumCandidateCount="2"/>
             </OrderBy>
         </From>
@@ -424,18 +406,27 @@
       <Var VarName="$DefinitionName98" StringValue="Replacement4pNode2"/>
 
     </Vars>
-    
+    <!--============ PREREQUISITES (self-trigger: only run when BalancedStarts is on) ============-->
+    <Prerequisites Target="$(Empires)" AnyTarget="true">
+        <GameSettingPrerequisite>BalancedStarts,True</GameSettingPrerequisite>
+    </Prerequisites>
     <!--============ STEPS ============-->
-    <Steps>   
+    <Steps>
         <Step Name="Step1">
             <ObjectiveSet>
               <Objective Name="Objective_Fake">
                   <Sequence>
+                    <Decorator_HeroAssigned>
+                      <Condition_CheckInterpreter>
+                        <Input_Context VarName="$ChosenEmpire"/>
+                        <Input_Expression VarName="$Constellation_5PlanetSurplusBoolean"/>
+                      </Condition_CheckInterpreter>
+                    </Decorator_HeroAssigned>
                     <Action_ApplyStarSystemDefinition>
                       <Input_DefinitionName VarName="$DefinitionName99"/>
                       <Input_StarSystemNode VarName="$SystemToDowngradeA"/>
-                    </Action_ApplyStarSystemDefinition> 
-                    <Action_ChooseOutcome Name="Outcome0"/> 
+                    </Action_ApplyStarSystemDefinition>
+                    <Action_ChooseOutcome Name="Outcome0"/>
                   </Sequence>
                   <Outcome Name="Outcome0">
                     <Triggers Weight="1">
@@ -454,7 +445,7 @@
   <!-- ##### GALAXY GEN QUEST Constellation 0 Step 1 Version 2: Rectify Large Deficit #####-->
   <QuestDefinition Name="GalaxyGenerationQuest_Planets-C0S1v2" Category="GalaxyGeneration" SubCategory="SystemNormalization" IsInstant="true" TriggeringProbability="1" CheckRandom="false" MinimumTurn="0">
     <!--============ TAGS ============-->
-    <Tags>Hidden, GalaxyGenerationQuest_Planets-C0S1v2</Tags>
+    <Tags>Hidden, BeginTurn, GalaxyGenerationQuest_Planets-C0S1v2</Tags>
     <!--============ CONTEXT ============-->
     <QuestContextSolo/>
     <!--============ OCCURRENCE RULES ============-->
@@ -512,17 +503,19 @@
 
       <!-- Create interpreter tests for determining required adjustments -->
       <Var VarName="$Constellation_5PlanetDeficitB" StringValue="$(Constellation_5PlanetDeficit_Count) ge 2"/>
+      <!-- Self-trigger gate: this variant (large deficit, +2) only acts when its case matches -->
+      <Var VarName="$Constellation_5PlanetDeficit2Boolean" StringValue="$(Constellation_5PlanetDeficit_Count) eq 2"/>
 
-      <!--Choose inferior systems to replace-->  
+      <!--Choose inferior systems to replace-->
       <Var VarName="$SystemsToUpgrade">
         <From Source="$Constellation0.$StarSystems">
             <Where>
                 <PathPrerequisite Inverted="true" Flags="Prerequisite">ClassStarSystem, QuestNode</PathPrerequisite>
                 <PathPrerequisite Inverted="true" Flags="Prerequisite">ClassStarSystem,HomeSystem</PathPrerequisite>
                 <PathPrerequisite Inverted="true" Flags="Prerequisite">ClassStarSystem,ColonizedStarSystemStateOutpost</PathPrerequisite>
-                <InterpreterPrerequisite Flags="Prerequisite">Count(Context, @'ClassStarSystem/ClassPlanet') le 3</InterpreterPrerequisite>            
+                <InterpreterPrerequisite Flags="Prerequisite">Count(Context, @'ClassStarSystem/ClassPlanet') le 3</InterpreterPrerequisite>
             </Where>
-            <OrderBy>                        
+            <OrderBy>
                 <SortSystemByDistance OriginVarName="$AcademySystem" SortBy="Nearest" MinimumDistance="1" MaximumDistance="9999" MinimumCandidateCount="2"/>
             </OrderBy>
         </From>
@@ -543,13 +536,22 @@
       <Var VarName="$DefinitionName2"  StringValue="Replacement5pNode2"/>
 
     </Vars>
-    
+    <!--============ PREREQUISITES (self-trigger: only run when BalancedStarts is on) ============-->
+    <Prerequisites Target="$(Empires)" AnyTarget="true">
+        <GameSettingPrerequisite>BalancedStarts,True</GameSettingPrerequisite>
+    </Prerequisites>
     <!--============ STEPS ============-->
-    <Steps>   
+    <Steps>
         <Step Name="Step1">
             <ObjectiveSet>
               <Objective Name="Objective_Fake">
                 <Sequence>
+                  <Decorator_HeroAssigned>
+                    <Condition_CheckInterpreter>
+                      <Input_Context VarName="$ChosenEmpire"/>
+                      <Input_Expression VarName="$Constellation_5PlanetDeficit2Boolean"/>
+                    </Condition_CheckInterpreter>
+                  </Decorator_HeroAssigned>
                   <Action_ApplyStarSystemDefinition>
                     <Input_DefinitionName VarName="$DefinitionName1"/>
                     <Input_StarSystemNode VarName="$SystemToUpgradeA"/>
@@ -557,8 +559,8 @@
                   <Action_ApplyStarSystemDefinition>
                     <Input_DefinitionName VarName="$DefinitionName2"/>
                     <Input_StarSystemNode VarName="$SystemToUpgradeB"/>
-                  </Action_ApplyStarSystemDefinition> 
-                  <Action_ChooseOutcome Name="Outcome0"/> 
+                  </Action_ApplyStarSystemDefinition>
+                  <Action_ChooseOutcome Name="Outcome0"/>
                 </Sequence>
                 <Outcome Name="Outcome0">
                   <Triggers Weight="1">
@@ -577,7 +579,7 @@
   <!-- ##### GALAXY GEN QUEST Constellation 0 Step 1 Version 3: Rectify Large Surplus #####-->
   <QuestDefinition Name="GalaxyGenerationQuest_Planets-C0S1v3" Category="GalaxyGeneration" SubCategory="SystemNormalization" IsInstant="true" TriggeringProbability="1" CheckRandom="false" MinimumTurn="0">
     <!--============ TAGS ============-->
-    <Tags>Hidden, GalaxyGenerationQuest_Planets-C0S1v3</Tags>
+    <Tags>Hidden, BeginTurn, GalaxyGenerationQuest_Planets-C0S1v3</Tags>
     <!--============ CONTEXT ============-->
     <QuestContextSolo/>
     <!--============ OCCURRENCE RULES ============-->
@@ -635,17 +637,19 @@
 
       <!-- Create interpreter tests for determining required adjustments -->
       <Var VarName="$Constellation_5PlanetSurplusB" StringValue="$(Constellation_5PlanetSurplus_Count) ge 2"/>
-      
-      <!--Choose surplus systems to replace-->  
+      <!-- Self-trigger gate: this variant (large surplus, +2) only acts when its case matches -->
+      <Var VarName="$Constellation_5PlanetSurplus2Boolean" StringValue="$(Constellation_5PlanetSurplus_Count) eq 2"/>
+
+      <!--Choose surplus systems to replace-->
       <Var VarName="$SystemsToDowngrade">
         <From Source="$Constellation0.$StarSystems">
             <Where>
                 <PathPrerequisite Inverted="true" Flags="Prerequisite">ClassStarSystem, QuestNode</PathPrerequisite>
                 <PathPrerequisite Inverted="true" Flags="Prerequisite">ClassStarSystem,HomeSystem</PathPrerequisite>
                 <PathPrerequisite Inverted="true" Flags="Prerequisite">ClassStarSystem,ColonizedStarSystemStateOutpost</PathPrerequisite>
-                <InterpreterPrerequisite Flags="Prerequisite">Count(Context, @'ClassStarSystem/ClassPlanet') ge 5</InterpreterPrerequisite>            
+                <InterpreterPrerequisite Flags="Prerequisite">Count(Context, @'ClassStarSystem/ClassPlanet') ge 5</InterpreterPrerequisite>
             </Where>
-            <OrderBy>                        
+            <OrderBy>
                 <SortSystemByDistance OriginVarName="$AcademySystem" SortBy="Nearest" MinimumDistance="1" MaximumDistance="9999" MinimumCandidateCount="2"/>
             </OrderBy>
         </From>
@@ -666,13 +670,22 @@
       <Var VarName="$DefinitionName98" StringValue="Replacement4pNode2"/>
 
     </Vars>
-    
+    <!--============ PREREQUISITES (self-trigger: only run when BalancedStarts is on) ============-->
+    <Prerequisites Target="$(Empires)" AnyTarget="true">
+        <GameSettingPrerequisite>BalancedStarts,True</GameSettingPrerequisite>
+    </Prerequisites>
     <!--============ STEPS ============-->
-    <Steps>   
+    <Steps>
         <Step Name="Step1">
             <ObjectiveSet>
               <Objective Name="Objective_Fake">
                   <Sequence>
+                    <Decorator_HeroAssigned>
+                      <Condition_CheckInterpreter>
+                        <Input_Context VarName="$ChosenEmpire"/>
+                        <Input_Expression VarName="$Constellation_5PlanetSurplus2Boolean"/>
+                      </Condition_CheckInterpreter>
+                    </Decorator_HeroAssigned>
                     <Action_ApplyStarSystemDefinition>
                       <Input_DefinitionName VarName="$DefinitionName99"/>
                       <Input_StarSystemNode VarName="$SystemToDowngradeA"/>
@@ -681,7 +694,7 @@
                       <Input_DefinitionName VarName="$DefinitionName98"/>
                       <Input_StarSystemNode VarName="$SystemToDowngradeB"/>
                     </Action_ApplyStarSystemDefinition>
-                    <Action_ChooseOutcome Name="Outcome0"/> 
+                    <Action_ChooseOutcome Name="Outcome0"/>
                   </Sequence>
                   <Outcome Name="Outcome0">
                     <Triggers Weight="1">
@@ -780,49 +793,13 @@
       <Var VarName="$Constellation_5PlanetSurplus2Boolean" StringValue="$(Constellation_5PlanetSurplus_Count) eq 2"/>
       <Var VarName="$Constellation_5PlanetBalancedBoolean" StringValue="$(Constellation_5PlanetDeficit_Count) eq 0"/>
 
-      <!-- ===== INLINED from variants C1S1v0-v3 so the work runs on Turn 1 in this quest (no deferred child-quest hop) ===== -->
-      <Var VarName="$SystemsToUpgrade">
-        <From Source="$TargetConstellation.$StarSystems">
-          <Where>
-              <PathPrerequisite Inverted="true" Flags="Prerequisite">ClassStarSystem, QuestNode</PathPrerequisite>
-              <PathPrerequisite Inverted="true" Flags="Prerequisite">ClassStarSystem,HomeSystem</PathPrerequisite>
-              <PathPrerequisite Inverted="true" Flags="Prerequisite">ClassStarSystem,ColonizedStarSystemStateOutpost</PathPrerequisite>
-              <InterpreterPrerequisite Flags="Prerequisite">Count(Context, @'ClassStarSystem/ClassPlanet') le 3</InterpreterPrerequisite>
-          </Where>
-          <OrderBy>
-              <SortSystemByDistance OriginVarName="$AcademySystem" SortBy="Nearest" MinimumDistance="1" MaximumDistance="9999" MinimumCandidateCount="2"/>
-          </OrderBy>
-        </From>
-      </Var>
-      <Var VarName="$SystemToUpgradeA"><Select Index="0"><From Source="$SystemsToUpgrade"/></Select></Var>
-      <Var VarName="$SystemToUpgradeB"><Select Index="1"><From Source="$SystemsToUpgrade"/></Select></Var>
-      <Var VarName="$SystemsToDowngrade">
-        <From Source="$TargetConstellation.$StarSystems">
-          <Where>
-              <PathPrerequisite Inverted="true" Flags="Prerequisite">ClassStarSystem, QuestNode</PathPrerequisite>
-              <PathPrerequisite Inverted="true" Flags="Prerequisite">ClassStarSystem,HomeSystem</PathPrerequisite>
-              <PathPrerequisite Inverted="true" Flags="Prerequisite">ClassStarSystem,ColonizedStarSystemStateOutpost</PathPrerequisite>
-              <InterpreterPrerequisite Flags="Prerequisite">Count(Context, @'ClassStarSystem/ClassPlanet') ge 5</InterpreterPrerequisite>
-          </Where>
-          <OrderBy>
-              <SortSystemByDistance OriginVarName="$AcademySystem" SortBy="Nearest" MinimumDistance="1" MaximumDistance="9999" MinimumCandidateCount="2"/>
-          </OrderBy>
-        </From>
-      </Var>
-      <Var VarName="$SystemToDowngradeA"><Select Index="0"><From Source="$SystemsToDowngrade"/></Select></Var>
-      <Var VarName="$SystemToDowngradeB"><Select Index="1"><From Source="$SystemsToDowngrade"/></Select></Var>
-      <Var VarName="$DefinitionName1" StringValue="Replacement5pNode3"/>
-      <Var VarName="$DefinitionName2" StringValue="Replacement5pNode4"/>
-      <Var VarName="$DefinitionName99" StringValue="Replacement4pNode3"/>
-      <Var VarName="$DefinitionName98" StringValue="Replacement4pNode4"/>
-
     </Vars>
     <!--============ PREREQUISITES ============-->
     <Prerequisites Target="$(Empires)" AnyTarget="true">
         <GameSettingPrerequisite>BalancedStarts,True</GameSettingPrerequisite>
     </Prerequisites>
     <!--============ STEPS ============-->
-    <Steps>
+    <Steps>   
         <Step Name="Step1">
             <ObjectiveSet>
               <Objective Name="Objective_Fake">
@@ -834,10 +811,7 @@
                         <Input_Expression VarName="$Constellation_5PlanetDeficitBoolean"/>
                       </Condition_CheckInterpreter>
                     </Decorator_HeroAssigned>
-                    <Action_ApplyStarSystemDefinition>
-                      <Input_DefinitionName VarName="$DefinitionName1"/>
-                      <Input_StarSystemNode VarName="$SystemToUpgradeA"/>
-                    </Action_ApplyStarSystemDefinition>
+                    <Action_ChooseOutcome Name="Outcome1"/>
                   </Sequence>
                   <Sequence>
                     <Decorator_HeroAssigned>
@@ -846,10 +820,7 @@
                         <Input_Expression VarName="$Constellation_5PlanetSurplusBoolean"/>
                       </Condition_CheckInterpreter>
                     </Decorator_HeroAssigned>
-                    <Action_ApplyStarSystemDefinition>
-                      <Input_DefinitionName VarName="$DefinitionName99"/>
-                      <Input_StarSystemNode VarName="$SystemToDowngradeA"/>
-                    </Action_ApplyStarSystemDefinition>
+                    <Action_ChooseOutcome Name="Outcome2"/>
                   </Sequence>
                   <Sequence>
                     <Decorator_HeroAssigned>
@@ -858,14 +829,7 @@
                         <Input_Expression VarName="$Constellation_5PlanetDeficit2Boolean"/>
                       </Condition_CheckInterpreter>
                     </Decorator_HeroAssigned>
-                    <Action_ApplyStarSystemDefinition>
-                      <Input_DefinitionName VarName="$DefinitionName1"/>
-                      <Input_StarSystemNode VarName="$SystemToUpgradeA"/>
-                    </Action_ApplyStarSystemDefinition>
-                    <Action_ApplyStarSystemDefinition>
-                      <Input_DefinitionName VarName="$DefinitionName2"/>
-                      <Input_StarSystemNode VarName="$SystemToUpgradeB"/>
-                    </Action_ApplyStarSystemDefinition>
+                    <Action_ChooseOutcome Name="Outcome3"/>
                   </Sequence>
                   <Sequence>
                     <Decorator_HeroAssigned>
@@ -874,14 +838,7 @@
                         <Input_Expression VarName="$Constellation_5PlanetSurplus2Boolean"/>
                       </Condition_CheckInterpreter>
                     </Decorator_HeroAssigned>
-                    <Action_ApplyStarSystemDefinition>
-                      <Input_DefinitionName VarName="$DefinitionName99"/>
-                      <Input_StarSystemNode VarName="$SystemToDowngradeA"/>
-                    </Action_ApplyStarSystemDefinition>
-                    <Action_ApplyStarSystemDefinition>
-                      <Input_DefinitionName VarName="$DefinitionName98"/>
-                      <Input_StarSystemNode VarName="$SystemToDowngradeB"/>
-                    </Action_ApplyStarSystemDefinition>
+                    <Action_ChooseOutcome Name="Outcome4"/>
                   </Sequence>
                   <Sequence>
                     <Decorator_HeroAssigned>
@@ -893,6 +850,38 @@
                     <Action_Fail/>
                   </Sequence>
                 </Parallel>
+                <Outcome Name="Outcome1">
+                  <Triggers Weight="1">
+                    <QuestTrigger>
+                      <Tags>GalaxyGenerationQuest_Planets-C1S1v0</Tags>
+                      <QuestContextSolo ParticipantsVarName="$ChosenEmpire"/>
+                    </QuestTrigger>
+                  </Triggers>
+                </Outcome>
+                <Outcome Name="Outcome2">
+                  <Triggers Weight="1">
+                    <QuestTrigger>
+                      <Tags>GalaxyGenerationQuest_Planets-C1S1v1</Tags>
+                      <QuestContextSolo ParticipantsVarName="$ChosenEmpire"/>
+                    </QuestTrigger>
+                  </Triggers>
+                </Outcome>
+                <Outcome Name="Outcome3">
+                  <Triggers Weight="1">
+                    <QuestTrigger>
+                      <Tags>GalaxyGenerationQuest_Planets-C1S1v2</Tags>
+                      <QuestContextSolo ParticipantsVarName="$ChosenEmpire"/>
+                    </QuestTrigger>
+                  </Triggers>
+                </Outcome>
+                <Outcome Name="Outcome4">
+                  <Triggers Weight="1">
+                    <QuestTrigger>
+                      <Tags>GalaxyGenerationQuest_Planets-C1S1v3</Tags>
+                      <QuestContextSolo ParticipantsVarName="$ChosenEmpire"/>
+                    </QuestTrigger>
+                  </Triggers>
+                </Outcome>
               </Objective>
             </ObjectiveSet>
         </Step>
@@ -1487,49 +1476,13 @@
     <Var VarName="$Constellation_5PlanetSurplus2Boolean" StringValue="$(Constellation_5PlanetSurplus_Count) eq 2"/>
     <Var VarName="$Constellation_5PlanetBalancedBoolean" StringValue="$(Constellation_5PlanetDeficit_Count) eq 0"/>
 
-    <!-- ===== INLINED from variants C2S1v0-v3 so the work runs on Turn 1 in this quest (no deferred child-quest hop) ===== -->
-    <Var VarName="$SystemsToUpgrade">
-      <From Source="$TargetConstellation.$StarSystems">
-        <Where>
-            <PathPrerequisite Inverted="true" Flags="Prerequisite">ClassStarSystem, QuestNode</PathPrerequisite>
-            <PathPrerequisite Inverted="true" Flags="Prerequisite">ClassStarSystem,HomeSystem</PathPrerequisite>
-            <PathPrerequisite Inverted="true" Flags="Prerequisite">ClassStarSystem,ColonizedStarSystemStateOutpost</PathPrerequisite>
-            <InterpreterPrerequisite Flags="Prerequisite">Count(Context, @'ClassStarSystem/ClassPlanet') le 3</InterpreterPrerequisite>
-        </Where>
-        <OrderBy>
-            <SortSystemByDistance OriginVarName="$AcademySystem" SortBy="Nearest" MinimumDistance="1" MaximumDistance="9999" MinimumCandidateCount="2"/>
-        </OrderBy>
-      </From>
-    </Var>
-    <Var VarName="$SystemToUpgradeA"><Select Index="0"><From Source="$SystemsToUpgrade"/></Select></Var>
-    <Var VarName="$SystemToUpgradeB"><Select Index="1"><From Source="$SystemsToUpgrade"/></Select></Var>
-    <Var VarName="$SystemsToDowngrade">
-      <From Source="$TargetConstellation.$StarSystems">
-        <Where>
-            <PathPrerequisite Inverted="true" Flags="Prerequisite">ClassStarSystem, QuestNode</PathPrerequisite>
-            <PathPrerequisite Inverted="true" Flags="Prerequisite">ClassStarSystem,HomeSystem</PathPrerequisite>
-            <PathPrerequisite Inverted="true" Flags="Prerequisite">ClassStarSystem,ColonizedStarSystemStateOutpost</PathPrerequisite>
-            <InterpreterPrerequisite Flags="Prerequisite">Count(Context, @'ClassStarSystem/ClassPlanet') ge 5</InterpreterPrerequisite>
-        </Where>
-        <OrderBy>
-            <SortSystemByDistance OriginVarName="$AcademySystem" SortBy="Nearest" MinimumDistance="1" MaximumDistance="9999" MinimumCandidateCount="2"/>
-        </OrderBy>
-      </From>
-    </Var>
-    <Var VarName="$SystemToDowngradeA"><Select Index="0"><From Source="$SystemsToDowngrade"/></Select></Var>
-    <Var VarName="$SystemToDowngradeB"><Select Index="1"><From Source="$SystemsToDowngrade"/></Select></Var>
-    <Var VarName="$DefinitionName1" StringValue="Replacement5pNode5"/>
-    <Var VarName="$DefinitionName2" StringValue="Replacement5pNode6"/>
-    <Var VarName="$DefinitionName99" StringValue="Replacement4pNode5"/>
-    <Var VarName="$DefinitionName98" StringValue="Replacement4pNode6"/>
-
   </Vars>
   <!--============ PREREQUISITES ============-->
   <Prerequisites Target="$(Empires)" AnyTarget="true">
       <GameSettingPrerequisite>BalancedStarts,True</GameSettingPrerequisite>
   </Prerequisites>
   <!--============ STEPS ============-->
-  <Steps>
+  <Steps>   
       <Step Name="Step1">
           <ObjectiveSet>
             <Objective Name="Objective_Fake">
@@ -1541,10 +1494,7 @@
                       <Input_Expression VarName="$Constellation_5PlanetDeficitBoolean"/>
                     </Condition_CheckInterpreter>
                   </Decorator_HeroAssigned>
-                  <Action_ApplyStarSystemDefinition>
-                    <Input_DefinitionName VarName="$DefinitionName1"/>
-                    <Input_StarSystemNode VarName="$SystemToUpgradeA"/>
-                  </Action_ApplyStarSystemDefinition>
+                  <Action_ChooseOutcome Name="Outcome1"/>
                 </Sequence>
                 <Sequence>
                   <Decorator_HeroAssigned>
@@ -1553,10 +1503,7 @@
                       <Input_Expression VarName="$Constellation_5PlanetSurplusBoolean"/>
                     </Condition_CheckInterpreter>
                   </Decorator_HeroAssigned>
-                  <Action_ApplyStarSystemDefinition>
-                    <Input_DefinitionName VarName="$DefinitionName99"/>
-                    <Input_StarSystemNode VarName="$SystemToDowngradeA"/>
-                  </Action_ApplyStarSystemDefinition>
+                  <Action_ChooseOutcome Name="Outcome2"/>
                 </Sequence>
                 <Sequence>
                   <Decorator_HeroAssigned>
@@ -1565,14 +1512,7 @@
                       <Input_Expression VarName="$Constellation_5PlanetDeficit2Boolean"/>
                     </Condition_CheckInterpreter>
                   </Decorator_HeroAssigned>
-                  <Action_ApplyStarSystemDefinition>
-                    <Input_DefinitionName VarName="$DefinitionName1"/>
-                    <Input_StarSystemNode VarName="$SystemToUpgradeA"/>
-                  </Action_ApplyStarSystemDefinition>
-                  <Action_ApplyStarSystemDefinition>
-                    <Input_DefinitionName VarName="$DefinitionName2"/>
-                    <Input_StarSystemNode VarName="$SystemToUpgradeB"/>
-                  </Action_ApplyStarSystemDefinition>
+                  <Action_ChooseOutcome Name="Outcome3"/>
                 </Sequence>
                 <Sequence>
                   <Decorator_HeroAssigned>
@@ -1581,14 +1521,7 @@
                       <Input_Expression VarName="$Constellation_5PlanetSurplus2Boolean"/>
                     </Condition_CheckInterpreter>
                   </Decorator_HeroAssigned>
-                  <Action_ApplyStarSystemDefinition>
-                    <Input_DefinitionName VarName="$DefinitionName99"/>
-                    <Input_StarSystemNode VarName="$SystemToDowngradeA"/>
-                  </Action_ApplyStarSystemDefinition>
-                  <Action_ApplyStarSystemDefinition>
-                    <Input_DefinitionName VarName="$DefinitionName98"/>
-                    <Input_StarSystemNode VarName="$SystemToDowngradeB"/>
-                  </Action_ApplyStarSystemDefinition>
+                  <Action_ChooseOutcome Name="Outcome4"/>
                 </Sequence>
                 <Sequence>
                   <Decorator_HeroAssigned>
@@ -1600,6 +1533,38 @@
                   <Action_Fail/>
                 </Sequence>
               </Parallel>
+              <Outcome Name="Outcome1">
+                <Triggers Weight="1">
+                  <QuestTrigger>
+                    <Tags>GalaxyGenerationQuest_Planets-C2S1v0</Tags>
+                    <QuestContextSolo ParticipantsVarName="$ChosenEmpire"/>
+                  </QuestTrigger>
+                </Triggers>
+              </Outcome>
+              <Outcome Name="Outcome2">
+                <Triggers Weight="1">
+                  <QuestTrigger>
+                    <Tags>GalaxyGenerationQuest_Planets-C2S1v1</Tags>
+                    <QuestContextSolo ParticipantsVarName="$ChosenEmpire"/>
+                  </QuestTrigger>
+                </Triggers>
+              </Outcome>
+              <Outcome Name="Outcome3">
+                <Triggers Weight="1">
+                  <QuestTrigger>
+                    <Tags>GalaxyGenerationQuest_Planets-C2S1v2</Tags>
+                    <QuestContextSolo ParticipantsVarName="$ChosenEmpire"/>
+                  </QuestTrigger>
+                </Triggers>
+              </Outcome>
+              <Outcome Name="Outcome4">
+                <Triggers Weight="1">
+                  <QuestTrigger>
+                    <Tags>GalaxyGenerationQuest_Planets-C2S1v3</Tags>
+                    <QuestContextSolo ParticipantsVarName="$ChosenEmpire"/>
+                  </QuestTrigger>
+                </Triggers>
+              </Outcome>
             </Objective>
           </ObjectiveSet>
       </Step>
@@ -2194,49 +2159,13 @@
     <Var VarName="$Constellation_5PlanetSurplus2Boolean" StringValue="$(Constellation_5PlanetSurplus_Count) eq 2"/>
     <Var VarName="$Constellation_5PlanetBalancedBoolean" StringValue="$(Constellation_5PlanetDeficit_Count) eq 0"/>
 
-    <!-- ===== INLINED from variants C3S1v0-v3 so the work runs on Turn 1 in this quest (no deferred child-quest hop) ===== -->
-    <Var VarName="$SystemsToUpgrade">
-      <From Source="$TargetConstellation.$StarSystems">
-        <Where>
-            <PathPrerequisite Inverted="true" Flags="Prerequisite">ClassStarSystem, QuestNode</PathPrerequisite>
-            <PathPrerequisite Inverted="true" Flags="Prerequisite">ClassStarSystem,HomeSystem</PathPrerequisite>
-            <PathPrerequisite Inverted="true" Flags="Prerequisite">ClassStarSystem,ColonizedStarSystemStateOutpost</PathPrerequisite>
-            <InterpreterPrerequisite Flags="Prerequisite">Count(Context, @'ClassStarSystem/ClassPlanet') le 3</InterpreterPrerequisite>
-        </Where>
-        <OrderBy>
-            <SortSystemByDistance OriginVarName="$AcademySystem" SortBy="Nearest" MinimumDistance="1" MaximumDistance="9999" MinimumCandidateCount="2"/>
-        </OrderBy>
-      </From>
-    </Var>
-    <Var VarName="$SystemToUpgradeA"><Select Index="0"><From Source="$SystemsToUpgrade"/></Select></Var>
-    <Var VarName="$SystemToUpgradeB"><Select Index="1"><From Source="$SystemsToUpgrade"/></Select></Var>
-    <Var VarName="$SystemsToDowngrade">
-      <From Source="$TargetConstellation.$StarSystems">
-        <Where>
-            <PathPrerequisite Inverted="true" Flags="Prerequisite">ClassStarSystem, QuestNode</PathPrerequisite>
-            <PathPrerequisite Inverted="true" Flags="Prerequisite">ClassStarSystem,HomeSystem</PathPrerequisite>
-            <PathPrerequisite Inverted="true" Flags="Prerequisite">ClassStarSystem,ColonizedStarSystemStateOutpost</PathPrerequisite>
-            <InterpreterPrerequisite Flags="Prerequisite">Count(Context, @'ClassStarSystem/ClassPlanet') ge 5</InterpreterPrerequisite>
-        </Where>
-        <OrderBy>
-            <SortSystemByDistance OriginVarName="$AcademySystem" SortBy="Nearest" MinimumDistance="1" MaximumDistance="9999" MinimumCandidateCount="2"/>
-        </OrderBy>
-      </From>
-    </Var>
-    <Var VarName="$SystemToDowngradeA"><Select Index="0"><From Source="$SystemsToDowngrade"/></Select></Var>
-    <Var VarName="$SystemToDowngradeB"><Select Index="1"><From Source="$SystemsToDowngrade"/></Select></Var>
-    <Var VarName="$DefinitionName1" StringValue="Replacement5pNode7"/>
-    <Var VarName="$DefinitionName2" StringValue="Replacement5pNode8"/>
-    <Var VarName="$DefinitionName99" StringValue="Replacement4pNode7"/>
-    <Var VarName="$DefinitionName98" StringValue="Replacement4pNode8"/>
-
   </Vars>
   <!--============ PREREQUISITES ============-->
   <Prerequisites Target="$(Empires)" AnyTarget="true">
       <GameSettingPrerequisite>BalancedStarts,True</GameSettingPrerequisite>
   </Prerequisites>
   <!--============ STEPS ============-->
-  <Steps>
+  <Steps>   
       <Step Name="Step1">
           <ObjectiveSet>
             <Objective Name="Objective_Fake">
@@ -2248,10 +2177,7 @@
                       <Input_Expression VarName="$Constellation_5PlanetDeficitBoolean"/>
                     </Condition_CheckInterpreter>
                   </Decorator_HeroAssigned>
-                  <Action_ApplyStarSystemDefinition>
-                    <Input_DefinitionName VarName="$DefinitionName1"/>
-                    <Input_StarSystemNode VarName="$SystemToUpgradeA"/>
-                  </Action_ApplyStarSystemDefinition>
+                  <Action_ChooseOutcome Name="Outcome1"/>
                 </Sequence>
                 <Sequence>
                   <Decorator_HeroAssigned>
@@ -2260,10 +2186,7 @@
                       <Input_Expression VarName="$Constellation_5PlanetSurplusBoolean"/>
                     </Condition_CheckInterpreter>
                   </Decorator_HeroAssigned>
-                  <Action_ApplyStarSystemDefinition>
-                    <Input_DefinitionName VarName="$DefinitionName99"/>
-                    <Input_StarSystemNode VarName="$SystemToDowngradeA"/>
-                  </Action_ApplyStarSystemDefinition>
+                  <Action_ChooseOutcome Name="Outcome2"/>
                 </Sequence>
                 <Sequence>
                   <Decorator_HeroAssigned>
@@ -2272,14 +2195,7 @@
                       <Input_Expression VarName="$Constellation_5PlanetDeficit2Boolean"/>
                     </Condition_CheckInterpreter>
                   </Decorator_HeroAssigned>
-                  <Action_ApplyStarSystemDefinition>
-                    <Input_DefinitionName VarName="$DefinitionName1"/>
-                    <Input_StarSystemNode VarName="$SystemToUpgradeA"/>
-                  </Action_ApplyStarSystemDefinition>
-                  <Action_ApplyStarSystemDefinition>
-                    <Input_DefinitionName VarName="$DefinitionName2"/>
-                    <Input_StarSystemNode VarName="$SystemToUpgradeB"/>
-                  </Action_ApplyStarSystemDefinition>
+                  <Action_ChooseOutcome Name="Outcome3"/>
                 </Sequence>
                 <Sequence>
                   <Decorator_HeroAssigned>
@@ -2288,14 +2204,7 @@
                       <Input_Expression VarName="$Constellation_5PlanetSurplus2Boolean"/>
                     </Condition_CheckInterpreter>
                   </Decorator_HeroAssigned>
-                  <Action_ApplyStarSystemDefinition>
-                    <Input_DefinitionName VarName="$DefinitionName99"/>
-                    <Input_StarSystemNode VarName="$SystemToDowngradeA"/>
-                  </Action_ApplyStarSystemDefinition>
-                  <Action_ApplyStarSystemDefinition>
-                    <Input_DefinitionName VarName="$DefinitionName98"/>
-                    <Input_StarSystemNode VarName="$SystemToDowngradeB"/>
-                  </Action_ApplyStarSystemDefinition>
+                  <Action_ChooseOutcome Name="Outcome4"/>
                 </Sequence>
                 <Sequence>
                   <Decorator_HeroAssigned>
@@ -2307,6 +2216,38 @@
                   <Action_Fail/>
                 </Sequence>
               </Parallel>
+              <Outcome Name="Outcome1">
+                <Triggers Weight="1">
+                  <QuestTrigger>
+                    <Tags>GalaxyGenerationQuest_Planets-C3S1v0</Tags>
+                    <QuestContextSolo ParticipantsVarName="$ChosenEmpire"/>
+                  </QuestTrigger>
+                </Triggers>
+              </Outcome>
+              <Outcome Name="Outcome2">
+                <Triggers Weight="1">
+                  <QuestTrigger>
+                    <Tags>GalaxyGenerationQuest_Planets-C3S1v1</Tags>
+                    <QuestContextSolo ParticipantsVarName="$ChosenEmpire"/>
+                  </QuestTrigger>
+                </Triggers>
+              </Outcome>
+              <Outcome Name="Outcome3">
+                <Triggers Weight="1">
+                  <QuestTrigger>
+                    <Tags>GalaxyGenerationQuest_Planets-C3S1v2</Tags>
+                    <QuestContextSolo ParticipantsVarName="$ChosenEmpire"/>
+                  </QuestTrigger>
+                </Triggers>
+              </Outcome>
+              <Outcome Name="Outcome4">
+                <Triggers Weight="1">
+                  <QuestTrigger>
+                    <Tags>GalaxyGenerationQuest_Planets-C3S1v3</Tags>
+                    <QuestContextSolo ParticipantsVarName="$ChosenEmpire"/>
+                  </QuestTrigger>
+                </Triggers>
+              </Outcome>
             </Objective>
           </ObjectiveSet>
       </Step>
@@ -2902,49 +2843,13 @@
     <Var VarName="$Constellation_5PlanetSurplus2Boolean" StringValue="$(Constellation_5PlanetSurplus_Count) eq 2"/>
     <Var VarName="$Constellation_5PlanetBalancedBoolean" StringValue="$(Constellation_5PlanetDeficit_Count) eq 0"/>
 
-    <!-- ===== INLINED from variants C4S1v0-v3 so the work runs on Turn 1 in this quest (no deferred child-quest hop) ===== -->
-    <Var VarName="$SystemsToUpgrade">
-      <From Source="$TargetConstellation.$StarSystems">
-        <Where>
-            <PathPrerequisite Inverted="true" Flags="Prerequisite">ClassStarSystem, QuestNode</PathPrerequisite>
-            <PathPrerequisite Inverted="true" Flags="Prerequisite">ClassStarSystem,HomeSystem</PathPrerequisite>
-            <PathPrerequisite Inverted="true" Flags="Prerequisite">ClassStarSystem,ColonizedStarSystemStateOutpost</PathPrerequisite>
-            <InterpreterPrerequisite Flags="Prerequisite">Count(Context, @'ClassStarSystem/ClassPlanet') le 3</InterpreterPrerequisite>
-        </Where>
-        <OrderBy>
-            <SortSystemByDistance OriginVarName="$AcademySystem" SortBy="Nearest" MinimumDistance="1" MaximumDistance="9999" MinimumCandidateCount="2"/>
-        </OrderBy>
-      </From>
-    </Var>
-    <Var VarName="$SystemToUpgradeA"><Select Index="0"><From Source="$SystemsToUpgrade"/></Select></Var>
-    <Var VarName="$SystemToUpgradeB"><Select Index="1"><From Source="$SystemsToUpgrade"/></Select></Var>
-    <Var VarName="$SystemsToDowngrade">
-      <From Source="$TargetConstellation.$StarSystems">
-        <Where>
-            <PathPrerequisite Inverted="true" Flags="Prerequisite">ClassStarSystem, QuestNode</PathPrerequisite>
-            <PathPrerequisite Inverted="true" Flags="Prerequisite">ClassStarSystem,HomeSystem</PathPrerequisite>
-            <PathPrerequisite Inverted="true" Flags="Prerequisite">ClassStarSystem,ColonizedStarSystemStateOutpost</PathPrerequisite>
-            <InterpreterPrerequisite Flags="Prerequisite">Count(Context, @'ClassStarSystem/ClassPlanet') ge 5</InterpreterPrerequisite>
-        </Where>
-        <OrderBy>
-            <SortSystemByDistance OriginVarName="$AcademySystem" SortBy="Nearest" MinimumDistance="1" MaximumDistance="9999" MinimumCandidateCount="2"/>
-        </OrderBy>
-      </From>
-    </Var>
-    <Var VarName="$SystemToDowngradeA"><Select Index="0"><From Source="$SystemsToDowngrade"/></Select></Var>
-    <Var VarName="$SystemToDowngradeB"><Select Index="1"><From Source="$SystemsToDowngrade"/></Select></Var>
-    <Var VarName="$DefinitionName1" StringValue="Replacement5pNode9"/>
-    <Var VarName="$DefinitionName2" StringValue="Replacement5pNode10"/>
-    <Var VarName="$DefinitionName99" StringValue="Replacement4pNode9"/>
-    <Var VarName="$DefinitionName98" StringValue="Replacement4pNode10"/>
-
   </Vars>
   <!--============ PREREQUISITES ============-->
   <Prerequisites Target="$(Empires)" AnyTarget="true">
       <GameSettingPrerequisite>BalancedStarts,True</GameSettingPrerequisite>
   </Prerequisites>
   <!--============ STEPS ============-->
-  <Steps>
+  <Steps>   
       <Step Name="Step1">
           <ObjectiveSet>
             <Objective Name="Objective_Fake">
@@ -2956,10 +2861,7 @@
                       <Input_Expression VarName="$Constellation_5PlanetDeficitBoolean"/>
                     </Condition_CheckInterpreter>
                   </Decorator_HeroAssigned>
-                  <Action_ApplyStarSystemDefinition>
-                    <Input_DefinitionName VarName="$DefinitionName1"/>
-                    <Input_StarSystemNode VarName="$SystemToUpgradeA"/>
-                  </Action_ApplyStarSystemDefinition>
+                  <Action_ChooseOutcome Name="Outcome1"/>
                 </Sequence>
                 <Sequence>
                   <Decorator_HeroAssigned>
@@ -2968,10 +2870,7 @@
                       <Input_Expression VarName="$Constellation_5PlanetSurplusBoolean"/>
                     </Condition_CheckInterpreter>
                   </Decorator_HeroAssigned>
-                  <Action_ApplyStarSystemDefinition>
-                    <Input_DefinitionName VarName="$DefinitionName99"/>
-                    <Input_StarSystemNode VarName="$SystemToDowngradeA"/>
-                  </Action_ApplyStarSystemDefinition>
+                  <Action_ChooseOutcome Name="Outcome2"/>
                 </Sequence>
                 <Sequence>
                   <Decorator_HeroAssigned>
@@ -2980,14 +2879,7 @@
                       <Input_Expression VarName="$Constellation_5PlanetDeficit2Boolean"/>
                     </Condition_CheckInterpreter>
                   </Decorator_HeroAssigned>
-                  <Action_ApplyStarSystemDefinition>
-                    <Input_DefinitionName VarName="$DefinitionName1"/>
-                    <Input_StarSystemNode VarName="$SystemToUpgradeA"/>
-                  </Action_ApplyStarSystemDefinition>
-                  <Action_ApplyStarSystemDefinition>
-                    <Input_DefinitionName VarName="$DefinitionName2"/>
-                    <Input_StarSystemNode VarName="$SystemToUpgradeB"/>
-                  </Action_ApplyStarSystemDefinition>
+                  <Action_ChooseOutcome Name="Outcome3"/>
                 </Sequence>
                 <Sequence>
                   <Decorator_HeroAssigned>
@@ -2996,14 +2888,7 @@
                       <Input_Expression VarName="$Constellation_5PlanetSurplus2Boolean"/>
                     </Condition_CheckInterpreter>
                   </Decorator_HeroAssigned>
-                  <Action_ApplyStarSystemDefinition>
-                    <Input_DefinitionName VarName="$DefinitionName99"/>
-                    <Input_StarSystemNode VarName="$SystemToDowngradeA"/>
-                  </Action_ApplyStarSystemDefinition>
-                  <Action_ApplyStarSystemDefinition>
-                    <Input_DefinitionName VarName="$DefinitionName98"/>
-                    <Input_StarSystemNode VarName="$SystemToDowngradeB"/>
-                  </Action_ApplyStarSystemDefinition>
+                  <Action_ChooseOutcome Name="Outcome4"/>
                 </Sequence>
                 <Sequence>
                   <Decorator_HeroAssigned>
@@ -3015,6 +2900,38 @@
                   <Action_Fail/>
                 </Sequence>
               </Parallel>
+              <Outcome Name="Outcome1">
+                <Triggers Weight="1">
+                  <QuestTrigger>
+                    <Tags>GalaxyGenerationQuest_Planets-C4S1v0</Tags>
+                    <QuestContextSolo ParticipantsVarName="$ChosenEmpire"/>
+                  </QuestTrigger>
+                </Triggers>
+              </Outcome>
+              <Outcome Name="Outcome2">
+                <Triggers Weight="1">
+                  <QuestTrigger>
+                    <Tags>GalaxyGenerationQuest_Planets-C4S1v1</Tags>
+                    <QuestContextSolo ParticipantsVarName="$ChosenEmpire"/>
+                  </QuestTrigger>
+                </Triggers>
+              </Outcome>
+              <Outcome Name="Outcome3">
+                <Triggers Weight="1">
+                  <QuestTrigger>
+                    <Tags>GalaxyGenerationQuest_Planets-C4S1v2</Tags>
+                    <QuestContextSolo ParticipantsVarName="$ChosenEmpire"/>
+                  </QuestTrigger>
+                </Triggers>
+              </Outcome>
+              <Outcome Name="Outcome4">
+                <Triggers Weight="1">
+                  <QuestTrigger>
+                    <Tags>GalaxyGenerationQuest_Planets-C4S1v3</Tags>
+                    <QuestContextSolo ParticipantsVarName="$ChosenEmpire"/>
+                  </QuestTrigger>
+                </Triggers>
+              </Outcome>
             </Objective>
           </ObjectiveSet>
       </Step>

--- a/Endless Space Competitive Mod/Quests/QuestDefinitions[ResourceSpawn].xml
+++ b/Endless Space Competitive Mod/Quests/QuestDefinitions[ResourceSpawn].xml
@@ -30,13 +30,9 @@
           </Select>
         </Var>
  
-        <!-- Find the Academy, just to have an objective frame of reference for this process-->
+        <!-- Anchor on the chosen empire home system (queryable at Turn-1 begin) as the frame of reference; replaces the WorldAcademy lookup which was not ready at Turn-1 begin-->
         <Var VarName="$AcademySystem">
-          <From Source="$Constellations.$StarSystems">
-              <Where>
-                  <PathPrerequisite Flags="Prerequisite">WorldAcademy</PathPrerequisite>
-              </Where>
-          </From>
+          <From Source="$ChosenEmpire.$HomeStarSystem"/>
         </Var>
         <Var VarName="$Constellation0">
           <From Source="$AcademySystem.$Constellation"/>
@@ -720,13 +716,9 @@
         </Select>
       </Var>
 
-      <!-- Find the Academy, just to have an objective frame of reference for this process-->
+      <!-- Anchor on the chosen empire home system (queryable at Turn-1 begin) as the frame of reference; replaces the WorldAcademy lookup which was not ready at Turn-1 begin-->
       <Var VarName="$AcademySystem">
-        <From Source="$Constellations.$StarSystems">
-            <Where>
-                <PathPrerequisite Flags="Prerequisite">WorldAcademy</PathPrerequisite>
-            </Where>
-        </From>
+        <From Source="$ChosenEmpire.$HomeStarSystem"/>
       </Var>
       <Var VarName="$Constellation0">
         <From Source="$AcademySystem.$Constellation"/>

--- a/Endless Space Competitive Mod/Quests/QuestDefinitions[ResourceSpawn].xml
+++ b/Endless Space Competitive Mod/Quests/QuestDefinitions[ResourceSpawn].xml
@@ -11,7 +11,7 @@
     -->
 
     <!-- ##### GALAXY GEN QUEST Spawn strategic resources in a way that is evenly distributed among constellations  #####-->
-    <QuestDefinition Name="StrategicResourceGenerationQuest" Category="GalaxyGeneration" SubCategory="ResourceNormalization" IsInstant="true" TriggeringProbability="1" CheckRandom="true" MinimumTurn="0">
+    <QuestDefinition Name="StrategicResourceGenerationQuest" Category="GalaxyGeneration" SubCategory="ResourceNormalization" IsInstant="true" TriggeringProbability="1" CheckRandom="false" MinimumTurn="0">
       <!--============ TAGS ============-->
       <Tags>StrategicResourceGenerationQuest</Tags>
       <!--============ CONTEXT ============-->
@@ -135,24 +135,24 @@
           </Count>
         </Var>
         <InterpretedVar VarName="$ExpectedSystems">
-          <Expression>Floor($(SystemCount)/$(ConstellationCount))</Expression>
+          <Expression>Floor($(SystemCount)/Max(1,$(ConstellationCount)))</Expression>
         </InterpretedVar>
 
         <!-- Calculate relative performance to find the rump constellation -->
         <InterpretedVar VarName="$Constellation0_RumpBoolean">
-          <Expression>1-Round(($(Constellation0_SystemCount)/$(ExpectedSystems)))</Expression>
+          <Expression>1-Round(($(Constellation0_SystemCount)/Max(1,$(ExpectedSystems))))</Expression>
         </InterpretedVar>
         <InterpretedVar VarName="$Constellation1_RumpBoolean">
-          <Expression>1-Round(($(Constellation1_SystemCount)/$(ExpectedSystems)))</Expression>
+          <Expression>1-Round(($(Constellation1_SystemCount)/Max(1,$(ExpectedSystems))))</Expression>
         </InterpretedVar>
         <InterpretedVar VarName="$Constellation2_RumpBoolean">
-          <Expression>1-Round(($(Constellation2_SystemCount)/$(ExpectedSystems)))</Expression>
+          <Expression>1-Round(($(Constellation2_SystemCount)/Max(1,$(ExpectedSystems))))</Expression>
         </InterpretedVar>
         <InterpretedVar VarName="$Constellation3_RumpBoolean">
-          <Expression>1-Round(($(Constellation3_SystemCount)/$(ExpectedSystems)))</Expression>
+          <Expression>1-Round(($(Constellation3_SystemCount)/Max(1,$(ExpectedSystems))))</Expression>
         </InterpretedVar>
         <InterpretedVar VarName="$Constellation4_RumpBoolean">
-          <Expression>1-Round(($(Constellation4_SystemCount)/$(ExpectedSystems)))</Expression>
+          <Expression>1-Round(($(Constellation4_SystemCount)/Max(1,$(ExpectedSystems))))</Expression>
         </InterpretedVar>
 
         <!-- Calculate number of deposits to spawn for each resource -->
@@ -160,49 +160,49 @@
           <Expression>Property(Context, @../ClassEmpire, GalaxySize, true)</Expression>
         </InterpretedVar>
         <InterpretedVar VarName="$C0StrategicT1Count">
-          <Expression>Ceil((5 - (2.5 * $(Constellation0_RumpBoolean))) * $(GalaxySize) / $(ConstellationCount))</Expression>
+          <Expression>Ceil((5 - (2.5 * $(Constellation0_RumpBoolean))) * $(GalaxySize) / Max(1,$(ConstellationCount)))</Expression>
         </InterpretedVar>
         <InterpretedVar VarName="$C0StrategicT2Count">
-          <Expression>Ceil((4 - (2 * $(Constellation0_RumpBoolean))) * $(GalaxySize) / $(ConstellationCount))</Expression>
+          <Expression>Ceil((4 - (2 * $(Constellation0_RumpBoolean))) * $(GalaxySize) / Max(1,$(ConstellationCount)))</Expression>
         </InterpretedVar>
         <InterpretedVar VarName="$C0StrategicT3Count">
-          <Expression>Ceil((3.5 - (1.75 * $(Constellation0_RumpBoolean))) * $(GalaxySize) / $(ConstellationCount))</Expression>
+          <Expression>Ceil((3.5 - (1.75 * $(Constellation0_RumpBoolean))) * $(GalaxySize) / Max(1,$(ConstellationCount)))</Expression>
         </InterpretedVar>
         <InterpretedVar VarName="$C1StrategicT1Count">
-          <Expression>Ceil((5 - (2.5 * $(Constellation1_RumpBoolean))) * $(GalaxySize) / $(ConstellationCount))</Expression>
+          <Expression>Ceil((5 - (2.5 * $(Constellation1_RumpBoolean))) * $(GalaxySize) / Max(1,$(ConstellationCount)))</Expression>
         </InterpretedVar>
         <InterpretedVar VarName="$C1StrategicT2Count">
-          <Expression>Ceil((4 - (2 * $(Constellation1_RumpBoolean))) * $(GalaxySize) / $(ConstellationCount))</Expression>
+          <Expression>Ceil((4 - (2 * $(Constellation1_RumpBoolean))) * $(GalaxySize) / Max(1,$(ConstellationCount)))</Expression>
         </InterpretedVar>
         <InterpretedVar VarName="$C1StrategicT3Count">
-          <Expression>Ceil((3.5 - (1.75 * $(Constellation1_RumpBoolean))) * $(GalaxySize) / $(ConstellationCount))</Expression>
+          <Expression>Ceil((3.5 - (1.75 * $(Constellation1_RumpBoolean))) * $(GalaxySize) / Max(1,$(ConstellationCount)))</Expression>
         </InterpretedVar>
         <InterpretedVar VarName="$C2StrategicT1Count">
-          <Expression>Ceil((5 - (2.5 * $(Constellation2_RumpBoolean))) * $(GalaxySize) / $(ConstellationCount))</Expression>
+          <Expression>Ceil((5 - (2.5 * $(Constellation2_RumpBoolean))) * $(GalaxySize) / Max(1,$(ConstellationCount)))</Expression>
         </InterpretedVar>
         <InterpretedVar VarName="$C2StrategicT2Count">
-          <Expression>Ceil((4 - (2 * $(Constellation2_RumpBoolean))) * $(GalaxySize) / $(ConstellationCount))</Expression>
+          <Expression>Ceil((4 - (2 * $(Constellation2_RumpBoolean))) * $(GalaxySize) / Max(1,$(ConstellationCount)))</Expression>
         </InterpretedVar>
         <InterpretedVar VarName="$C2StrategicT3Count">
-          <Expression>Ceil((3.5 - (1.75 * $(Constellation2_RumpBoolean))) * $(GalaxySize) / $(ConstellationCount))</Expression>
+          <Expression>Ceil((3.5 - (1.75 * $(Constellation2_RumpBoolean))) * $(GalaxySize) / Max(1,$(ConstellationCount)))</Expression>
         </InterpretedVar>
         <InterpretedVar VarName="$C3StrategicT1Count">
-          <Expression>Ceil((5 - (2.5 * $(Constellation3_RumpBoolean))) * $(GalaxySize) / $(ConstellationCount))</Expression>
+          <Expression>Ceil((5 - (2.5 * $(Constellation3_RumpBoolean))) * $(GalaxySize) / Max(1,$(ConstellationCount)))</Expression>
         </InterpretedVar>
         <InterpretedVar VarName="$C3StrategicT2Count">
-          <Expression>Ceil((4 - (2 * $(Constellation3_RumpBoolean))) * $(GalaxySize) / $(ConstellationCount))</Expression>
+          <Expression>Ceil((4 - (2 * $(Constellation3_RumpBoolean))) * $(GalaxySize) / Max(1,$(ConstellationCount)))</Expression>
         </InterpretedVar>
         <InterpretedVar VarName="$C3StrategicT3Count">
-          <Expression>Ceil((3.5 - (1.75 * $(Constellation3_RumpBoolean))) * $(GalaxySize) / $(ConstellationCount))</Expression>
+          <Expression>Ceil((3.5 - (1.75 * $(Constellation3_RumpBoolean))) * $(GalaxySize) / Max(1,$(ConstellationCount)))</Expression>
         </InterpretedVar>
         <InterpretedVar VarName="$C4StrategicT1Count">
-          <Expression>Ceil((5 - (2.5 * $(Constellation4_RumpBoolean))) * $(GalaxySize) / $(ConstellationCount))</Expression>
+          <Expression>Ceil((5 - (2.5 * $(Constellation4_RumpBoolean))) * $(GalaxySize) / Max(1,$(ConstellationCount)))</Expression>
         </InterpretedVar>
         <InterpretedVar VarName="$C4StrategicT2Count">
-          <Expression>Ceil((4 - (2 * $(Constellation4_RumpBoolean))) * $(GalaxySize) / $(ConstellationCount))</Expression>
+          <Expression>Ceil((4 - (2 * $(Constellation4_RumpBoolean))) * $(GalaxySize) / Max(1,$(ConstellationCount)))</Expression>
         </InterpretedVar>
         <InterpretedVar VarName="$C4StrategicT3Count">
-          <Expression>Ceil((3.5 - (1.75 * $(Constellation4_RumpBoolean))) * $(GalaxySize) / $(ConstellationCount))</Expression>
+          <Expression>Ceil((3.5 - (1.75 * $(Constellation4_RumpBoolean))) * $(GalaxySize) / Max(1,$(ConstellationCount)))</Expression>
         </InterpretedVar>
 
         <!-- Separate planets by constellation and type (we sample twice from each section to get 2 separate randomized sets so that different resources of the same tier spawn independently) -->
@@ -701,7 +701,7 @@
 
 
   <!-- ##### GALAXY GEN QUEST Spawn strategic resources in a way that is evenly distributed among constellations  #####-->
-  <QuestDefinition Name="LuxuryResourceGenerationQuest" Category="GalaxyGeneration" SubCategory="ResourceNormalization" IsInstant="true" TriggeringProbability="1" CheckRandom="true" MinimumTurn="0">
+  <QuestDefinition Name="LuxuryResourceGenerationQuest" Category="GalaxyGeneration" SubCategory="ResourceNormalization" IsInstant="true" TriggeringProbability="1" CheckRandom="false" MinimumTurn="0">
     <!--============ TAGS ============-->
     <Tags>LuxuryResourceGenerationQuest</Tags>
     <!--============ CONTEXT ============-->
@@ -825,24 +825,24 @@
         </Count>
       </Var>
       <InterpretedVar VarName="$ExpectedSystems">
-        <Expression>Floor($(SystemCount)/$(ConstellationCount))</Expression>
+        <Expression>Floor($(SystemCount)/Max(1,$(ConstellationCount)))</Expression>
       </InterpretedVar>
 
       <!-- Calculate relative performance to find the rump constellation -->
       <InterpretedVar VarName="$Constellation0_RumpBoolean">
-        <Expression>1-Round(($(Constellation0_SystemCount)/$(ExpectedSystems)))</Expression>
+        <Expression>1-Round(($(Constellation0_SystemCount)/Max(1,$(ExpectedSystems))))</Expression>
       </InterpretedVar>
       <InterpretedVar VarName="$Constellation1_RumpBoolean">
-        <Expression>1-Round(($(Constellation1_SystemCount)/$(ExpectedSystems)))</Expression>
+        <Expression>1-Round(($(Constellation1_SystemCount)/Max(1,$(ExpectedSystems))))</Expression>
       </InterpretedVar>
       <InterpretedVar VarName="$Constellation2_RumpBoolean">
-        <Expression>1-Round(($(Constellation2_SystemCount)/$(ExpectedSystems)))</Expression>
+        <Expression>1-Round(($(Constellation2_SystemCount)/Max(1,$(ExpectedSystems))))</Expression>
       </InterpretedVar>
       <InterpretedVar VarName="$Constellation3_RumpBoolean">
-        <Expression>1-Round(($(Constellation3_SystemCount)/$(ExpectedSystems)))</Expression>
+        <Expression>1-Round(($(Constellation3_SystemCount)/Max(1,$(ExpectedSystems))))</Expression>
       </InterpretedVar>
       <InterpretedVar VarName="$Constellation4_RumpBoolean">
-        <Expression>1-Round(($(Constellation4_SystemCount)/$(ExpectedSystems)))</Expression>
+        <Expression>1-Round(($(Constellation4_SystemCount)/Max(1,$(ExpectedSystems))))</Expression>
       </InterpretedVar>
 
       <!-- Calculate number of deposits to spawn for each resource -->


### PR DESCRIPTION
Galaxy-generation and resource-spawn quests intermittently triggered on turn 2 instead of turn 1, or not at all.

Two root causes addressed:

1. Non-deterministic triggering. Every quest in both chains (roots and tag-triggered variants) used CheckRandom="true" (the default), routing them through the per-turn random triggering system instead of firing deterministically when eligible. This is what the base game reserves CheckRandom="false" for (scripted/chained/tutorial quests). Set CheckRandom="false" on all 25 GalaxyGen quests and both ResourceSpawn quests so they fire reliably on T1.

2. Divide-by-zero null aborts. ExpectedSystems = SystemCount/ConstellationCount and the RumpBoolean = .../ExpectedSystems divisions could yield NaN on small galaxies (systems < constellations -> ExpectedSystems floors to 0), nulling every downstream var and silently aborting the quest. Guarded all denominators with Max(1, ...). Max() is used 452x in the base game, so the syntax is engine-valid.

Follow-ups deferred pending in-game playtest data (see session notes):
- Dynamic constellation count for tiny/huge galaxies (currently hardcoded 5).
- Optional WorldAcademy readiness gate / Select Index="0" anchor on $AcademySystem.