### PR TITLE
Fixes for Guardians 3rd tier collection bonus

### DIFF
--- a/Endless Space Competitive Mod/GUI/GUIElements[PopulationCollectionMinor].xml
+++ b/Endless Space Competitive Mod/GUI/GUIElements[PopulationCollectionMinor].xml
@@ -82,4 +82,7 @@
   <ExtendedGuiElement Name="PopulationCollectionBonusZvali3">
     <Title>%PopulationCollectionBonusZvali3</Title>
   </ExtendedGuiElement>
+  <ExtendedGuiElement Name="PopulationCollectionBonusGuardians3">
+    <Title>%PopulationCollectionBonusGuardians3</Title>
+  </ExtendedGuiElement>
 </Datatable>

--- a/Endless Space Competitive Mod/Localization/brazilian/ES2_Localization_1-3-2.xml
+++ b/Endless Space Competitive Mod/Localization/brazilian/ES2_Localization_1-3-2.xml
@@ -338,7 +338,6 @@
   <LocalizationPair Name="%PopulationCollectionBonusPilgrims3_TraitEffect">Fornece a localização de cada frota no mapa</LocalizationPair>
   <LocalizationPair Name="%PopulationCollectionBonusPulsos3_TraitEffect">+0.1 [scienceColored] por [industryColored] em Sistemas</LocalizationPair>
   <LocalizationPair Name="%PopulationCollectionBonusRonnant3_TraitEffect">+50% Valor de depósito em recursos estratégicos</LocalizationPair>
-  <LocalizationPair Name="%PopulationCollectionBonusGuardians3_TraitEffect">+10% Saúde da tropa durante a invasão por Paz, +15% Saúde da tropa durante a invasão por Aliança</LocalizationPair>
   <LocalizationPair Name="%PopulationCollectionBonusHaroshons3_TraitEffect">-20% População [foodColored] manutenção</LocalizationPair>
   <LocalizationPair Name="%PopulationCollectionBonusHisshos3_TraitEffect">+25% [manpower] reabastecimento em frotas fora das fronteiras</LocalizationPair>
   <LocalizationPair Name="%PopulationCollectionBonusGreenman3_TraitEffect">+50% Valor do depósito em recursos de luxo</LocalizationPair>

--- a/Endless Space Competitive Mod/Localization/english/ES2_Localization_1-3-2.xml
+++ b/Endless Space Competitive Mod/Localization/english/ES2_Localization_1-3-2.xml
@@ -322,7 +322,6 @@ Maximum [dustColored] from Blockading is increased by 75 per Hero in Empire</Loc
   <LocalizationPair Name="%PopulationCollectionBonusPilgrims3_TraitEffect">Provides the location of every fleet on the map</LocalizationPair>
   <LocalizationPair Name="%PopulationCollectionBonusPulsos3_TraitEffect">+0.1 [scienceColored] per [industryColored] on Systems</LocalizationPair>
   <LocalizationPair Name="%PopulationCollectionBonusRemnant3_TraitEffect">+50% Deposit Value on Strategic Resources</LocalizationPair>
-  <LocalizationPair Name="%PopulationCollectionBonusGuardians3_TraitEffect">+10% Troop Health during Invasion per Peace, +15% Troop Health during Invasion per Alliance</LocalizationPair>
   <LocalizationPair Name="%PopulationCollectionBonusHaroshems3_TraitEffect">-20% Population [foodColored] upkeep</LocalizationPair>
   <LocalizationPair Name="%PopulationCollectionBonusHisshos3_TraitEffect">+25% [manpower] replenishment on fleets outside borders</LocalizationPair>
   <LocalizationPair Name="%PopulationCollectionBonusGreenman3_TraitEffect">+50% Deposit Value on Luxury Resources</LocalizationPair>

--- a/Endless Space Competitive Mod/Localization/french/ES2_Localization_1-3-2.xml
+++ b/Endless Space Competitive Mod/Localization/french/ES2_Localization_1-3-2.xml
@@ -322,7 +322,6 @@ Maximum [dustColored] généré par les blocus est augmenté de 75 par héros da
   <LocalizationPair Name="%PopulationCollectionBonusPilgrims3_TraitEffect">Donne l'emplacement de toutes les flottes sur la carte</LocalizationPair>
   <LocalizationPair Name="%PopulationCollectionBonusPulsos3_TraitEffect">+0.1 [scienceColored] par [industryColored] sur systèmes</LocalizationPair>
   <LocalizationPair Name="%PopulationCollectionBonusRemnant3_TraitEffect">+50% valeur de dépôt sur ressource stratégique</LocalizationPair>
-  <LocalizationPair Name="%PopulationCollectionBonusGuardians3_TraitEffect">+10% santé de troupe pendant une invasion par paix, +15% santé de troupe pendant une invasion par alliance</LocalizationPair>
   <LocalizationPair Name="%PopulationCollectionBonusHaroshems3_TraitEffect">-20% [foodColored] pour le maintien de population</LocalizationPair>
   <LocalizationPair Name="%PopulationCollectionBonusHisshos3_TraitEffect">+25% de regain de [manpower] sur flotte hors des frontières</LocalizationPair>
   <LocalizationPair Name="%PopulationCollectionBonusGreenman3_TraitEffect">+50% valeur de dépôt sur ressource de luxe</LocalizationPair>

--- a/Endless Space Competitive Mod/Localization/german/ES2_Localization_1-3-2.xml
+++ b/Endless Space Competitive Mod/Localization/german/ES2_Localization_1-3-2.xml
@@ -363,7 +363,6 @@ Der maximale [dustColored] -Ertrag von Blockaden erhöht sich um 75 je Held im I
   <LocalizationPair Name="%PopulationCollectionBonusPilgrims3_TraitEffect">Zeigt die Position aller Flotten auf der Karte an</LocalizationPair>
   <LocalizationPair Name="%PopulationCollectionBonusPulsos3_TraitEffect">+0.1 [scienceColored] je [industryColored] auf: Systeme</LocalizationPair>
   <LocalizationPair Name="%PopulationCollectionBonusRemnant3_TraitEffect">+50% Wert auf Vorkommen strategischer Ressourcen</LocalizationPair>
-  <LocalizationPair Name="%PopulationCollectionBonusGuardians3_TraitEffect">+10% Truppen-[health] während einer Invasion je Friedensabkommen, +15% Truppen-[health] während einer Invasion je Allianzabkommen</LocalizationPair>
   <LocalizationPair Name="%PopulationCollectionBonusHaroshems3_TraitEffect">-20% [foodColored]-Unterhaltskosten auf: Bevölkerung</LocalizationPair>
   <LocalizationPair Name="%PopulationCollectionBonusHisshos3_TraitEffect">+25% [manpower]-Regenerationsrate auf: Flotten außerhalb der eigenen Imperiumsgrenzen</LocalizationPair>
   <LocalizationPair Name="%PopulationCollectionBonusGreenman3_TraitEffect">+50% Wert auf Vorkommen an Luxusressourcen</LocalizationPair>

--- a/Endless Space Competitive Mod/Localization/polish/ES2_Localization_1-3-2.xml
+++ b/Endless Space Competitive Mod/Localization/polish/ES2_Localization_1-3-2.xml
@@ -342,7 +342,6 @@ Maksimum [dustColored] za Blokowanie Węzła Specjalnego jest zwiększone o +75 
   <LocalizationPair Name="%PopulationCollectionBonusPilgrims3_TraitEffect">Zapewnia wizję wszystkich wrogich flot w galaktyce</LocalizationPair>
   <LocalizationPair Name="%PopulationCollectionBonusPulsos3_TraitEffect">+0.1 [scienceColored] na [industryColored] w Systemach</LocalizationPair>
   <LocalizationPair Name="%PopulationCollectionBonusRemnant3_TraitEffect">+50% Wartości Złoża Zasobów Strategicznych w Imperium</LocalizationPair>
-  <LocalizationPair Name="%PopulationCollectionBonusGuardians3_TraitEffect">+10% Zdrowia Żołnierzy podczas Inwazji na Imperium w stanie Pokoju, +15% Zdrowia Żołnierzy podczas Inwazji na Imperium w Sojuszu</LocalizationPair>
   <LocalizationPair Name="%PopulationCollectionBonusHaroshems3_TraitEffect">-20% [foodColored] utrzymania na [population]</LocalizationPair>
   <LocalizationPair Name="%PopulationCollectionBonusHisshos3_TraitEffect">+25% [manpower] uzupełniania we flotach poza granicami Imperium</LocalizationPair>
   <LocalizationPair Name="%PopulationCollectionBonusGreenman3_TraitEffect">+50% Wartości Złoża Zasobów Luksusowych w Imperium</LocalizationPair>

--- a/Endless Space Competitive Mod/Localization/russian/ES2_Localization_1-3-2.xml
+++ b/Endless Space Competitive Mod/Localization/russian/ES2_Localization_1-3-2.xml
@@ -321,7 +321,6 @@
   <LocalizationPair Name="%PopulationCollectionBonusPilgrims3_TraitEffect">Предоставляет местоположение каждого флота на карте</LocalizationPair>
   <LocalizationPair Name="%PopulationCollectionBonusPulsos3_TraitEffect">+0.1 [scienceColored] за [industryColored] на системах</LocalizationPair>
   <LocalizationPair Name="%PopulationCollectionBonusRemnant3_TraitEffect">+50% стоимость месторождений стратегических ресурсов</LocalizationPair>
-  <LocalizationPair Name="%PopulationCollectionBonusGuardians3_TraitEffect">+10% здоровья войск во время вторжения за мир, +15% здоровья войск во время вторжения за альянс</LocalizationPair>
   <LocalizationPair Name="%PopulationCollectionBonusHaroshems3_TraitEffect">-20% потребление [foodColored] населением</LocalizationPair>
   <LocalizationPair Name="%PopulationCollectionBonusHisshos3_TraitEffect">+25% пополнение [manpower] на флотах за пределами границ</LocalizationPair>
   <LocalizationPair Name="%PopulationCollectionBonusGreenman3_TraitEffect">+50% стоимость месторождений роскошных ресурсов</LocalizationPair>

--- a/Endless Space Competitive Mod/Localization/spanish/ES2_Localization_1-3-2.xml
+++ b/Endless Space Competitive Mod/Localization/spanish/ES2_Localization_1-3-2.xml
@@ -323,7 +323,6 @@ El [dustColored] máximo por bloquear aumenta en 75 por héroe en Imperio</Local
   <LocalizationPair Name="%PopulationCollectionBonusPilgrims3_TraitEffect">Proporciona la ubicación de todas las flotas en el mapa</LocalizationPair>
   <LocalizationPair Name="%PopulationCollectionBonusPulsos3_TraitEffect">+0.1 [scienceColored] por [industryColored] en sistemas</LocalizationPair>
   <LocalizationPair Name="%PopulationCollectionBonusRemnant3_TraitEffect">+50% Valor de depósito en recursos estratégicos</LocalizationPair>
-  <LocalizationPair Name="%PopulationCollectionBonusGuardians3_TraitEffect">+10% Salud de las tropas durante invasión por Imperio en paz, +15% Salud de las tropas durante invasión por Imperio aliado</LocalizationPair>
   <LocalizationPair Name="%PopulationCollectionBonusHaroshems3_TraitEffect">-20% consumo de [foodColored] en población</LocalizationPair>
   <LocalizationPair Name="%PopulationCollectionBonusHisshos3_TraitEffect">+25% reabastecimiento de [manpower] en flotas fuera de las fronteras</LocalizationPair>
   <LocalizationPair Name="%PopulationCollectionBonusGreenman3_TraitEffect">+50% Valor de depósito en recursos de lujo</LocalizationPair>

--- a/Endless Space Competitive Mod/Simulation/SimulationDescriptors[Empire].xml
+++ b/Endless Space Competitive Mod/Simulation/SimulationDescriptors[Empire].xml
@@ -612,7 +612,6 @@
 		<Property Name="CanUsePortals" BaseValue="0"/>
 		<Property Name="CannotUsePortals" BaseValue="0"/>
     <Property Name="MovementBonusFromKalTikMasLaw" BaseValue="0" RoundingFunction="Floor"/>
-    <Property Name="CollectionBonusLawsUnlocked" BaseValue="0" MinValue="0"/>
 
 		<Property Name="KnownSystemCount" BaseValue="0" IsSealed="1"/>
 		<Property Name="DetectionLevel" BaseValue="2"/>

--- a/Endless Space Competitive Mod/Simulation/SimulationDescriptors[Empire].xml
+++ b/Endless Space Competitive Mod/Simulation/SimulationDescriptors[Empire].xml
@@ -612,6 +612,7 @@
 		<Property Name="CanUsePortals" BaseValue="0"/>
 		<Property Name="CannotUsePortals" BaseValue="0"/>
     <Property Name="MovementBonusFromKalTikMasLaw" BaseValue="0" RoundingFunction="Floor"/>
+    <Property Name="CollectionBonusLawsUnlocked" BaseValue="0" MinValue="0"/>
 
 		<Property Name="KnownSystemCount" BaseValue="0" IsSealed="1"/>
 		<Property Name="DetectionLevel" BaseValue="2"/>

--- a/Endless Space Competitive Mod/Simulation/SimulationDescriptors[PopulationCollectionBonus].xml
+++ b/Endless Space Competitive Mod/Simulation/SimulationDescriptors[PopulationCollectionBonus].xml
@@ -68,10 +68,9 @@
 <!--Guardians pop collection bonus 3-->
   <SimulationDescriptor Name="PopulationCollectionBonusGuardians3" Type="PopulationCollectionBonus">
     <!-- Tooltip -->
-    <Modifier TargetProperty="UselessForTooltip" Operation="Addition" Value="1" Path="../ClassEmpire,FactionTraitEnableMinorLaws" TooltipOverride="%PopulationCollectionBonusGuardians3_TooltipEffect" TooltipHiddenIfPathInvalid="true"/>
-    <Modifier TargetProperty="UselessForTooltip" Operation="Addition" Value="1" Path="../ClassEmpire,FactionTraitDisableMinorLaws" TooltipOverride="%PopulationCollectionBonusGuardians3_TraitEffect" TooltipHiddenIfPathInvalid="true"/>
+    <Modifier TargetProperty="CollectionBonusLawsUnlocked" Operation="Addition" Value="1" Path="../ClassEmpire,FactionTraitEnableMinorLaws" TooltipOverride="%PopulationCollectionBonusGuardians3_TooltipEffect" TooltipHiddenIfPathInvalid="true"/>
     <!--  Effect -->
-    <BinaryModifier TargetProperty="GroundBattleDefenderTroopsDamageMultiplier" Operation="Percent" Left="0.1" BinaryOperation="Multiplication" Right="$(PeaceCount)" Path="../ClassEmpire,FactionTraitDisableMinorLaws/ClassColonizedStarSystem" Priority="-5" TooltipHidden="true" SearchValueFromPath="true"/>
+    <BinaryModifier TargetProperty="GroundBattleDefenderTroopsDamageMultiplier" Operation="Percent" Left="0.1" BinaryOperation="Multiplication" Right="$(PeaceCount)" Path="../ClassEmpire,FactionTraitDisableMinorLaws/ClassColonizedStarSystem" Priority="-5" TooltipOverride="%PopulationCollectionBonusGuardians3_TraitEffect" SearchValueFromPath="true"/>
     <BinaryModifier TargetProperty="GroundBattleDefenderTroopsDamageMultiplier" Operation="Percent" Left="0.15" BinaryOperation="Multiplication" Right="$(AllianceCount)" Path="../ClassEmpire,FactionTraitDisableMinorLaws/ClassColonizedStarSystem" Priority="-5" TooltipHidden="true" SearchValueFromPath="true"/>
   </SimulationDescriptor>
 

--- a/Endless Space Competitive Mod/Simulation/SimulationDescriptors[PopulationCollectionBonus].xml
+++ b/Endless Space Competitive Mod/Simulation/SimulationDescriptors[PopulationCollectionBonus].xml
@@ -71,8 +71,8 @@
     <Modifier TargetProperty="UselessForTooltip" Operation="Addition" Value="1" Path="../ClassEmpire,FactionTraitEnableMinorLaws" TooltipOverride="%PopulationCollectionBonusGuardians3_TooltipEffect" TooltipHiddenIfPathInvalid="true"/>
     <Modifier TargetProperty="UselessForTooltip" Operation="Addition" Value="1" Path="../ClassEmpire,FactionTraitDisableMinorLaws" TooltipOverride="%PopulationCollectionBonusGuardians3_TraitEffect" TooltipHiddenIfPathInvalid="true"/>
     <!--  Effect -->
-    <BinaryModifier TargetProperty="GroundBattleDefenderTroopsDamageMultiplier" Operation="Percent" Left="0.1" BinaryOperation="Multiplication" Right="$(PeaceCount)" Path="../ClassEmpire,FactionTraitDisableMinorLaws/ClassColonizedStarSystem" Priority="-5" TooltipHidden="true"/>
-    <BinaryModifier TargetProperty="GroundBattleDefenderTroopsDamageMultiplier" Operation="Percent" Left="0.15" BinaryOperation="Multiplication" Right="$(AllianceCount)" Path="../ClassEmpire,FactionTraitDisableMinorLaws/ClassColonizedStarSystem" Priority="-5" TooltipHidden="true"/>
+    <BinaryModifier TargetProperty="GroundBattleDefenderTroopsDamageMultiplier" Operation="Percent" Left="0.1" BinaryOperation="Multiplication" Right="$(PeaceCount)" Path="../ClassEmpire,FactionTraitDisableMinorLaws/ClassColonizedStarSystem" Priority="-5" TooltipHidden="true" SearchValueFromPath="true"/>
+    <BinaryModifier TargetProperty="GroundBattleDefenderTroopsDamageMultiplier" Operation="Percent" Left="0.15" BinaryOperation="Multiplication" Right="$(AllianceCount)" Path="../ClassEmpire,FactionTraitDisableMinorLaws/ClassColonizedStarSystem" Priority="-5" TooltipHidden="true" SearchValueFromPath="true"/>
   </SimulationDescriptor>
 
 <!--United Empire pop collection bonus 2-->

--- a/Endless Space Competitive Mod/Simulation/SimulationDescriptors[PopulationCollectionBonus].xml
+++ b/Endless Space Competitive Mod/Simulation/SimulationDescriptors[PopulationCollectionBonus].xml
@@ -68,10 +68,10 @@
 <!--Guardians pop collection bonus 3-->
   <SimulationDescriptor Name="PopulationCollectionBonusGuardians3" Type="PopulationCollectionBonus">
     <!-- Tooltip -->
-    <Modifier TargetProperty="CollectionBonusLawsUnlocked" Operation="Addition" Value="1" Path="../ClassEmpire,FactionTraitEnableMinorLaws" TooltipOverride="%PopulationCollectionBonusGuardians3_TooltipEffect" TooltipHiddenIfPathInvalid="true"/>
+    <Modifier TargetProperty="UselessForTooltip" Operation="Addition" Value="1" Path="../ClassEmpire,FactionTraitEnableMinorLaws" TooltipOverride="%PopulationCollectionBonusGuardians3_TooltipEffect" TooltipHiddenIfPathInvalid="true"/>
     <!--  Effect -->
-    <BinaryModifier TargetProperty="GroundBattleDefenderTroopsDamageMultiplier" Operation="Percent" Left="0.1" BinaryOperation="Multiplication" Right="$(PeaceCount)" Path="../ClassEmpire,FactionTraitDisableMinorLaws/ClassColonizedStarSystem" Priority="-5" TooltipOverride="%PopulationCollectionBonusGuardians3_TraitEffect" SearchValueFromPath="true"/>
-    <BinaryModifier TargetProperty="GroundBattleDefenderTroopsDamageMultiplier" Operation="Percent" Left="0.15" BinaryOperation="Multiplication" Right="$(AllianceCount)" Path="../ClassEmpire,FactionTraitDisableMinorLaws/ClassColonizedStarSystem" Priority="-5" TooltipHidden="true" SearchValueFromPath="true"/>
+    <BinaryModifier TargetProperty="GroundBattleDefenderTroopsDamageMultiplier" Operation="Percent" Left="0.1" BinaryOperation="Multiplication" Right="$(PeaceCount)" Path="../ClassEmpire/ClassColonizedStarSystem" Priority="-5" TooltipOverride="%PopulationCollectionBonusGuardians3_TraitEffect" SearchValueFromPath="true"/>
+    <BinaryModifier TargetProperty="GroundBattleDefenderTroopsDamageMultiplier" Operation="Percent" Left="0.15" BinaryOperation="Multiplication" Right="$(AllianceCount)" Path="../ClassEmpire/ClassColonizedStarSystem" Priority="-5" TooltipHidden="true" SearchValueFromPath="true"/>
   </SimulationDescriptor>
 
 <!--United Empire pop collection bonus 2-->

--- a/Endless Space Competitive Mod/Simulation/SimulationDescriptors[PopulationCollectionBonus].xml
+++ b/Endless Space Competitive Mod/Simulation/SimulationDescriptors[PopulationCollectionBonus].xml
@@ -70,8 +70,8 @@
     <!-- Tooltip -->
     <Modifier TargetProperty="UselessForTooltip" Operation="Addition" Value="1" Path="../ClassEmpire,FactionTraitEnableMinorLaws" TooltipOverride="%PopulationCollectionBonusGuardians3_TooltipEffect" TooltipHiddenIfPathInvalid="true"/>
     <!--  Effect -->
-    <BinaryModifier TargetProperty="GroundBattleDefenderTroopsDamageMultiplier" Operation="Percent" Left="0.1" BinaryOperation="Multiplication" Right="$(PeaceCount)" Path="../ClassEmpire/ClassColonizedStarSystem" Priority="-5" TooltipOverride="%PopulationCollectionBonusGuardians3_TraitEffect" SearchValueFromPath="true"/>
-    <BinaryModifier TargetProperty="GroundBattleDefenderTroopsDamageMultiplier" Operation="Percent" Left="0.15" BinaryOperation="Multiplication" Right="$(AllianceCount)" Path="../ClassEmpire/ClassColonizedStarSystem" Priority="-5" TooltipHidden="true" SearchValueFromPath="true"/>
+    <BinaryModifier TargetProperty="GroundBattleDefenderTroopsDamageMultiplier" Operation="Percent" Left="0.1" BinaryOperation="Multiplication" Right="$(PeaceCount)" Path="../ClassEmpire/ClassColonizedStarSystem" Priority="-5" SearchValueFromPath="true"/>
+    <BinaryModifier TargetProperty="GroundBattleDefenderTroopsDamageMultiplier" Operation="Percent" Left="0.15" BinaryOperation="Multiplication" Right="$(AllianceCount)" Path="../ClassEmpire/ClassColonizedStarSystem" Priority="-5" SearchValueFromPath="true"/>
   </SimulationDescriptor>
 
 <!--United Empire pop collection bonus 2-->


### PR DESCRIPTION
Closes #1729.

- Added missing `ExtendedGuiElement` that the other minor populations have, that removes the vanilla `TooltipOverride` so the ESG-specific tooltip can display
- Added missing `SearchValueFromPath` so the `GroundBattleDefenderTroopsDamageMultiplier` modifiers can resolve `$(PeaceCount)` / `$(AllianceCount)`
- Removed the `FactionTraitDisableMinorLaws` condition from the modifiers (consistent with the way the other population types work)
- The tooltips referred to Troop Health but the buff is actually to damage. The default tooltips actually look fine for these modifiers IMO so I've opted to just remove the overrides rather than correct them

There is still a latent issue with the tooltip described in #1728, but that affects all pop types, not just this one.