### PR TITLE
Fix frozen exploration-progress quest objectives

### DIFF
--- a/Endless Space Competitive Mod/Quests/QuestDefinitions[Sophons].xml
+++ b/Endless Space Competitive Mod/Quests/QuestDefinitions[Sophons].xml
@@ -554,14 +554,16 @@
                     <Condition_IsProgressionComplete>
                       <Input_Expression VarName="$Step2_2_Objective1Expr"/>
                     </Condition_IsProgressionComplete>
+                    <Output_Percentage VarName="$Step2_2_Objective1Val"/>
                   </Decorator_ExploredNode>
                   <Action_ChooseOutcome Name="Outcome1"/>
                 </Sequence>
                 <Sequence>
                   <Decorator_BeginTurn>
-                    <Condition_IsProgressionComplete>
-                      <Input_Expression VarName="$Step2_2_Objective1Expr"/>
-                    </Condition_IsProgressionComplete>
+                    <Condition_ExplorationProgress MinimumState="Revealed">
+                      <Input_Empire VarName="$CurrentEmpire"/>
+                      <Input_Percentage VarName="$GalaxyExplorationRequirement"/>
+                    </Condition_ExplorationProgress>
                   </Decorator_BeginTurn>
                   <Action_ChooseOutcome Name="Outcome1"/>
                 </Sequence>
@@ -1616,6 +1618,7 @@
                     <Condition_IsProgressionComplete>
                       <Input_Expression VarName="$Step2_Objective1Expr"/>
                     </Condition_IsProgressionComplete>
+                    <Output_Percentage VarName="$Step2_Objective1Val"/>
                   </Decorator_ExploredNode>
                 </Sequence>
               </Parallel>
@@ -1795,6 +1798,7 @@
                     <Condition_IsProgressionComplete>
                       <Input_Expression VarName="$Step2_Objective1Expr"/>
                     </Condition_IsProgressionComplete>
+                    <Output_Percentage VarName="$Step2_Objective1Val"/>
                   </Decorator_ExploredNode>
                 </Sequence>
               </Parallel>
@@ -2001,9 +2005,10 @@
               <Parallel CompletionPolicy="Any">
                 <Sequence>
                   <Decorator_BeginTurn>
-                    <Condition_IsProgressionComplete>
-                      <Input_Expression VarName="$Step2_Objective1Expr"/>
-                    </Condition_IsProgressionComplete>
+                    <Condition_ExplorationProgress MinimumState="Revealed">
+                      <Input_Empire VarName="$CurrentEmpire"/>
+                      <Input_Percentage VarName="$MinimumAmout02"/>
+                    </Condition_ExplorationProgress>
                   </Decorator_BeginTurn>
                 </Sequence>
                 <Sequence>
@@ -2011,6 +2016,7 @@
                     <Condition_IsProgressionComplete>
                       <Input_Expression VarName="$Step2_Objective1Expr"/>
                     </Condition_IsProgressionComplete>
+                    <Output_Percentage VarName="$Step2_Objective1Val"/>
                   </Decorator_ExploredNode>
                 </Sequence>
               </Parallel>
@@ -2192,6 +2198,7 @@
                     <Condition_IsProgressionComplete>
                       <Input_Expression VarName="$Step2_Objective1Expr"/>
                     </Condition_IsProgressionComplete>
+                    <Output_Percentage VarName="$Step2_Objective1Val"/>
                   </Decorator_ExploredNode>
                 </Sequence>
               </Parallel>

--- a/Endless Space Competitive Mod/Quests/QuestDefinitions[Update8].xml
+++ b/Endless Space Competitive Mod/Quests/QuestDefinitions[Update8].xml
@@ -1496,6 +1496,7 @@
                                     <Condition_IsProgressionComplete>
                                         <Input_Expression VarName="$Objective2Expr"/>
                                     </Condition_IsProgressionComplete>
+                                    <Output_Percentage VarName="$Objective2Val"/>
                                 </Decorator_ExploredNode>
                                 <Action_ChooseOutcome Name="Outcome1"/>
                             </Sequence>
@@ -1545,6 +1546,7 @@
                                     <Condition_IsProgressionComplete>
                                         <Input_Expression VarName="$Objective2Expr"/>
                                     </Condition_IsProgressionComplete>
+                                    <Output_Percentage VarName="$Objective2Val"/>
                                 </Decorator_ExploredNode>
                                 <Action_ChooseOutcome Name="Outcome1"/>
                             </Sequence>

--- a/Endless Space Competitive Mod/Quests/QuestDefinitions[Vaulters].xml
+++ b/Endless Space Competitive Mod/Quests/QuestDefinitions[Vaulters].xml
@@ -879,6 +879,7 @@
                                         <Condition_IsProgressionComplete>
                                             <Input_Expression VarName="$Objective_ScientistExpr"/>
                                         </Condition_IsProgressionComplete>
+                                        <Output_Percentage VarName="$Objective_ScientistVal"/>
                                     </Decorator_ExploredNode>
                                 </Sequence>
                             </Parallel>


### PR DESCRIPTION
Fixes #1732.

Seven quest exploration objectives set their progress expression to `$XExpr = "$(XVal)"` where `$XVal` is a one-time snapshot of `RevealedNodePercentage` (a plain `<Var><From>`). The game re-evaluates that expression to drive the objective progress counter, but the snapshot never changes, so the counter was pinned to its starting value.

**Fix:** add `<Output_Percentage VarName="$XVal"/>` to each `Decorator_ExploredNode` so the val is refreshed with the current exploration % as nodes are revealed — the same mechanism vanilla (and the questcounters patcher output) relies on to make this idiom live.

Two objectives had **no live per-turn fallback** and were genuinely uncompletable; their `Decorator_BeginTurn` `Condition_IsProgressionComplete` (also frozen) is swapped for a live `Condition_ExplorationProgress`:
- `SophonsQuest-Chapter1Alt` (explore 25% of the galaxy, science path)
- `SophonsQuest-Chapter3-Military`

The other five already completed via a `Condition_ExplorationProgress` sibling; the `Output_Percentage` addition revives their otherwise-dead `ExploredNode` arm:
- `SophonsQuest-Chapter3-Diplomacy` / `-Science` / `-Military-Alt`
- `VaultersQuest-Chapter2B`
- `MinorPopulationQuest22` (both Objective2 variants)
