### PR TITLE
Manpower Planet Improvements and Arcological Administration fixes

### DIFF
--- a/Endless Space Competitive Mod/Simulation/ConstructibleElement_Industry[PlanetSpecialization].xml
+++ b/Endless Space Competitive Mod/Simulation/ConstructibleElement_Industry[PlanetSpecialization].xml
@@ -447,7 +447,7 @@
     <PathPrerequisite Inverted="true"  Flags="Prerequisite,Discard">ClassColonizedPlanet/PlanetImprovementManpower1,!FastForwardedImprovement</PathPrerequisite>
     <PathPrerequisite Inverted="false" Flags="Prerequisite,Discard">./ColonizedStarSystemStateColony</PathPrerequisite>
     <SimulationDescriptorReference Name="PlanetImprovementManpower1" />
-    <PopulationEvent Name="PopulationPoliticalEventPlanetaryImprovementManpower1" />
+    <PopulationEvent Name="PopulationPoliticalEventBuildingConstructionDefense1" />
     <NextUpgradeName>PlanetImprovementManpower2</NextUpgradeName>
     <NextUpgradeName>PlanetImprovementManpower3</NextUpgradeName>
     <NextUpgradeName>PlanetImprovementManpower4</NextUpgradeName>
@@ -463,7 +463,7 @@
     <PathPrerequisite Inverted="true"  Flags="Prerequisite,Discard">ClassColonizedPlanet/PlanetImprovementManpower2,!FastForwardedImprovement</PathPrerequisite>
     <PathPrerequisite Inverted="false" Flags="Prerequisite,Discard">./ColonizedStarSystemStateColony</PathPrerequisite>
     <SimulationDescriptorReference Name="PlanetImprovementManpower2" />
-    <PopulationEvent Name="PopulationPoliticalEventPlanetaryImprovementManpower1" />
+    <PopulationEvent Name="PopulationPoliticalEventBuildingConstructionDefense1" />
     <NextUpgradeName>PlanetImprovementManpower3</NextUpgradeName>
     <NextUpgradeName>PlanetImprovementManpower4</NextUpgradeName>
   </PlanetImprovementDefinition>
@@ -477,7 +477,7 @@
     <PathPrerequisite Inverted="true"  Flags="Prerequisite,Discard">ClassColonizedPlanet/PlanetImprovementManpower3,!FastForwardedImprovement</PathPrerequisite>
     <PathPrerequisite Inverted="false" Flags="Prerequisite,Discard">./ColonizedStarSystemStateColony</PathPrerequisite>
     <SimulationDescriptorReference Name="PlanetImprovementManpower3" />
-    <PopulationEvent Name="PopulationPoliticalEventPlanetaryImprovementManpower1" />
+    <PopulationEvent Name="PopulationPoliticalEventBuildingConstructionDefense1" />
     <NextUpgradeName>PlanetImprovementManpower4</NextUpgradeName>
   </PlanetImprovementDefinition>
 
@@ -489,6 +489,6 @@
     <PathPrerequisite Inverted="true"  Flags="Prerequisite,Discard">ClassColonizedPlanet/PlanetImprovementManpower4,!FastForwardedImprovement</PathPrerequisite>
     <PathPrerequisite Inverted="false" Flags="Prerequisite,Discard">./ColonizedStarSystemStateColony</PathPrerequisite>
     <SimulationDescriptorReference Name="PlanetImprovementManpower4" />
-    <PopulationEvent Name="PopulationPoliticalEventPlanetaryImprovementManpower1" />
+    <PopulationEvent Name="PopulationPoliticalEventBuildingConstructionDefense1" />
   </PlanetImprovementDefinition>
 </Datatable>

--- a/Endless Space Competitive Mod/Simulation/ConstructibleElement_Industry[StarSystemImprovement].xml
+++ b/Endless Space Competitive Mod/Simulation/ConstructibleElement_Industry[StarSystemImprovement].xml
@@ -1798,7 +1798,7 @@
     <SupervisorGain Name="Science" Weight="0.25"/>
     <SupervisorGain Name="Dust" Weight="0.25"/>
     <QueuedSimulationDescriptorReference Name="IncreaseArcologyBeingBuiltCount"/>
-    <CustomCost ResourceName="EmpireEmpirePoint" Instant="true">2000 * (1 + Property(StockLocation,@'../ClassEmpire', ArcologicalAdministrationCount)) * (1 + Property(StockLocation,@ClassColonizedStarSystem, ArcologicalAdministrationCount)) * Property(StockLocation,@'../ClassEmpire', GameSpeedMultiplier)</CustomCost>
+    <CustomCost ResourceName="EmpireEmpirePoint" Instant="true">2000 * (1 + Property(StockLocation,@'../ClassEmpire', ArcologicalAdministrationCount)) * (1 + Property(StockLocation,@ClassColonizedStarSystem, ArcologicalAdministrationCount, true)) * Property(StockLocation,@'../ClassEmpire', GameSpeedMultiplier)</CustomCost>
     <Cost ResourceName="SystemProduction">1</Cost>
     <PathPrerequisite Flags="Prerequisite,Disable,RequiresSystemLevel4">ColonizedStarSystemStateColony,StarSystemImprovementLevel4</PathPrerequisite>
     <TechnologyPrerequisite Flags="Prerequisite,Discard,Technology">TechnologyUnlockPropaganda</TechnologyPrerequisite>
@@ -1814,7 +1814,7 @@
     <SupervisorGain Name="Science" Weight="0.25" />
     <SupervisorGain Name="Dust" Weight="0.25" />
     <QueuedSimulationDescriptorReference Name="IncreaseArcologyBeingBuiltCount"/>
-    <CustomCost ResourceName="EmpireEmpirePoint" Instant="true">2000 * (1 + Property(StockLocation,@'../ClassEmpire', ArcologicalAdministrationCount)) * (1 + Property(StockLocation,@ClassColonizedStarSystem, ArcologicalAdministrationCount))  * Property(StockLocation,@'../ClassEmpire', GameSpeedMultiplier)</CustomCost>
+    <CustomCost ResourceName="EmpireEmpirePoint" Instant="true">2000 * (1 + Property(StockLocation,@'../ClassEmpire', ArcologicalAdministrationCount)) * (1 + Property(StockLocation,@ClassColonizedStarSystem, ArcologicalAdministrationCount, true))  * Property(StockLocation,@'../ClassEmpire', GameSpeedMultiplier)</CustomCost>
     <Cost ResourceName="SystemProduction">1</Cost>
     <TechnologyPrerequisite Flags="Prerequisite,Discard,Technology">TechnologyUnlockPropaganda</TechnologyPrerequisite>
     <PathPrerequisite Flags="Prerequisite,Disable,RequiresSystemLevel4">ColonizedStarSystemStateColony,StarSystemImprovementLevel4</PathPrerequisite>


### PR DESCRIPTION
- All Manpower Planet Improvements: Changes political impact "PopulationPoliticalEventPlanetaryImprovementManpower1" with existing "PopulationPoliticalEventBuildingConstructionDefense1"

- Adds a parameter "true" on Property interpreter function on the CustomCost for Arcological Administration to control and avoid exceptions.

Fixes: #1719 